### PR TITLE
Silk Mapreduce Upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,12 @@
 *.ipr
 *.iws
 #eclipse
+bin/
 target/
 */.gitignore
 .classpath
 .project
 .settings
-.cache
+.cache*
 **/.idea
 myScripts

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,18 @@ lazy val commonSettings = Seq(
   // Testing
   libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test",
   libraryDependencies += "org.mockito" % "mockito-all" % "1.9.5" % "test",
-  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-u", "target/test-reports")
+  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-u", "target/test-reports"),
+
+  // The assembly plugin cannot resolve multiple dependencies to commons logging
+  assemblyMergeStrategy in assembly := {
+    case PathList("org", "apache", "commons", "logging",  xs @ _*) => MergeStrategy.first
+    case PathList(xs @ _*) if xs.last endsWith ".class" => MergeStrategy.first
+    case PathList(xs @ _*) if xs.last endsWith ".xsd" => MergeStrategy.first
+    case PathList(xs @ _*) if xs.last endsWith ".dtd" => MergeStrategy.first
+    case other =>
+      val oldStrategy = (assemblyMergeStrategy in assembly).value
+      oldStrategy(other)
+  }
 )
 
 //////////////////////////////////////////////////////////////////////////////
@@ -193,10 +204,18 @@ lazy val singlemachine = (project in file("silk-tools/silk-singlemachine"))
     }
   )
 
+lazy val mapreduce = (project in file("silk-tools/silk-mapreduce"))
+  .dependsOn(core, plugins)
+  .aggregate(core, plugins)
+  .settings(commonSettings: _*)
+  .settings(
+    name := "Silk MapReduce"
+  )
+
 //////////////////////////////////////////////////////////////////////////////
 // Root
 //////////////////////////////////////////////////////////////////////////////
 
 lazy val root = (project in file("."))
-  .aggregate(core, plugins, singlemachine, learning, workspace, workbench)
+  .aggregate(core, plugins, mapreduce, singlemachine, learning, workspace, workbench)
   .settings(commonSettings: _*)

--- a/silk-tools/silk-mapreduce/build.sbt
+++ b/silk-tools/silk-mapreduce/build.sbt
@@ -4,4 +4,7 @@ version := "2.6.1-SNAPSHOT"
 
 scalaVersion := "2.11.6"
 
-libraryDependencies += "org.apache.hadoop" % "hadoop-core" % "1.0.0"
+resolvers += "cloudera" at "https://repository.cloudera.com/artifactory/cloudera-repos/"
+
+libraryDependencies += "org.apache.hadoop" % "hadoop-common" % "2.6.0-cdh5.7.0"
+libraryDependencies += "org.apache.hadoop" % "hadoop-client" % "2.6.0-cdh5.7.0"

--- a/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/Load.scala
+++ b/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/Load.scala
@@ -29,6 +29,7 @@ import org.silkframework.execution.Loader
 import org.silkframework.hadoop.impl.HadoopEntityCache
 import org.silkframework.runtime.activity.Activity
 import org.silkframework.plugins.dataset.rdf.RdfPlugins
