### PR TITLE
Bugfix/cmem 51 wrong endpoint position

### DIFF
--- a/silk-workbench/silk-workbench-rules/app/views/editor/operators.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/editor/operators.scala.html
@@ -10,13 +10,15 @@ $(function() {
   // Make operators draggable
   $('.@name.toLowerCase').draggable({
     helper: function() {
-      var box = $(this).children('.@{opType}Div').clone(false);
-      var id = box.find(".handler label").text();
-      box.attr("id", generateNewElementId(id));
-      $("#droppable").append(box); // append box to our canvas to make it the offsetParent
+      var box = $(this).children('.dragDiv');
       box.show();
       return box;
     } ,
+    stop: function(event, ui) {
+      ui.helper.hide();
+      $.ui.ddmanager.current.cancelHelperRemoval = true;
+    } ,
+    containment: "#content"
   });
 
 

--- a/silk-workbench/silk-workbench-rules/app/views/editor/operators.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/editor/operators.scala.html
@@ -13,10 +13,12 @@ $(function() {
       var box = $(this).children('.@{opType}Div').clone(false);
       var id = box.find(".handler label").text();
       box.attr("id", generateNewElementId(id));
+      $("#droppable").append(box); // append box to our canvas to make it the offsetParent
       box.show();
       return box;
-    }
+    } ,
   });
+
 
   // Hide all operators except the recommended ones
   @for(category <- pluginsByCategory.keys if category != "Recommended") {

--- a/silk-workbench/silk-workbench-rules/app/views/editor/operators.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/editor/operators.scala.html
@@ -17,8 +17,8 @@ $(function() {
     stop: function(event, ui) {
       ui.helper.hide();
       $.ui.ddmanager.current.cancelHelperRemoval = true;
-    } ,
-    containment: "#content"
+    }
+    //containment: "#content"
   });
 
 

--- a/silk-workbench/silk-workbench-rules/app/views/editor/operatorsAll.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/editor/operatorsAll.scala.html
@@ -4,22 +4,6 @@ pluginGroup: org.silkframework.runtime.plugin.PluginFactory[_])
 
 @import org.silkframework.runtime.plugin.PluginDescription
 
-<script type="text/javascript">
-// Initialization
-$(function() {
-  // Make operators draggable
-  $('.@name.toLowerCase').draggable({
-    helper: function() {
-      var box = $(this).children('.@{opType}Div').clone(false);
-      var id = box.find(".handler label").text();
-      box.attr("id", generateNewElementId(id));
-      box.show();
-      return box;
-    }
-  });
-});
-</script>
-
 @for(plugin <- pluginGroup.availablePlugins) {
   <div class="operator plugin">
     <div class="operator-index">

--- a/silk-workbench/silk-workbench-rules/app/views/editor/paths.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/editor/paths.scala.html
@@ -10,13 +10,17 @@
     // Make operators draggable
     $('.sourcePaths, .targetPaths').draggable({
       helper: function() {
-        var box = $(this).children('.dragDiv').clone(false);
-        var id = box.find(".handler label").text();
-        box.attr("id", generateNewElementId(id));
+        var box = $(this).children('.dragDiv');
         box.show();
         return box;
-      }
+      } ,
+      stop: function(event, ui) {
+        ui.helper.hide();
+        $.ui.ddmanager.current.cancelHelperRemoval = true;
+      } ,
+      containment: "#content"
     });
+
   })
 </script>
 

--- a/silk-workbench/silk-workbench-rules/app/views/editor/paths.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/editor/paths.scala.html
@@ -17,8 +17,8 @@
       stop: function(event, ui) {
         ui.helper.hide();
         $.ui.ddmanager.current.cancelHelperRemoval = true;
-      } ,
-      containment: "#content"
+      } 
+      //containment: "#content"
     });
 
   })

--- a/silk-workbench/silk-workbench-rules/app/views/editor/renderRule.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/editor/renderRule.scala.html
@@ -101,7 +101,9 @@
       initEditor();
 
       var dropArea = $('#droppable');
-      jsPlumb.draggable(dropArea.find('.dragDiv')); //TODO move
+      jsPlumb.draggable(dropArea.find('.dragDiv'), {
+        containment: "parent"
+      }); //TODO move
 
       jsPlumb.setSuspendEvents(true);
       jsPlumb.setSuspendDrawing(true);

--- a/silk-workbench/silk-workbench-rules/app/views/editor/renderRule.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/editor/renderRule.scala.html
@@ -101,9 +101,10 @@
       initEditor();
 
       var dropArea = $('#droppable');
