### PR TITLE
Bugfix/13361

### DIFF
--- a/silk-workbench/silk-workbench-rules/app/views/dialogs/deleteRuleDialog.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/dialogs/deleteRuleDialog.scala.html
@@ -10,7 +10,6 @@
 <script>//<![CDATA[
 
     function submit() {
-      console.log("@ruleName");
       $('#@ruleName').remove();
       if ('@ruleName' == 'uri') {
         showURIMapping(false);

--- a/silk-workbench/silk-workbench-rules/app/views/editor/transformRules.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/editor/transformRules.scala.html
@@ -142,6 +142,7 @@
 
       $("#rule-type-textfield input").bind("enter", function(e) {
         if ($(this).val() != '') {
+          $(this).autocomplete("close");
           addRule("#typeTemplate");
         }
       });

--- a/silk-workbench/silk-workbench-rules/app/views/editor/transformRules.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/editor/transformRules.scala.html
@@ -141,8 +141,8 @@
     $().ready( function() {
 
       $("#rule-type-textfield input").bind("enter", function(e) {
+        $(this).autocomplete("close");
         if ($(this).val() != '') {
-          $(this).autocomplete("close");
           addRule("#typeTemplate");
         }
       });

--- a/silk-workbench/silk-workbench-rules/app/views/editor/transformRules.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/editor/transformRules.scala.html
@@ -153,10 +153,7 @@
       $("#rule-type-textfield input").blur(function() {
         $(this).trigger("enter");
       });
-      $("#rule-type-textfield input").autocomplete({
-        source: apiUrl + "/targetPathCompletions",
-        minLength: 0
-      }).focus(function() { $(this).autocomplete("search"); });
+      addTypeAutocomplete($("#rule-type-textfield input"));
     });
   </script>
 

--- a/silk-workbench/silk-workbench-rules/app/views/editor/transformRules.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/editor/transformRules.scala.html
@@ -141,14 +141,16 @@
     $().ready( function() {
 
       $("#rule-type-textfield input").bind("enter", function(e) {
-        $(this).autocomplete("close");
         if ($(this).val() != '') {
           addRule("#typeTemplate");
         }
       });
-      $("#rule-type-textfield input").keyup(function(e) {
+      $("input").keyup(function(e) {
         if (e.keyCode == 13) {
-          $(this).trigger("enter");
+          $(this).autocomplete("close");
+          if ($(this).is($("#rule-type-textfield input"))) {
+            $(this).trigger("enter");
+          }
         }
       });
       $("#rule-type-textfield input").blur(function() {

--- a/silk-workbench/silk-workbench-rules/public/js/editor/transformRules.js
+++ b/silk-workbench/silk-workbench-rules/public/js/editor/transformRules.js
@@ -242,10 +242,6 @@ function serializeComplexRule(xmlDoc, ruleXml, name, target) {
   xmlDoc.documentElement.appendChild(ruleXml);
 }
 
-function addType(typeString) {
-  console.log(typeString);
-}
-
 function addURIMapping() {
   addRule("#uriMappingTemplate");
   $(".uri-ui").toggle();

--- a/silk-workbench/silk-workbench-rules/public/js/editor/transformRules.js
+++ b/silk-workbench/silk-workbench-rules/public/js/editor/transformRules.js
@@ -388,9 +388,10 @@ function showURIMapping(defined) {
 
 function addSourceAutocomplete(sourceInputs) {
   sourceInputs.autocomplete({
-    source: apiUrl + "/sourcePathCompletions",
-    minLength: 0,
-    position: { my: "left bottom", at: "left top", collision: "flip" }
+    source: apiUrl + "/sourcePathCompletions" ,
+    minLength: 0 ,
+    position: { my: "left bottom", at: "left top", collision: "flip" } ,
+    close: function(event, ui) { modified(); }
   }).focus(function() { $(this).autocomplete("search"); });
 }
 

--- a/silk-workbench/silk-workbench-rules/public/js/editor/transformRules.js
+++ b/silk-workbench/silk-workbench-rules/public/js/editor/transformRules.js
@@ -386,6 +386,16 @@ function showURIMapping(defined) {
   }
 }
 
+function addTypeAutocomplete(typeInputs) {
+  typeInputs.autocomplete({
+    source: apiUrl + "/targetPathCompletions" ,
+    minLength: 0 ,
+    select: function(event, ui) {
+      window.setTimeout(function() { $("#rule-type-textfield input").trigger("enter"); }, 5);
+    }
+  }).focus(function() { $(this).autocomplete("search"); });
+}
+
 function addSourceAutocomplete(sourceInputs) {
   sourceInputs.autocomplete({
     source: apiUrl + "/sourcePathCompletions" ,

--- a/silk-workbench/silk-workbench-rules/public/js/editor/transformRules.js
+++ b/silk-workbench/silk-workbench-rules/public/js/editor/transformRules.js
@@ -254,16 +254,19 @@ function addURIMapping() {
 function addRule(template) {
 
   if (template == "#typeTemplate") {
+    var typeTextfield = $("#rule-type-textfield");
+    var typeInput = $("#rule-type-textfield input");
     var newRule = $(template + " .typeMapping").clone();
     var nameInput = newRule.find(".rule-name");
     var ruleName = generateRuleName(nameInput.text());
     nameInput.text(ruleName);
     var ruleId = "type-" + ruleName;
     newRule.attr("id", ruleId);
-    var typeString = $("#rule-type-textfield input").val();
+    var typeString = typeInput.val();
     newRule.find(".type").text(typeString);
     newRule.appendTo("#typeContainer");
-    $("#rule-type-textfield input").val("");
+    typeInput.val("");
+    typeTextfield.removeClass("is-dirty");
     var deleteButton = newRule.find("button");
     deleteButton.attr("onclick", "deleteRule('" + ruleId + "');");
   } else if(template == "#uriMappingTemplate") {


### PR DESCRIPTION
This fixes autocompletion in the transformation editor and should close story 13361:
- selecting an autocompletion option in the "source" input now triggers modified(), as it already did in "target" before
- the same happens in "Entity Types" (via creating a new type chip)
- all input fields now close on hitting return (they always open on gaining focus, but if the user just types and hits return, they wouldn't close)