### PR TITLE
Bugfix/12903

### DIFF
--- a/silk-workbench/silk-workbench-core/public/mdl-adjustments.css
+++ b/silk-workbench/silk-workbench-core/public/mdl-adjustments.css
@@ -664,3 +664,8 @@ td.rule-toggle, th.rule-toggle {
 .mdl-file-upload input {
   font-size: 16px;
 }
+
+/* Fix blurry tooltip problem */
+.mdl-tooltip {
+  will-change: unset;
+}

--- a/silk-workbench/silk-workbench-rules/app/views/editor/transformRules.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/editor/transformRules.scala.html
@@ -146,6 +146,9 @@
           $(this).trigger("enter");
         }
       });
+      $("#rule-type-textfield input").blur(function() {
+        addRule("#typeTemplate");
+      });
       $("#rule-type-textfield input").autocomplete({
         source: apiUrl + "/targetPathCompletions",
         minLength: 0

--- a/silk-workbench/silk-workbench-rules/app/views/editor/transformRules.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/editor/transformRules.scala.html
@@ -227,7 +227,7 @@
     <div class="transformRule uriMapping">
       <span class="rule-name">@rule.name</span>
       <div class="mdl-textfield mdl-js-textfield">
-        <input class="mdl-textfield__input pattern" type="text" id="@{rule.name}-pattern" value="@rule.pattern">
+        <input class="mdl-textfield__input pattern" type="text" id="@{rule.name}-pattern" value="@rule.pattern" onblur="checkForEmptyURIMapping();">
       </div>
     </div>
     <button class="mdl-button mdl-js-button mdl-button--icon" onclick="deleteRule('uri')">

--- a/silk-workbench/silk-workbench-rules/app/views/evaluateTransform/evaluateTransform.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/evaluateTransform/evaluateTransform.scala.html
@@ -1,16 +1,18 @@
 @import org.silkframework.rule.TransformSpec
 @import plugins.Context
+@import controllers.rules.routes.Assets
 
 @(context: Context[TransformSpec], offset: Int, limit: Int)(implicit session: play.api.mvc.Session)
 
 @header = {
+  <link type="text/css" href="@Assets.at("stylesheets/evaluateTransform/evaluateTransform.css")" rel="stylesheet" />
 }
 
 @toolbar = {
 }
 
 @content = {
-  <iframe src="evaluate/generatedEntities?offset=@offset&limit=@limit" frameborder="0" width="100%" height="100%"></iframe>
+  <iframe src="evaluate/generatedEntities?offset=@offset&limit=@limit" frameborder="0"></iframe>
 }
 
 @main(Some(context))(header)(toolbar)(content)

--- a/silk-workbench/silk-workbench-rules/app/views/evaluateTransform/generatedEntities.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/evaluateTransform/generatedEntities.scala.html
@@ -10,7 +10,6 @@
   <script src="@Assets.at("js/jquery.treeview.js")" type="text/javascript"></script>
   <script src="@Assets.at("js/evaluateTransform/generatedEntities.js")" type="text/javascript"></script>
 } {
-  <div class="wrapper">
     <div id="tree-header">
       <div class="left">
         <div class="toggle-all" onclick="expand_all()">
@@ -31,7 +30,6 @@
       }
     </div>
 
-  </div>
 }
 
 @renderHeader = {

--- a/silk-workbench/silk-workbench-rules/public/js/editor/transformRules.js
+++ b/silk-workbench/silk-workbench-rules/public/js/editor/transformRules.js
@@ -36,8 +36,9 @@ $(function() {
   addSourceAutocomplete($(".source"));
   addTargetAutocomplete($(".target"));
 
-   // toggle URI mapping UI
-   uriMappingExists() ? showURIMapping(true) : showURIMapping(false);
+  // toggle URI mapping UI
+  uriMappingExists() ? showURIMapping(true) : showURIMapping(false);
+
 });
 
 function modified() {
@@ -347,6 +348,17 @@ function toggleRule(ruleId) {
 
 function uriMappingExists() {
   return $(".uri-ui--defined").children()[0] != null;
+}
+
+function checkForEmptyURIMapping() {
+  var pattern = $("#uri-pattern").val();
+  console.log(pattern);
+  if (pattern == "") {
+    console.log("empty URI pattern");
+    $('#uri').remove();
+    showURIMapping(false);
+    modified();
+  }
 }
 
 function showURIMapping(defined) {

--- a/silk-workbench/silk-workbench-rules/public/js/editor/transformRules.js
+++ b/silk-workbench/silk-workbench-rules/public/js/editor/transformRules.js
@@ -256,11 +256,16 @@ function addRule(template) {
   if (template == "#typeTemplate") {
     var newRule = $(template + " .typeMapping").clone();
     var nameInput = newRule.find(".rule-name");
-    nameInput.text(generateRuleName(nameInput.text()));
+    var ruleName = generateRuleName(nameInput.text());
+    nameInput.text(ruleName);
+    var ruleId = "type-" + ruleName;
+    newRule.attr("id", ruleId);
     var typeString = $("#rule-type-textfield input").val();
     newRule.find(".type").text(typeString);
     newRule.appendTo("#typeContainer");
     $("#rule-type-textfield input").val("");
+    var deleteButton = newRule.find("button");
+    deleteButton.attr("onclick", "deleteRule('" + ruleId + "');");
   } else if(template == "#uriMappingTemplate") {
     var newRule = $(template).children().clone();
     resetMDLTextfields(newRule);
@@ -268,8 +273,20 @@ function addRule(template) {
   } else {
     // Clone rule template
     var newRule = $(template).children().clone();
+
     var nameInput = newRule.find(".rule-name");
-    nameInput.text(generateRuleName(nameInput.text()));
+    var oldRuleName = nameInput.text();
+    var newRuleName = generateRuleName(oldRuleName);
+    nameInput.text(newRuleName);
+
+    var ruleRows = newRule.find("tr");
+    $.each(ruleRows, function(index, row) {
+      row = $(row);
+      var ruleId = row.attr("id");
+      ruleId = ruleId.replace(oldRuleName, newRuleName);
+      row.attr("id", ruleId);
+      row.find("button.delete-button").attr("onclick", "deleteRule('" + ruleId + "');");
+    })
 
     resetMDLTextfields(newRule);
 

--- a/silk-workbench/silk-workbench-rules/public/js/editor/transformRules.js
+++ b/silk-workbench/silk-workbench-rules/public/js/editor/transformRules.js
@@ -352,9 +352,7 @@ function uriMappingExists() {
 
 function checkForEmptyURIMapping() {
   var pattern = $("#uri-pattern").val();
-  console.log(pattern);
   if (pattern.match(/^\s*$/)) { // if empty or only whitespace
-    console.log("empty URI pattern");
     $('#uri').remove();
     showURIMapping(false);
     modified();

--- a/silk-workbench/silk-workbench-rules/public/js/editor/transformRules.js
+++ b/silk-workbench/silk-workbench-rules/public/js/editor/transformRules.js
@@ -353,7 +353,7 @@ function uriMappingExists() {
 function checkForEmptyURIMapping() {
   var pattern = $("#uri-pattern").val();
   console.log(pattern);
-  if (pattern == "") {
+  if (pattern.match(/^\s*$/)) { // if empty or only whitespace
     console.log("empty URI pattern");
     $('#uri').remove();
     showURIMapping(false);

--- a/silk-workbench/silk-workbench-rules/public/stylesheets/evaluateTransform/evaluateTransform.css
+++ b/silk-workbench/silk-workbench-rules/public/stylesheets/evaluateTransform/evaluateTransform.css
@@ -1,0 +1,26 @@
+main.mdl-layout__content {
+  display: flex;
+  flex-direction: column;
+}
+
+#content {
+  background: #f7f7f7;
+  float: left;
+  min-width: 300px;
+  width: calc(100% - 20px);
+  height: calc(100% - 110px);
+  padding: 10px 10px;
+
+  flex: 1;
+  height: 100%;
+  overflow-y: scroll;
+  display: flex;
+  flex-direction: column;
+}
+
+#content iframe {
+  flex: 1;
+  border: 1px solid #DBDBDB;
+  background: #ffffff;
+  padding: 10px;
+}


### PR DESCRIPTION
these issues are fixed:
- major: Transformation View: Unfocus in Entity Type field should also create class URI tag when loosing focus. At the moment you have to press <Enter>.
- major: Fix Transformation Evaluation Screen, not using full screen
- major: fix the blurry tooltip problem
- major: Turn empty whitespace-only URI template pattern into default pattern (copy existing URI)
