### PR TITLE
Fix/break long value path

### DIFF
--- a/silk-react-components/src/HierarchicalMapping/HierarchicalMapping.scss
+++ b/silk-react-components/src/HierarchicalMapping/HierarchicalMapping.scss
@@ -579,6 +579,12 @@ ul.ecc-hierarchical-mapping-error-list {
 
 }
 
+.ecc-silk-mapping__rulesviewer__sourcePath {
+    code {
+        word-wrap: break-word;
+    }
+}
+
 .ecc-silk-mapping__rulesviewer__infobox {
 
     display: flex;

--- a/silk-react-components/src/HierarchicalMapping/retrieval2.json
+++ b/silk-react-components/src/HierarchicalMapping/retrieval2.json
@@ -102,7 +102,7 @@
                                     "nodeType": "StringValueType"
                                 }
                             },
-                            "sourcePath": "zip code",
+                            "sourcePath": "/whatever:urn:This+is+a+very+very+very+very+very+very+very+very+very+very+long+column+title+just+to+have+a+header+to+describe+the+zip+code",
                             "id": "valueMapping34",
                             "type": "direct"
                         },


### PR DESCRIPTION
A long value path in the expanded mapping view now does not overflow the list but breaks to multiple lines.