### PR TITLE
ignore IDEA related files

### DIFF
--- a/silk2/.gitignore
+++ b/silk2/.gitignore
@@ -3,3 +3,6 @@
 .idea_modules/*
 **/target/*
 **/logs/*
+*.iml
+*.ipr
+*.iws


### PR DESCRIPTION
When using `mvn idea:idea` and importing into IntelliJ IDEA a number of IDEA-related files are created. We might want to ignore this files.