-      jsPlumb.draggable(dropArea.find('.dragDiv'), {
-        containment: "parent"
-      }); //TODO move
+      jsPlumb.draggable(dropArea.find('.dragDiv'));
+      //jsPlumb.draggable(dropArea.find('.dragDiv'), {
+      //  containment: "parent"
+      //}); //TODO move
 
       jsPlumb.setSuspendEvents(true);
       jsPlumb.setSuspendDrawing(true);

--- a/silk-workbench/silk-workbench-rules/public/js/editor/editor.js
+++ b/silk-workbench/silk-workbench-rules/public/js/editor/editor.js
@@ -140,24 +140,25 @@ function initEditor()
       // Check if we still need to add endpoints to the dropped element
       if(jsPlumb.getEndpoints(ui.helper) === undefined) {
         $.ui.ddmanager.current.cancelHelperRemoval = true;
-        ui.helper.appendTo(this);
 
         // Set operator name to current id
         $('#' + boxId + " .handler label").text(boxId);
 
         // Make operator draggable
-        jsPlumb.draggable($('#' + boxId));
+        jsPlumb.draggable($('#' + boxId), {
+          containment: "parent"
+        });
 
         addEndpoints(boxId, draggedClass);
 
         // fix the position of the new added box
-        var offset = $('#' + boxId).offset();
-        var scrollleft = $("#droppable").scrollLeft();
-        var scrolltop = $("#droppable").scrollTop();
-        var top = offset.top-118+scrolltop+scrolltop;
-        var left = offset.left-504+scrollleft+scrollleft;
-        $('#' + boxId).attr("style", "left: " + left + "px; top: " + top +  "px; position: absolute;");
-        jsPlumb.repaint(boxId);
+//        var offset = $('#' + boxId).offset();
+//        var scrollleft = $("#droppable").scrollLeft();
+//        var scrolltop = $("#droppable").scrollTop();
+//        var top = offset.top-118+scrolltop+scrolltop;
+//        var left = offset.left-504+scrollleft+scrollleft;
+//        $('#' + boxId).attr("style", "left: " + left + "px; top: " + top +  "px; position: absolute;");
+//        jsPlumb.repaint(boxId);
         modifyLinkSpec();
       }
     }