+import org.silkframework.config.Task
 
 /**
  * Populates the entity cache.
@@ -91,7 +92,7 @@ class Load(silkConfigPath : String, entityCachePath : String, linkSpec : Option[
     }
   }
 
-  private def write(config : LinkingConfig, linkSpec : LinkSpec, entityCachePath : Path)
+  private def write(config : LinkingConfig, linkSpec : Task[LinkSpec], entityCachePath : Path)
   {
     val cacheFS = FileSystem.get(entityCachePath.toUri, hadoopConfig)
 

--- a/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/Match.scala
+++ b/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/Match.scala
@@ -62,9 +62,6 @@ class Match(inputPath : String, outputPath : String, linkSpec : Option[String], 
    */
   private def setupJob(job : Job)
   {
-    // FIXME
-    // Plugins.register()
-
     val config = SilkConfiguration.get(job.getConfiguration)
 
     //General settings

--- a/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/Match.scala
+++ b/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/Match.scala
@@ -19,6 +19,11 @@ import java.util.logging.Logger
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.mapreduce._
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
+import org.silkframework.hadoop.impl.SilkInputFormat
+import org.silkframework.hadoop.impl.EntityConfidence
+import org.silkframework.hadoop.impl.SilkMap
+import org.silkframework.hadoop.impl.SilkReduce
+import org.silkframework.hadoop.impl.SilkOutputFormat
 
 /**
  * Executes Silk - MapReduce.
@@ -57,7 +62,8 @@ class Match(inputPath : String, outputPath : String, linkSpec : Option[String], 
    */
   private def setupJob(job : Job)
   {
-    Plugins.register()
+    // FIXME
+    // Plugins.register()
 
     val config = SilkConfiguration.get(job.getConfiguration)
 

--- a/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/SilkConfiguration.scala
+++ b/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/SilkConfiguration.scala
@@ -16,6 +16,10 @@ package org.silkframework.hadoop
 
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.silkframework.config.LinkingConfig
+import org.silkframework.runtime.resource.EmptyResourceManager
+import org.silkframework.hadoop.impl.HadoopEntityCache
+import org.silkframework.runtime.serialization.ReadContext
+import scala.xml.XML
 
 object SilkConfiguration {
   val InputParam = "silk.inputpath"
@@ -41,10 +45,10 @@ class SilkConfiguration private(hadoopConfig : org.apache.hadoop.conf.Configurat
   private lazy val cacheFS = FileSystem.get(entityCachePath.toUri, hadoopConfig)
 
   lazy val config = {
-    Plugins.register()
-    JenaPlugins.register()
-    val resourceLoader = new EmptyResourceManager()
-    LinkingConfig.load(resourceLoader)(cacheFS.open(entityCachePath.suffix("/config.xml")))
+    // FIXME:
+    // Plugins.register()
+    // JenaPlugins.register()
+    LinkingConfig.LinkingConfigFormat.read(XML.load(cacheFS.open(entityCachePath.suffix("/config.xml"))))(new ReadContext(EmptyResourceManager))
   }
 
   lazy val linkSpec = {
@@ -55,10 +59,10 @@ class SilkConfiguration private(hadoopConfig : org.apache.hadoop.conf.Configurat
   lazy val entityDescs = linkSpec.entityDescriptions
 
   lazy val sourceCache = {
-    new HadoopEntityCache(entityDescs.source, linkSpec.rule.index(_), cacheFS, entityCachePath.suffix("/source/" + linkSpec.id + "/"), config.runtime)
+    new HadoopEntityCache(entityDescs.source, linkSpec.rule.index(_, true), cacheFS, entityCachePath.suffix("/source/" + linkSpec.id + "/"), config.runtime)
   }
 
   lazy val targetCache = {
-    new HadoopEntityCache(entityDescs.target, linkSpec.rule.index(_), cacheFS, entityCachePath.suffix("/target/" + linkSpec.id + "/"), config.runtime)
+    new HadoopEntityCache(entityDescs.target, linkSpec.rule.index(_, false), cacheFS, entityCachePath.suffix("/target/" + linkSpec.id + "/"), config.runtime)
   }
 }

--- a/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/SilkConfiguration.scala
+++ b/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/SilkConfiguration.scala
@@ -45,9 +45,6 @@ class SilkConfiguration private(hadoopConfig : org.apache.hadoop.conf.Configurat
   private lazy val cacheFS = FileSystem.get(entityCachePath.toUri, hadoopConfig)
 
   lazy val config = {
-    // FIXME:
-    // Plugins.register()
-    // JenaPlugins.register()
     LinkingConfig.LinkingConfigFormat.read(XML.load(cacheFS.open(entityCachePath.suffix("/config.xml"))))(new ReadContext(EmptyResourceManager))
   }
 

--- a/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/impl/HadoopEntityCache.scala
+++ b/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/impl/HadoopEntityCache.scala
@@ -21,16 +21,17 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 import org.silkframework.cache.{BitsetIndex, EntityCache, Partition}
 import org.silkframework.config.RuntimeConfig
 import org.silkframework.entity._
-import org.silkframework.entity.rdf.SparqlEntitySchema
 
 /**
  * An entity cache, which uses the Hadoop FileSystem API.
  * This can be used to cache the entities on any file system which is supported by Hadoop e.g. the Hadoop Distributed FileSystem.
  */
-class HadoopEntityCache(val entityDesc: SparqlEntitySchema,
+class HadoopEntityCache(val entityDesc: EntitySchema,
                         val indexFunction: (Entity => Index),
                         fs: FileSystem, path: Path,
                         runtimeConfig: RuntimeConfig) extends EntityCache {
+  
+  override def entitySchema = entityDesc
 
   private val logger = Logger.getLogger(getClass.getName)
 
@@ -81,7 +82,7 @@ class HadoopEntityCache(val entityDesc: SparqlEntitySchema,
   }
 
   override def clear() {
-    throw new UnsupportedOperationException()
+    // throw new UnsupportedOperationException()
   }
 
   override def close() { }

--- a/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/impl/SilkInputFormat.scala
+++ b/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/impl/SilkInputFormat.scala
@@ -19,6 +19,7 @@ import org.apache.hadoop.mapreduce._
 import org.silkframework.cache.Partition
 
 import scala.collection.immutable.HashSet
+import org.silkframework.hadoop.SilkConfiguration
 
 class SilkInputFormat extends InputFormat[NullWritable, EntityPair]
 {
@@ -86,8 +87,8 @@ class SilkInputFormat extends InputFormat[NullWritable, EntityPair]
       sourcePartition = config.sourceCache.read(silkInputSplit.blockIndex, silkInputSplit.sourcePartition)
       targetPartition = config.targetCache.read(silkInputSplit.blockIndex, silkInputSplit.targetPartition)
 
-      sourceIndices = sourcePartition.entities.map(entity => HashSet(linkSpec.rule.index(entity, 0.0).flatten.toSeq : _*))
-      targetIndices = targetPartition.entities.map(entity => HashSet(linkSpec.rule.index(entity, 0.0).flatten.toSeq : _*))
+      sourceIndices = sourcePartition.entities.map(entity => HashSet(linkSpec.rule.index(entity, true, 0.0).flatten.toSeq : _*))
+      targetIndices = targetPartition.entities.map(entity => HashSet(linkSpec.rule.index(entity, false, 0.0).flatten.toSeq : _*))
 
       context.setStatus("Comparing partition " + silkInputSplit.sourcePartition + " and " + silkInputSplit.targetPartition)
     }

--- a/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/impl/SilkMap.scala
+++ b/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/impl/SilkMap.scala
@@ -16,6 +16,7 @@ package org.silkframework.hadoop.impl
 
 import org.apache.hadoop.io.{NullWritable, Text}
 import org.apache.hadoop.mapreduce.Mapper
+import org.silkframework.hadoop.SilkConfiguration
 
 class SilkMap extends Mapper[NullWritable, EntityPair, Text, EntityConfidence]
 {

--- a/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/impl/SilkOutputFormat.scala
+++ b/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/impl/SilkOutputFormat.scala
@@ -19,6 +19,7 @@ import java.io.DataOutputStream
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
 import org.apache.hadoop.mapreduce.{RecordWriter, TaskAttemptContext}
+import org.silkframework.hadoop.SilkConfiguration
 
 class SilkOutputFormat extends FileOutputFormat[Text, EntityConfidence]
 {

--- a/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/impl/SilkReduce.scala
+++ b/silk-tools/silk-mapreduce/src/main/scala/org/silkframework/hadoop/impl/SilkReduce.scala
@@ -18,6 +18,7 @@ import org.apache.hadoop.io.Text
 import org.apache.hadoop.mapreduce.Reducer
 
 import scala.collection.JavaConversions._
+import org.silkframework.hadoop.SilkConfiguration
 
 class SilkReduce extends Reducer[Text, EntityConfidence, Text, EntityConfidence] {
 


### PR DESCRIPTION
This is an upgraded version of Silk MapReduce which can compile against the current version of Silk Core.
Build files have also been updated to be able to generate an assembly JAR.

This should fix #41.