### PR TITLE
Feature/transform execution errors

### DIFF
--- a/silk-plugins/silk-serialization-json/src/main/scala/org/silkframework/serialization/json/JsonPluginModule.scala
+++ b/silk-plugins/silk-serialization-json/src/main/scala/org/silkframework/serialization/json/JsonPluginModule.scala
@@ -5,7 +5,8 @@ import org.silkframework.serialization.json.EntitySerializers.{CachedEntitySchem
 import org.silkframework.serialization.json.InputJsonSerializer.InputJsonFormat
 import org.silkframework.serialization.json.JsonSerializers.{GenericInfoJsonFormat, JsonDatasetSpecFormat, MappingRulesJsonFormat, RootMappingRuleJsonFormat, TransformRuleJsonFormat, TransformSpecJsonFormat, TransformTaskJsonFormat, VocabularyPropertyJsonFormat, _}
 import org.silkframework.serialization.json.LinkingSerializers.LinkingJsonFormat
-import org.silkframework.serialization.json.WorkflowSerializers.{WorkflowJsonFormat}
+import org.silkframework.serialization.json.TransformSerializers.TransformReportJsonFormat
+import org.silkframework.serialization.json.WorkflowSerializers.WorkflowJsonFormat
 
 class JsonPluginModule extends PluginModule {
 
@@ -39,5 +40,6 @@ class JsonPluginModule extends PluginModule {
       CachedEntitySchemataJsonFormat.getClass ::
       EntityHolderJsonFormat.getClass ::
       LinkingJsonFormat.getClass ::
+      TransformReportJsonFormat.getClass ::
       Nil
 }

--- a/silk-plugins/silk-serialization-json/src/main/scala/org/silkframework/serialization/json/TransformSerializers.scala
+++ b/silk-plugins/silk-serialization-json/src/main/scala/org/silkframework/serialization/json/TransformSerializers.scala
@@ -14,6 +14,12 @@ object TransformSerializers {
     final val ENTITY_ERROR_COUNTER = "entityErrorCounter"
     final val RULE_RESULTS = "ruleResults"
 
+    final val ERROR_COUNT = "errorCount"
+    final val SAMPLE_ERRORS = "sampleErrors"
+
+    final val ENTITY = "entity"
+    final val VALUE = "value"
+
     override def write(value: TransformReport)(implicit writeContext: WriteContext[JsValue]): JsValue = {
       Json.obj(
         ENTITY_COUNTER -> value.entityCounter,
@@ -32,15 +38,15 @@ object TransformSerializers {
 
     private def writeRuleResult(ruleResult: RuleResult): JsValue = {
       Json.obj(
-      "errorCount" -> ruleResult.errorCount,
-        "sampleErrors" -> ruleResult.sampleErrors.map(writeRuleError)
+        ERROR_COUNT -> ruleResult.errorCount,
+        SAMPLE_ERRORS -> ruleResult.sampleErrors.map(writeRuleError)
       )
     }
 
     private def writeRuleError(ruleError: RuleError): JsValue = {
       Json.obj(
-      "entity" -> ruleError.entity,
-        "value" -> ruleError.value
+        ENTITY -> ruleError.entity,
+        VALUE -> ruleError.value
       )
     }
 

--- a/silk-plugins/silk-serialization-json/src/main/scala/org/silkframework/serialization/json/TransformSerializers.scala
+++ b/silk-plugins/silk-serialization-json/src/main/scala/org/silkframework/serialization/json/TransformSerializers.scala
@@ -1,0 +1,49 @@
+package org.silkframework.serialization.json
+
+import org.silkframework.rule.execution.TransformReport
+import org.silkframework.rule.execution.TransformReport.{RuleError, RuleResult}
+import org.silkframework.runtime.serialization.WriteContext
+import org.silkframework.util.Identifier
+import play.api.libs.json.{JsObject, JsValue, Json}
+
+object TransformSerializers {
+
+  implicit object TransformReportJsonFormat extends WriteOnlyJsonFormat[TransformReport] {
+
+    final val ENTITY_COUNTER = "entityCounter"
+    final val ENTITY_ERROR_COUNTER = "entityErrorCounter"
+    final val RULE_RESULTS = "ruleResults"
+
+    override def write(value: TransformReport)(implicit writeContext: WriteContext[JsValue]): JsValue = {
+      Json.obj(
+        ENTITY_COUNTER -> value.entityCounter,
+        ENTITY_ERROR_COUNTER -> value.entityErrorCounter,
+        RULE_RESULTS -> writeRuleResults(value.ruleResults)
+      )
+    }
+
+    private def writeRuleResults(ruleResults: Map[Identifier, RuleResult]): JsValue = {
+      JsObject(
+        for((ruleId, ruleResult) <- ruleResults) yield {
+          (ruleId.toString, writeRuleResult(ruleResult))
+        }
+      )
+    }
+
+    private def writeRuleResult(ruleResult: RuleResult): JsValue = {
+      Json.obj(
+      "errorCount" -> ruleResult.errorCount,
+        "sampleErrors" -> ruleResult.sampleErrors.map(writeRuleError)
+      )
+    }
+
+    private def writeRuleError(ruleError: RuleError): JsValue = {
+      Json.obj(
+      "entity" -> ruleError.entity,
+        "value" -> ruleError.value
+      )
+    }
+
+  }
+
+}

--- a/silk-rules/src/main/scala/org/silkframework/rule/TransformSpec.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/TransformSpec.scala
@@ -47,7 +47,7 @@ case class TransformSpec(selection: DatasetSelection,
     */
   def ruleById(ruleId: Identifier): TransformRule = {
     nestedRuleAndSourcePath(ruleId)
-      .getOrElse(throw new NoSuchElementException(s"No rule with identifier 'ruleId' has been found."))
+      .getOrElse(throw new NoSuchElementException(s"No rule with identifier '$ruleId' has been found."))
       ._1
   }
 

--- a/silk-rules/src/main/scala/org/silkframework/rule/execution/ExecuteTransform.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/execution/ExecuteTransform.scala
@@ -49,7 +49,7 @@ class ExecuteTransform(input: UserContext => DataSource,
     entitySink.openTable(rule.outputSchema.typeUri, rule.outputSchema.typedPaths.map(_.property.get))
 
     val entities = dataSource.retrieve(rule.inputSchema)
-    val transformedEntities = new TransformedEntities(entities, rule.transformRule.rules, rule.outputSchema, context.asInstanceOf[ActivityContext[ExecutionReport]])
+    val transformedEntities = new TransformedEntities(entities, rule.transformRule.rules, rule.outputSchema, context)
     var count = 0
     breakable {
       for (entity <- transformedEntities) {

--- a/silk-rules/src/main/scala/org/silkframework/rule/execution/TransformReport.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/execution/TransformReport.scala
@@ -2,7 +2,6 @@ package org.silkframework.rule.execution
 
 import org.silkframework.execution.ExecutionReport
 import org.silkframework.rule.execution.TransformReport._
-import org.silkframework.rule.TransformRule
 import org.silkframework.util.Identifier
 
 /**

--- a/silk-rules/src/main/scala/org/silkframework/rule/execution/TransformReportBuilder.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/execution/TransformReportBuilder.scala
@@ -9,13 +9,15 @@ import org.silkframework.util.Identifier
   * A builder for generating transform reports.
   * Not thread safe!
   */
-private class TransformReportBuilder(rules: Seq[TransformRule]) {
+private class TransformReportBuilder(rules: Seq[TransformRule], previousReport: TransformReport) {
 
-  private var entityCounter = 0L
+  private var entityCounter = previousReport.entityCounter
 
-  private var entityErrorCounter = 0L
+  private var entityErrorCounter = previousReport.entityErrorCounter
 
-  private var ruleResults: Map[Identifier, RuleResult] = rules.map(rule => (rule.id, RuleResult())).toMap
+  private var ruleResults: Map[Identifier, RuleResult] = {
+    previousReport.ruleResults ++ rules.map(rule => (rule.id, RuleResult())).toMap
+  }
 
   // The maximum number of erroneous values to be held for each rule.
   private val maxSampleErrors = 10

--- a/silk-rules/src/main/scala/org/silkframework/rule/execution/local/LocalTransformSpecExecutor.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/execution/local/LocalTransformSpecExecutor.scala
@@ -5,6 +5,7 @@ import org.silkframework.entity.{EntitySchema, TypedPath}
 import org.silkframework.execution.local.{GenericEntityTable, LocalEntities, LocalExecution, MultiEntityTable}
 import org.silkframework.execution.{ExecutionReport, Executor, TaskException}
 import org.silkframework.rule._
+import org.silkframework.rule.execution.TransformReport
 import org.silkframework.runtime.activity.{ActivityContext, UserContext}
 
 import scala.collection.mutable
@@ -45,7 +46,7 @@ class LocalTransformSpecExecutor extends Executor[TransformSpec, LocalExecution]
 
       val entities = inputTables.remove(0).entities
 
-      val transformedEntities = new TransformedEntities(entities, rules, outputSchema, context)
+      val transformedEntities = new TransformedEntities(entities, rules, outputSchema, context.asInstanceOf[ActivityContext[TransformReport]])
       outputTables.append(GenericEntityTable(transformedEntities, outputSchema, task))
 
       for(objectMapping @ ObjectMapping(_, relativePath, _, childRules, _) <- rules) {

--- a/silk-rules/src/main/scala/org/silkframework/rule/execution/local/TransformedEntities.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/execution/local/TransformedEntities.scala
@@ -21,7 +21,7 @@ class TransformedEntities(entities: Traversable[Entity],
 
   private val propertyRules = rules.filter(_.target.nonEmpty).toIndexedSeq
 
-  private val report = new TransformReportBuilder(rules, context.value())
+  private val report = new TransformReportBuilder(rules, context.value.get.getOrElse(TransformReport()))
 
   private var errorFlag = false
 

--- a/silk-rules/src/main/scala/org/silkframework/rule/execution/local/TransformedEntities.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/execution/local/TransformedEntities.scala
@@ -3,9 +3,9 @@ package org.silkframework.rule.execution.local
 import java.util.logging.Logger
 
 import org.silkframework.entity.{Entity, EntitySchema, UriValueType}
-import org.silkframework.execution.{ExecutionException, ExecutionReport}
+import org.silkframework.execution.ExecutionException
 import org.silkframework.rule.TransformRule
-import org.silkframework.rule.execution.TransformReportBuilder
+import org.silkframework.rule.execution.{TransformReport, TransformReportBuilder}
 import org.silkframework.runtime.activity.ActivityContext
 
 import scala.util.control.NonFatal
@@ -13,7 +13,7 @@ import scala.util.control.NonFatal
 class TransformedEntities(entities: Traversable[Entity],
                           rules: Seq[TransformRule],
                           outputSchema: EntitySchema,
-                          context: ActivityContext[ExecutionReport]) extends Traversable[Entity] {
+                          context: ActivityContext[TransformReport]) extends Traversable[Entity] {
 
   private val log: Logger = Logger.getLogger(this.getClass.getName)
 
@@ -21,7 +21,7 @@ class TransformedEntities(entities: Traversable[Entity],
 
   private val propertyRules = rules.filter(_.target.nonEmpty).toIndexedSeq
 
-  private val report = new TransformReportBuilder(rules)
+  private val report = new TransformReportBuilder(rules, context.value())
 
   private var errorFlag = false
 

--- a/silk-workbench/silk-workbench-rules/app/views/executeTransform/transformStatistics.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/executeTransform/transformStatistics.scala.html
@@ -28,6 +28,7 @@
     </thead>
     <tbody>
 
+    @** Currently, the results are unsorted. We could structure them according to the rule structure instead. *@
     @for((ruleId, RuleResult(errorCount, sampleErrors)) <- statistics.ruleResults) {
       <tr class="mdl-color--blue-grey-100">
         <td><b>@task.data.ruleById(ruleId).metaData.formattedLabel(defaultLabel = ruleId, maxLength = 100)</b></td>

--- a/silk-workbench/silk-workbench-rules/app/views/executeTransform/transformStatistics.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/executeTransform/transformStatistics.scala.html
@@ -5,6 +5,7 @@
 @import org.silkframework.config.Prefixes
 @import org.silkframework.config.Task
 @import org.silkframework.workbench.Context
+@import org.silkframework.rule.TransformRule
 
 @(task: Task[TransformSpec], statistics: TransformReport, prefixes: Prefixes)
 
@@ -27,39 +28,44 @@
       </tr>
     </thead>
     <tbody>
+      @ruleReport(task.data.mappingRule)
+    </tbody>
+  </table>
+}
 
-    @** Currently, the results are unsorted. We could structure them according to the rule structure instead. *@
-    @for((ruleId, RuleResult(errorCount, sampleErrors)) <- statistics.ruleResults) {
-      <tr class="mdl-color--blue-grey-100">
-        <td><b>@task.data.ruleById(ruleId).metaData.formattedLabel(defaultLabel = ruleId, maxLength = 100)</b></td>
+@ruleReport(rule: TransformRule) = {
+  @for(ruleResults <- statistics.ruleResults.get(rule.id)) {
+    <tr class="mdl-color--blue-grey-100">
+      <td><b>@rule.metaData.formattedLabel(defaultLabel = rule.id, maxLength = 100)</b></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+
+    @if(ruleResults.sampleErrors.isEmpty) {
+      <tr>
         <td></td>
+        <td>
+          No issues
+        </td>
         <td></td>
         <td></td>
       </tr>
-
-      @if(sampleErrors.isEmpty) {
+    } else {
+      @for(RuleError(entity, values, exception) <- ruleResults.sampleErrors) {
         <tr>
           <td></td>
           <td>
-            No issues
+            <a href="@entity" target="_blank" >@prefixes.shorten(entity)</a>
           </td>
-          <td></td>
-          <td></td>
+          <td>@values.flatten.mkString(", ")</td>
+          <td>@exception.getMessage</td>
         </tr>
-      } else {
-        @for(RuleError(entity, values, exception) <- sampleErrors) {
-          <tr>
-            <td></td>
-            <td>
-              <a href="@entity" target="_blank" >@prefixes.shorten(entity)</a>
-            </td>
-            <td>@values.flatten.mkString(", ")</td>
-            <td>@exception.getMessage</td>
-          </tr>
-        }
       }
     }
+  }
 
-    </tbody>
-  </table>
+  @for(childRule <- rule.rules.allRules) {
+    @ruleReport(childRule)
+  }
 }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/activity/transform/ExecuteTransformFactory.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/activity/transform/ExecuteTransformFactory.scala
@@ -10,7 +10,7 @@ import org.silkframework.workspace.activity.TaskActivityFactory
 import org.silkframework.workspace.activity.transform.TransformTaskUtils._
 
 @Plugin(
-  id = "ExecuteTransform",
+  id = ExecuteTransformFactory.ID,
   label = "Execute Transform",
   categories = Array("TransformSpecification"),
   description = "Executes the transformation."
@@ -30,4 +30,10 @@ case class ExecuteTransformFactory(
       )
     }
   }
+}
+
+object ExecuteTransformFactory {
+
+  final val ID = "ExecuteTransform"
+
 }


### PR DESCRIPTION
- Execute Mapping shows validation report for all rules and not just the ones of the last object mapping.
- If the evaluation of a URI pattern fails, an error is added to the validation report instead of failing the entire execution.
