### PR TITLE
table building algorithm improved:

### DIFF
--- a/silk-core/src/main/scala/org/silkframework/util/Table.scala
+++ b/silk-core/src/main/scala/org/silkframework/util/Table.scala
@@ -49,24 +49,43 @@ case class Table(name: String,
   }
 
   /**
-   * Formats this table as markdown.
-   */
+    * Formats this table as markdown.
+    * This is how multiline table should look like:
+
+|  First column  | Second column                                                |
+|-------------------------|----------------------------------------------------|
+| Cell content  | This cell holds some more text content.\
+                  The row exceeds the maximum count of chars.\
+                  \
+                  Third line.                                                  |
+
+    */
   def toMarkdown = {
     val sb = new StringBuilder()
 
     sb.append(header.mkString("| ", " | ", " |\n"))
     sb.append("| " + (" --- |" * header.size) + "\n")
     for(row <- values) {
+      sb.append("| ")
+      val lineValues = scala.collection.mutable.ListBuffer.empty[String]
+      for(cell <- row.zip(columnWidthInCharacters)) {
+        val v = cell._1
+        val maxChars = cell._2
+        val lines = Table.softGrouped(v.toString.replace("\\", "\\\\"), maxChars)
+        lineValues += lines.mkString("\\\n")
+      }
+      sb.append(lineValues.mkString(" | "))
+      sb.append(" |\n")
       // If there are line breaks in a value, we need to generate multiple rows
-      val rowLines = row.zip(columnWidthInCharacters).map { case (v, maxChars) =>
-        Table.softGrouped(v.toString.replace("\\", "\\\\"), maxChars).flatMap(_.split("[\n\r]+"))
-      }
-      val maxLines = rowLines.map(_.length).max
-
-      for(index <- 0 until maxLines) {
-        val lineValues = rowLines.map(lines => if(index >= lines.length) "" else lines(index))
-        sb.append("| " + lineValues.mkString(" | ") + " |\n")
-      }
+//      val rowLines = row.zip(columnWidthInCharacters).map { case (v, maxChars) =>
+//        Table.softGrouped(v.toString.replace("\\", "\\\\"), maxChars).flatMap(_.split("[\n\r]+"))
+//      }
+//      val maxLines = rowLines.map(_.length).max
+//
+//      for(index <- 0 until maxLines) {
+//        val lineValues = rowLines.map(lines => if(index >= lines.length) "" else lines(index))
+//        sb.append("| " + lineValues.mkString(" | ") + " |\n")
+//      }
     }
 
     sb.toString()
@@ -105,18 +124,26 @@ object Table {
     var splits = Vector.empty[String]
     while(remainingString.size > 0) {
       val whiteSpaceSplitIdx = remainingString.take(maxLength + 1).lastIndexOf(' ')
+      val slashSplitIdx = remainingString.take(maxLength + 1).lastIndexOf('/') + 1
       val camelCaseSplitIdx = remainingString.take(maxLength + 1).sliding(2).toSeq.lastIndexWhere(s => s.length == 2 && s(0).isLower && s(1).isUpper) + 1
+      var isCamelCase = false
 
       val splitIndex = if(whiteSpaceSplitIdx > minLength) {
         whiteSpaceSplitIdx
+      } else if(slashSplitIdx > minLength) {
+        slashSplitIdx
       } else if(camelCaseSplitIdx > minLength) {
+        isCamelCase = true
         camelCaseSplitIdx
       } else {
         maxLength
       }
 
       val (next, remain) = remainingString.splitAt(splitIndex)
-      splits :+= next
+      if (isCamelCase)
+        splits :+= next + "-"
+      else
+        splits :+= next
       remainingString = remain
     }
     splits


### PR DESCRIPTION
- correct multilines (backslash instead of pipe for new line)
- hyphen after camel case splits
- splits after / (for long URIs)

This is part of fixing CMEM-78 (rest is in DI)