### PR TITLE
Bugfix/prevent dialog closing on error

### DIFF
--- a/silk-workbench/silk-workbench-core/app/views/widgets/dialog.scala.html
+++ b/silk-workbench/silk-workbench-core/app/views/widgets/dialog.scala.html
@@ -4,7 +4,13 @@
   <strong class="mdl-dialog__title-text">@title</strong>
   <div id="dialog-progress-spinner" class="mdl-spinner mdl-spinner--single-color mdl-js-spinner is-active"></div>
 </div>
-
+<div class="dialog__error-msg">
+  <div class="mdl-alert mdl-alert--danger mdl-alert--border mdl-alert--spacing">
+    <div class="mdl-alert__content">
+      Error message.
+    </div>
+  </div>
+</div>
 <form id="dialog-form" action="javascript:submit();" enctype="multipart/form-data">
   <div class="mdl-dialog__content">
   @content
@@ -22,5 +28,6 @@
   primary_dialog.querySelector('#dialog-secondary-button').addEventListener('click', function() {
     dialog_secondary();
   });
+  $(".dialog__error-msg").click(function() { $(this).fadeToggle(); });
 </script>
 

--- a/silk-workbench/silk-workbench-core/app/views/widgets/pluginDialog.scala.html
+++ b/silk-workbench/silk-workbench-core/app/views/widgets/pluginDialog.scala.html
@@ -64,10 +64,15 @@
     });
 
     function submit() {
+      console.log("submit");
       var selected_resource_type = $("#resource_type_select").val();
-      if (plugin_dialog_submit_delegates[selected_resource_type](false)) {
-        closeDialog();
-      }
+      plugin_dialog_submit_delegates[selected_resource_type](false, {
+        success: function() {
+          closeDialog();
+        } ,
+        error: function() {
+        }
+      });
     }
 
     function dialog_secondary() {
@@ -97,7 +102,7 @@
   </div>
 
   <script type="text/javascript">
-    function @(plugin.id)_submit(onlyAutoConfigure) {
+    function @(plugin.id)_submit(onlyAutoConfigure, callbacks) {
       // Retrieve the name of the plugin
       var name = $('[name=\'@(plugin.id)_name\']').val();
       if(name.length === 0) {
@@ -116,7 +121,7 @@
 
       // Submit dialog
       if(!onlyAutoConfigure) {
-        savePlugin('@plugin.id', name, parameters);
+        savePlugin('@plugin.id', name, parameters, callbacks);
       } else {
         autoConfigure('@plugin.id', name, parameters);
       }

--- a/silk-workbench/silk-workbench-core/app/views/widgets/pluginDialog.scala.html
+++ b/silk-workbench/silk-workbench-core/app/views/widgets/pluginDialog.scala.html
@@ -70,7 +70,9 @@
         success: function() {
           closeDialog();
         } ,
-        error: function() {
+        error: function(msg) {
+          $("#primary_dialog .dialog__error-msg .mdl-alert__content").text(msg);
+          $("#primary_dialog .dialog__error-msg").fadeToggle();
         }
       });
     }

--- a/silk-workbench/silk-workbench-core/public/main.css
+++ b/silk-workbench/silk-workbench-core/public/main.css
@@ -256,3 +256,11 @@ div#newproject {
 .error-details-stacktrace {
   font-family: monospace;
 }
+
+/* Dialogs */
+
+.dialog__error-msg {
+  max-width: 324px;
+  margin-left: 24px;
+  display: none;
+}

--- a/silk-workbench/silk-workbench-workspace/app/views/workspace/dataset/datasetDialog.scala.html
+++ b/silk-workbench/silk-workbench-workspace/app/views/workspace/dataset/datasetDialog.scala.html
@@ -13,7 +13,7 @@
     secondaryLabel = "Autoconfigure") {
 
     <script type="text/javascript">
-      function savePlugin(pluginId, name, parameters) {
+      function savePlugin(pluginId, name, parameters, callbacks) {
         // Build dataset xml
         var xml = '<Dataset id=\'' + name + '\' type=\'' + pluginId + '\'>';
         for(var i in parameters) {
@@ -22,7 +22,7 @@
         xml += '</Dataset>';
 
         // Submit data source
-        putTask('@config.baseUrl/workspace/projects/@project.name/datasets/' + name, xml);
+        putTask('@config.baseUrl/workspace/projects/@project.name/datasets/' + name, xml, callbacks);
       }
 
       function autoConfigure(pluginId, name, parameters) {

--- a/silk-workbench/silk-workbench-workspace/public/workspace.js
+++ b/silk-workbench/silk-workbench-workspace/public/workspace.js
@@ -86,8 +86,7 @@ function putTask(path, xml, callbacks={
     processData: false,
     data: xml,
     error: function(request) {
-      alert(request.responseText);
-      callbacks.error();
+      callbacks.error(JSON.parse(request.responseText).message);
     },
     success: function(request) {
       reloadWorkspace();

--- a/silk-workbench/silk-workbench-workspace/public/workspace.js
+++ b/silk-workbench/silk-workbench-workspace/public/workspace.js
@@ -75,7 +75,10 @@ function workspaceDialog(relativePath) {
   showDialog(baseUrl + '/' + relativePath);
 }
 
-function putTask(path, xml) {
+function putTask(path, xml, callbacks={
+    success: function() {} ,
+    error: function() {}
+  }) {
   $.ajax({
     type: 'PUT',
     url: path,
@@ -84,9 +87,11 @@ function putTask(path, xml) {
     data: xml,
     error: function(request) {
       alert(request.responseText);
+      callbacks.error();
     },
     success: function(request) {
       reloadWorkspace();
+      callbacks.success();
     }
   });
 }


### PR DESCRIPTION
In the (create/edit) dataset dialog, no longer show alert and close dialog if an error occurs trying to save (e.g., illegal dataset name). Instead an error message is shown in the dialog, and the dialog stays open. Clicking on the error message lets it disappear.