### PR TITLE
- Fix for issue #251 (fresh Docker built container not running)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,4 +57,4 @@ HEALTHCHECK --interval=5s --timeout=10s --retries=20 \
   CMD curl "http://localhost:${PORT}${SERVER_CONTEXTPATH}"
 
 # start application
-CMD [ "/silk-workbench/bin/silk-workbench", "-Dplay.server.http.port=$PORT", "-Dpidfile.path=/dev/null" ]
+CMD /silk-workbench/bin/silk-workbench -Dplay.server.http.port=${PORT} -Dpidfile.path=/dev/null


### PR DESCRIPTION
docker container built from source does not run properly. It exits with Docker error (255) equivalent to bash -1 error code. The reason is incorrect resolution of the $PORT environment variable.