### PR TITLE
Fix/execution

### DIFF
--- a/silk-core/src/main/scala/org/silkframework/runtime/activity/Activity.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/activity/Activity.scala
@@ -2,9 +2,9 @@ package org.silkframework.runtime.activity
 
 import java.util.concurrent.ForkJoinPool
 
+import org.silkframework.runtime.execution.Execution
 import org.silkframework.util.StringUtils._
 
-import scala.math.max
 import scala.reflect.ClassTag
 
 /**
@@ -67,11 +67,7 @@ object Activity {
   /**
    * The fork join pool used to run activities.
    */
-  val forkJoinPool: ForkJoinPool = {
-    val minimumNumberOfThreads = 4
-    val threadCount = max(minimumNumberOfThreads, Runtime.getRuntime.availableProcessors())
-    new ForkJoinPool(threadCount, ForkJoinPool.defaultForkJoinWorkerThreadFactory, null, true)
-  }
+  val forkJoinPool: ForkJoinPool = Execution.createForkJoinPool("Activity")
 
   /**
     * The base path into which all activity output is logged

--- a/silk-core/src/main/scala/org/silkframework/runtime/execution/Execution.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/execution/Execution.scala
@@ -1,0 +1,80 @@
+package org.silkframework.runtime.execution
+
+import java.lang.Thread.UncaughtExceptionHandler
+import java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory
+import java.util.concurrent._
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.logging.{Level, Logger}
+
+import scala.math.max
+
+object Execution {
+
+  private val log = Logger.getLogger(getClass.getName)
+
+  /**
+    * Creates a new fork/join pool.
+    * The size of the thread pool is determined by the number of available processors.
+    *
+    * @param name A label to be used for naming threads. Helps debugging and finding threads that belong to this pool.
+    */
+  def createForkJoinPool(name: String): ForkJoinPool = {
+    val minimumNumberOfThreads = 4
+    val threadCount = max(minimumNumberOfThreads, Runtime.getRuntime.availableProcessors())
+    new ForkJoinPool(threadCount, new PrefixedForkJoinWorkerThreadFactory(name + "-thread-"), null, true)
+  }
+
+  /**
+    * Creates a new unlimited cached thread pool.
+    *
+    * @param name A label to be used for naming threads. Helps debugging and finding threads that belong to this pool.
+    */
+  def createThreadPool(name: String): ExecutorService = {
+    Executors.newCachedThreadPool( new PrefixedThreadFactory(name + "-thread-"))
+  }
+
+  /**
+    * Thread factory that names threads using a prefix and a count.
+    * Also makes sure that uncaught exceptions are logged.
+    */
+  private class PrefixedThreadFactory(prefix: String) extends ThreadFactory {
+
+    private val threadNumber = new AtomicInteger(1)
+
+    override def newThread(r: Runnable): Thread = {
+      val t = new Thread(null, r, prefix + threadNumber.getAndIncrement, 0)
+      if (t.isDaemon) t.setDaemon(false)
+      if (t.getPriority != Thread.NORM_PRIORITY) t.setPriority(Thread.NORM_PRIORITY)
+      t.setUncaughtExceptionHandler(LoggingExceptionHandler)
+      t
+    }
+  }
+
+  /**
+    * ForkJoinWorkerThreadFactory that names threads using a prefix and a count.
+    * Also makes sure that uncaught exceptions are logged.
+    */
+  private class PrefixedForkJoinWorkerThreadFactory(prefix: String) extends ForkJoinWorkerThreadFactory {
+
+    private val factory = ForkJoinPool.defaultForkJoinWorkerThreadFactory
+
+    private val threadNumber = new AtomicInteger(1)
+
+    override def newThread(pool: ForkJoinPool): ForkJoinWorkerThread = {
+      val t = factory.newThread(pool)
+      t.setName(prefix + threadNumber.getAndIncrement)
+      t.setUncaughtExceptionHandler(LoggingExceptionHandler)
+      t
+    }
+  }
+
+  /**
+    * Exception handler that logs uncaught exceptions.
+    */
+  private object LoggingExceptionHandler extends UncaughtExceptionHandler {
+    override def uncaughtException(t: Thread, e: Throwable): Unit = {
+      log.log(Level.WARNING, s"Thread ${t.getName} failed with an exception", e)
+    }
+  }
+
+}

--- a/silk-rules/src/main/scala/org/silkframework/rule/execution/Matcher.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/execution/Matcher.scala
@@ -22,6 +22,7 @@ import org.silkframework.cache.EntityCache
 import org.silkframework.entity.Link
 import org.silkframework.rule.{LinkageRule, RuntimeLinkingConfig}
 import org.silkframework.runtime.activity.{Activity, ActivityContext, ActivityControl, UserContext}
+import org.silkframework.runtime.execution.Execution
 import org.silkframework.util.DPair
 
 import scala.math.{max, min}
@@ -58,7 +59,7 @@ class Matcher(loaders: DPair[ActivityControl[Unit]],
     cancelled = false
 
     //Create execution service for the matching tasks
-    val executorService = Executors.newFixedThreadPool(runtimeConfig.numThreads)
+    val executorService = Execution.createFixedThreadPool("Matcher", runtimeConfig.numThreads)
     val executor = new ExecutorCompletionService[IndexedSeq[Link]](executorService)
 
     //Start matching thread scheduler

--- a/silk-workbench/silk-workbench-core/app/org/silkframework/workbench/utils/Listener.scala
+++ b/silk-workbench/silk-workbench-core/app/org/silkframework/workbench/utils/Listener.scala
@@ -1,7 +1,9 @@
 package org.silkframework.workbench.utils
 
-import java.util.concurrent.{Executors, TimeUnit}
+import java.util.concurrent.TimeUnit
 import java.util.logging.{Level, Logger}
+
+import org.silkframework.runtime.execution.Execution
 
 /**
   * A Listener that limits that rate of updates.
@@ -56,5 +58,5 @@ trait Listener[T] extends (T => Unit) {
 }
 
 object Listener {
-  private val executor = Executors.newScheduledThreadPool(1)
+  private val executor = Execution.createScheduledThreadPool(getClass.getSimpleName, 1)
 }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/ProjectTask.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/ProjectTask.scala
@@ -15,11 +15,12 @@
 package org.silkframework.workspace
 
 import java.time.Instant
-import java.util.concurrent.{Executors, ScheduledFuture, TimeUnit}
+import java.util.concurrent.{ScheduledFuture, TimeUnit}
 import java.util.logging.{Level, Logger}
 
 import org.silkframework.config.{MetaData, Prefixes, Task, TaskSpec}
 import org.silkframework.runtime.activity.{HasValue, Status, UserContext, ValueHolder}
+import org.silkframework.runtime.execution.Execution
 import org.silkframework.runtime.plugin.PluginRegistry
 import org.silkframework.runtime.resource.ResourceManager
 import org.silkframework.util.Identifier
@@ -229,5 +230,5 @@ object ProjectTask {
   /* Do not persist updates more frequently than this (in seconds) */
   val writeInterval = 3
 
-  private val scheduledExecutor = Executors.newSingleThreadScheduledExecutor()
+  private val scheduledExecutor = Execution.createScheduledThreadPool(getClass.getSimpleName, 1)
 }


### PR DESCRIPTION
- Add execution runtime package to centralize creation of thread pools.
- Use prefixes for naming threads to help debugging (e.g. when reading thread dumps)
- Uncaught exceptions in threads are logged.
- Project exports are now written in a separate thread pool to prevent deadlock.