### PR TITLE
Introduce AbortExecutionException

### DIFF
--- a/silk-core/src/main/scala/org/silkframework/execution/AbortExecutionException.scala
+++ b/silk-core/src/main/scala/org/silkframework/execution/AbortExecutionException.scala
@@ -1,0 +1,11 @@
+package org.silkframework.execution
+
+/**
+  * Thrown if a fatal problem occurred during the execution.
+  * The execution must be aborted after throwing this exception.
+  *
+  * @param message User-friendly error message
+  * @param cause Cause of the exception, if any
+  */
+case class AbortExecutionException(message: String, cause: Option[Throwable] = None)
+  extends ExecutionException(message, cause, abortExecution = true)

--- a/silk-core/src/main/scala/org/silkframework/execution/ExecutionException.scala
+++ b/silk-core/src/main/scala/org/silkframework/execution/ExecutionException.scala
@@ -2,5 +2,9 @@ package org.silkframework.execution
 
 /**
   * Thrown if a problem occurred during the execution of a task.
+  *
+  * @param message User-friendly error message
+  * @param cause Cause of the exception, if any
+  * @param abortExecution If true, this is a fatal exception that should abort the execution.
   */
-case class ExecutionException(message: String, cause: Option[Throwable] = None) extends RuntimeException(message, cause.orNull)
+class ExecutionException(message: String, cause: Option[Throwable], val abortExecution: Boolean) extends RuntimeException(message, cause.orNull)

--- a/silk-rules/src/main/scala/org/silkframework/rule/execution/ExecuteTransform.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/execution/ExecuteTransform.scala
@@ -1,7 +1,7 @@
 package org.silkframework.rule.execution
 
 import org.silkframework.dataset.{DataSource, EntitySink}
-import org.silkframework.execution.ExecutionReport
+import org.silkframework.execution.{AbortExecutionException, ExecutionReport}
 import org.silkframework.rule.TransformSpec.RuleSchemata
 import org.silkframework.rule._
 import org.silkframework.rule.execution.local.TransformedEntities

--- a/silk-rules/src/main/scala/org/silkframework/rule/execution/local/TransformedEntities.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/execution/local/TransformedEntities.scala
@@ -3,7 +3,7 @@ package org.silkframework.rule.execution.local
 import java.util.logging.Logger
 
 import org.silkframework.entity.{Entity, EntitySchema, UriValueType}
-import org.silkframework.execution.ExecutionReport
+import org.silkframework.execution.{ExecutionException, ExecutionReport}
 import org.silkframework.rule.TransformRule
 import org.silkframework.rule.execution.TransformReportBuilder
 import org.silkframework.runtime.activity.ActivityContext
@@ -80,6 +80,8 @@ class TransformedEntities(entities: Traversable[Entity],
     try {
       rule(entity)
     } catch {
+      case ex: ExecutionException if ex.abortExecution =>
+        throw ex
       case NonFatal(ex) =>
         log.fine("Error during execution of transform rule " + rule.id.toString + ": " + ex.getMessage)
         report.addError(rule, entity, ex)

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/activity/linking/ExecuteLinkingFactory.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/activity/linking/ExecuteLinkingFactory.scala
@@ -2,7 +2,7 @@ package org.silkframework.workspace.activity.linking
 
 import org.silkframework.dataset.DatasetSpec.GenericDatasetSpec
 import org.silkframework.entity.EntitySchema
-import org.silkframework.execution.{ExecutionException, ExecutionType, ExecutorRegistry}
+import org.silkframework.execution.{AbortExecutionException, ExecutionException, ExecutionType, ExecutorRegistry}
 import org.silkframework.rule.{DatasetSelection, LinkSpec, TransformSpec}
 import org.silkframework.runtime.activity.{Activity, ActivityContext, UserContext}
 import org.silkframework.runtime.plugin.Plugin
@@ -46,7 +46,7 @@ class ExecuteLinking(task: ProjectTask[LinkSpec]) extends Activity[Unit] {
     context.status.update("Generating links", 0.4)
     val links = ExecutorRegistry.execute(task, inputs, None, execution) match {
       case Some(result) => result
-      case None => throw ExecutionException("Linking task did not generate any links")
+      case None => throw AbortExecutionException("Linking task did not generate any links")
     }
 
     // Write links to outputs
@@ -70,7 +70,7 @@ class ExecuteLinking(task: ProjectTask[LinkSpec]) extends Activity[Unit] {
           ExecutorRegistry.execute(datasetTask, Seq.empty, Some(entitySchema), execution)
       }
 
-    result.getOrElse(throw ExecutionException(s"The input task ${selection.inputId} did not generate any result"))
+    result.getOrElse(throw AbortExecutionException(s"The input task ${selection.inputId} did not generate any result"))
   }
 
 }


### PR DESCRIPTION
Introduces AbortExecutionException that aborts execution of the task if thrown inside a transform operator.