@@ -516,7 +517,9 @@ function loadInstance(index) {
 
     endpoints[boxId] = boxEndpoints.left;
     elements[i][2] = boxEndpoints.right;
-    jsPlumb.draggable(box);
+    jsPlumb.draggable(box, {
+      containment: "parent"
+    });
   }
 
   for(var j = 0; j < elements.length; j++) {

--- a/silk-workbench/silk-workbench-rules/public/js/editor/editor.js
+++ b/silk-workbench/silk-workbench-rules/public/js/editor/editor.js
@@ -159,9 +159,10 @@ function initEditor()
       addEndpoints(boxId, draggedClass);
 
       // Make operator draggable
-      jsPlumb.draggable(boxId, {
-        containment: "parent"
-      });
+      jsPlumb.draggable(boxId);
+//      jsPlumb.draggable(boxId, {
+//        containment: "parent"
+//      });
 
       clone.show();
 
@@ -560,9 +561,10 @@ function loadInstance(index) {
 
     endpoints[boxId] = boxEndpoints.left;
     elements[i][2] = boxEndpoints.right;
-    jsPlumb.draggable(box, {
-      containment: "parent"
-    });
+    jsPlumb.draggable(box);
+//    jsPlumb.draggable(box, {
+//      containment: "parent"
+//    });
   }
 
   for(var j = 0; j < elements.length; j++) {

--- a/silk-workbench/silk-workbench-rules/public/js/editor/editor.js
+++ b/silk-workbench/silk-workbench-rules/public/js/editor/editor.js
@@ -484,8 +484,7 @@ Array.max = function(array) {
 function removeElement(elementId) {
   //We need to set a time-out here as a element should not remove its own parent in its event handler
   setTimeout(function() {
-    jsPlumb.removeAllEndpoints(elementId);
-    $('#' + elementId).remove();
+    jsPlumb.remove(elementId);
     modifyLinkSpec();
   }, 100);
 }

--- a/silk-workbench/silk-workbench-rules/public/js/editor/editor.js
+++ b/silk-workbench/silk-workbench-rules/public/js/editor/editor.js
@@ -132,35 +132,40 @@ function initEditor()
 {
   jsPlumb.reset();
 
-  $("#droppable").droppable({
+   var canvas = $("#droppable");
+
+
+  canvas.droppable({
     drop: function (ev, ui) {
+      var clone = ui.helper.clone(false);
+      var mousePosDraggable = getRelativeOffset(event, ui.helper);
+      var mousePosCanvas = getRelativeOffset(event, canvas);
+      mousePosCanvas = adjustOffset(mousePosCanvas, canvas);
+      var mousePosCombined = subtractOffsets(mousePosCanvas, mousePosDraggable);
+      clone.appendTo(canvas);
+      clone.css(mousePosCombined);
+      clone.css({
+        "z-index": "auto"
+      });
+
       var draggedClass = $(ui.draggable).attr("class");
-      var boxId = ui.helper.attr('id');
+      var idPrefix = clone.find(".handler label").text();
+      var boxId = generateNewElementId(idPrefix);
+      clone.attr("id", boxId);
 
-      // Check if we still need to add endpoints to the dropped element
-      if(jsPlumb.getEndpoints(ui.helper) === undefined) {
-        $.ui.ddmanager.current.cancelHelperRemoval = true;
+      // Set operator name to current id
+      $('#' + boxId + " .handler label").text(boxId);
 
-        // Set operator name to current id
-        $('#' + boxId + " .handler label").text(boxId);
+      addEndpoints(boxId, draggedClass);
 
-        // Make operator draggable
-        jsPlumb.draggable($('#' + boxId), {
-          containment: "parent"
-        });
+      // Make operator draggable
+      jsPlumb.draggable(boxId, {
+        containment: "parent"
+      });
 
-        addEndpoints(boxId, draggedClass);
+      clone.show();
 
-        // fix the position of the new added box
-//        var offset = $('#' + boxId).offset();
-//        var scrollleft = $("#droppable").scrollLeft();
-//        var scrolltop = $("#droppable").scrollTop();
-//        var top = offset.top-118+scrolltop+scrolltop;
-//        var left = offset.left-504+scrollleft+scrollleft;
-//        $('#' + boxId).attr("style", "left: " + left + "px; top: " + top +  "px; position: absolute;");
-//        jsPlumb.repaint(boxId);
-        modifyLinkSpec();
-      }
+      modifyLinkSpec();
     }
   });
 
@@ -232,6 +237,45 @@ function initEditor()
   }
 
 }
+
+/**
+ * Get the mouse position of an event relative to an element.
+ * Returns an offset.
+ */
+var getRelativeOffset = function(event, element) {
+  var relX = event.pageX - element.offset().left;
+  var relY = event.pageY - element.offset().top;
+  return {
+    left: relX,
+    top: relY
+  }
+}
+
+/**
+ * Subtracts offset2 from offset1 by subtracting their respective left and top attributes
+ */
+var subtractOffsets = function(offset1, offset2) {
+  return {
+    left: offset1.left - offset2.left ,
+    top: offset1.top - offset2.top
+  }
+}
+
+/**
+ * Adjusts an offset within an element by taking into account border width and
+ * scrolling position.
+ */
+var adjustOffset = function(offset, element) {
+  var borderLeft = parseInt(element.css("border-left-width"));
+  var borderTop = parseInt(element.css("border-top-width"));
+  var scrollTop = element.scrollTop();
+  var scrollLeft = element.scrollLeft();
+  return {
+    left: offset.left - borderLeft + scrollLeft,
+    top: offset.top - borderTop + scrollTop
+  }
+}
+
 
 function confirmExit() {
   if(confirmOnExit) {

--- a/silk-workbench/silk-workbench-rules/public/stylesheets/editor/editor.css
+++ b/silk-workbench/silk-workbench-rules/public/stylesheets/editor/editor.css
@@ -139,6 +139,8 @@ body{
   cursor: move;
   padding: 4px;
   border-radius: 5px 5px 0 0;
+  margin-top: 0px;
+  margin-bottom: 0px;
 }
 
 .dragDiv .content {


### PR DESCRIPTION
* Wrong endpoint position fixed.
* The problem was related to how the objects were deleted: when deleting jsPlumb'ed elements, jsPlumb.remove() has to be used. So far, jQuery.remove() was used. That messed up something in jsPlumb when the same id was used for a new object.
* Also in this merge request:
** fixed CSS when dragging
** somewhat cleaner drag/drop code (objects get cloned on drop)
** (drag containment not included, this lead to problems in connection with scrolling)