### PR TITLE
Rule Editor fixes

### DIFF
--- a/silk-rules/src/main/scala/org/silkframework/rule/LinkageRule.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/LinkageRule.scala
@@ -27,6 +27,10 @@ import scala.xml.Node
 case class LinkageRule(operator: Option[SimilarityOperator] = None,
                        filter: LinkFilter = LinkFilter(),
                        linkType: Uri = Uri.fromString("http://www.w3.org/2002/07/owl#sameAs")) {
+
+  // Make sure that all operators use unique identifiers
+  operator.foreach(_.validateIds())
+
   /**
    * Computes the similarity between two entities.
    *

--- a/silk-rules/src/main/scala/org/silkframework/rule/Operator.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/Operator.scala
@@ -17,6 +17,7 @@ package org.silkframework.rule
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.silkframework.runtime.serialization.XmlSerialization
+import org.silkframework.runtime.validation.ValidationException
 import org.silkframework.util.Identifier
 
 import scala.xml.Node
@@ -40,6 +41,19 @@ trait Operator {
     */
   def withChildren(newChildren: Seq[Operator]): Operator
 
+  /**
+    * Asserts that all identifiers in this rule tree are unique.
+    *
+    * @throws ValidationException If duplicate identifiers have been found.
+    */
+  final def validateIds(): Unit = {
+    val allIds = RuleTraverser(this).iterateAllChildren.map(_.operator.id).toList
+    val duplicateIds = allIds.groupBy(_.toString).filter(_._2.size > 1).keys
+    if (duplicateIds.nonEmpty) {
+      throw new ValidationException("Duplicate identifiers found in rule: " + duplicateIds.mkString(", "))
+    }
+  }
+
 }
 
 /**
@@ -53,7 +67,7 @@ object Operator {
   /**
    * Generates a new operator identifier.
    */
-  def generateId = Identifier("unnamed_" + lastId.incrementAndGet())
+  def generateId: Identifier = Identifier("unnamed_" + lastId.incrementAndGet())
 
   /**
    * Reads the operator identifier from an xml element.

--- a/silk-rules/src/main/scala/org/silkframework/rule/TransformRule.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/TransformRule.scala
@@ -116,8 +116,6 @@ sealed trait TransformRule extends Operator {
   def representsDefaultUriRule: Boolean = {
     false
   }
-
-  def ids: List[Identifier] = id :: rules.allRules.toList.flatMap(_.ids)
 }
 
 /**
@@ -143,16 +141,7 @@ case class RootMappingRule(override val rules: MappingRules,
   /** Fails on the first rule it encounters that's invalid */
   override def validate(): Unit = {
     rules.allRules foreach (_.validate())
-    validateIDs
-  }
-
-
-  private def validateIDs: Unit = {
-    val allIds = ids
-    val duplicateIds = allIds.groupBy(_.toString).filter(_._2.size > 1).keys
-    if (duplicateIds.nonEmpty) {
-      throw new ValidationException("Duplicate IDs in nested mapping rule found: " + duplicateIds.mkString(", "))
-    }
+    validateIds()
   }
 
   /**

--- a/silk-rules/src/main/scala/org/silkframework/rule/TransformRule.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/TransformRule.scala
@@ -81,11 +81,17 @@ sealed trait TransformRule extends Operator {
   }
 
   /** Throws ValidationException if this transform rule is not valid. */
-  def validate(): Unit = {
+  protected def validate(): Unit = {
     validateTargetUri()
+    // Validate that the operator tree uses unique identifiers
+    operator.validateIds()
+    // Validate all child transform rules
     rules.foreach(_.validate())
   }
 
+  /**
+    * Validates that the target URI is a valid URI.
+    */
   private def validateTargetUri(): Unit = {
     target foreach { mt =>
       val failure = Try {
@@ -138,11 +144,9 @@ sealed trait ValueTransformRule extends TransformRule
 case class RootMappingRule(override val rules: MappingRules,
                            id: Identifier = RootMappingRule.defaultId,
                            metaData: MetaData = MetaData(RootMappingRule.defaultLabel)) extends ContainerTransformRule {
-  /** Fails on the first rule it encounters that's invalid */
-  override def validate(): Unit = {
-    rules.allRules foreach (_.validate())
-    validateIds()
-  }
+
+  validate()
+  validateIds()
 
   /**
     * The children operators.

--- a/silk-rules/src/test/scala/org/silkframework/rule/TransformRuleTest.scala
+++ b/silk-rules/src/test/scala/org/silkframework/rule/TransformRuleTest.scala
@@ -15,20 +15,18 @@ class TransformRuleTest extends FlatSpec with MustMatchers {
   val duplicated2 = "duplicated2"
 
   it should "validate IDs in nested rules" in {
-    val rootMappingCorrect: RootMappingRule = createRootRule(duplicate1 = false, duplicate2 = false)
-    rootMappingCorrect.validate() // Should validate
+    createRootRule(duplicate1 = false, duplicate2 = false)
     testErrorCases(duplicate1 = true, duplicate2 = true)
     testErrorCases(duplicate1 = false, duplicate2 = true)
     testErrorCases(duplicate1 = true, duplicate2 = false)
   }
 
   private def testErrorCases(duplicate1: Boolean, duplicate2: Boolean): Unit = {
-    val rootMappingDuplicate: RootMappingRule = createRootRule(duplicate1 = duplicate1, duplicate2 = duplicate2)
     intercept[ValidationException]{
-      rootMappingDuplicate.validate()
+      createRootRule(duplicate1 = duplicate1, duplicate2 = duplicate2)
     }
     try {
-      rootMappingDuplicate.validate()
+      createRootRule(duplicate1 = duplicate1, duplicate2 = duplicate2)
     } catch {
       case e: ValidationException =>
         val errorMessage = e.errors.map(_.message).mkString("")
@@ -73,7 +71,6 @@ class TransformRuleTest extends FlatSpec with MustMatchers {
     val objectMapping = ObjectMapping(rules = MappingRules(propertyRules = Seq(
       DirectMapping(mappingTarget = MappingTarget(Uri(targetPropertyUri)))
     )))
-    val rootMappingRule = RootMappingRule(MappingRules(propertyRules = Seq(objectMapping)))
-    rootMappingRule.validate()
+    RootMappingRule(MappingRules(propertyRules = Seq(objectMapping)))
   }
 }

--- a/silk-rules/src/test/scala/org/silkframework/rule/TransformRuleTest.scala
+++ b/silk-rules/src/test/scala/org/silkframework/rule/TransformRuleTest.scala
@@ -1,12 +1,12 @@
 package org.silkframework.rule
 
 import org.scalatest.{FlatSpec, MustMatchers}
-import org.silkframework.rule.input.TransformInput
+import org.silkframework.entity.Path
+import org.silkframework.rule.input.{PathInput, TransformInput}
+import org.silkframework.rule.plugins.transformer.normalize.LowerCaseTransformer
 import org.silkframework.rule.plugins.transformer.value.ConstantUriTransformer
 import org.silkframework.runtime.validation.ValidationException
 import org.silkframework.util.Uri
-
-import scala.util.Try
 
 class TransformRuleTest extends FlatSpec with MustMatchers {
   behavior of "Transform Rule"
@@ -19,6 +19,12 @@ class TransformRuleTest extends FlatSpec with MustMatchers {
     testErrorCases(duplicate1 = true, duplicate2 = true)
     testErrorCases(duplicate1 = false, duplicate2 = true)
     testErrorCases(duplicate1 = true, duplicate2 = false)
+  }
+
+  it should "validate IDs in rule operator trees" in {
+    intercept[ValidationException] {
+      createRuleWithDuplicatedOperatorID()
+    }
   }
 
   private def testErrorCases(duplicate1: Boolean, duplicate2: Boolean): Unit = {
@@ -60,6 +66,19 @@ class TransformRuleTest extends FlatSpec with MustMatchers {
               )
             )
           )
+        )
+      )
+    )
+    rootMapping
+  }
+
+  private def createRuleWithDuplicatedOperatorID() = {
+    val rootMapping = RootMappingRule(
+      MappingRules(
+        uriRule = None,
+        typeRules = Seq.empty,
+        propertyRules = Seq(
+          ComplexMapping("invalidRule", TransformInput("duplicateID", LowerCaseTransformer(), Seq(PathInput("duplicateID", Path.empty))))
         )
       )
     )

--- a/silk-rules/src/test/scala/org/silkframework/rule/execution/ExecuteTransformTest.scala
+++ b/silk-rules/src/test/scala/org/silkframework/rule/execution/ExecuteTransformTest.scala
@@ -22,7 +22,7 @@ class ExecuteTransformTest extends FlatSpec with Matchers with MockitoSugar {
 
   it should "output faulty entities to error output" in {
     val prop = "http://prop"
-    val prop2 = "http:// prop2"
+    val prop2 = "http://prop2"
     val outputMock = mock[EntitySink]
     val entities = Seq(entity(IndexedSeq("valid", "valid"), IndexedSeq(prop, prop2)), entity(IndexedSeq("invalid", "valid"), IndexedSeq(prop, prop2)))
     val dataSourceMock = mock[DataSource]

--- a/silk-workbench/silk-workbench-rules/app/controllers/transform/TransformTaskApi.scala
+++ b/silk-workbench/silk-workbench-rules/app/controllers/transform/TransformTaskApi.scala
@@ -95,7 +95,6 @@ class TransformTaskApi extends Controller {
         deserializeCompileTime[RootMappingRule]() { updatedRules =>
           //Update transformation task
           val updatedTask = task.data.copy(mappingRule = updatedRules)
-          updatedTask.mappingRule.validate()
           project.updateTask(taskName, updatedTask)
           Ok
         }
@@ -245,7 +244,6 @@ class TransformTaskApi extends Controller {
                          userContext: UserContext): Unit = {
     val updatedRoot = ruleTraverser.root.operator.asInstanceOf[RootMappingRule]
     val updatedTask = task.data.copy(mappingRule = updatedRoot)
-    updatedRoot.validate()
     task.project.updateTask(task.id, updatedTask)
   }
 

--- a/silk-workbench/silk-workbench-rules/public/stylesheets/editor/editor.css
+++ b/silk-workbench/silk-workbench-rules/public/stylesheets/editor/editor.css
@@ -405,6 +405,14 @@ label:hover {
     border-radius:5px;
 }
 
+label.edit_label {
+  display: inline-block;
+  width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+}
+
 input.edit_label {
   display: none;
   border-width: 0px;

--- a/silk-workbench/silk-workbench-rules/test/controllers/transform/AutoCompletionApiTest.scala
+++ b/silk-workbench/silk-workbench-rules/test/controllers/transform/AutoCompletionApiTest.scala
@@ -92,7 +92,7 @@ class AutoCompletionApiTest extends TransformTaskApiTestBase {
             uriRule = None,
             typeRules = Seq(TypeMapping(typeUri = uri("Person"))),
             propertyRules = Seq(
-              DirectMapping(sourcePath = Path(uri("name")), mappingTarget = MappingTarget(uri("name"))),
+              DirectMapping("name", sourcePath = Path(uri("name")), mappingTarget = MappingTarget(uri("name"))),
               ObjectMapping(
                 id = "addressMapping",
                 sourcePath = Path(uri("address")),
@@ -101,8 +101,8 @@ class AutoCompletionApiTest extends TransformTaskApiTestBase {
                   uriRule = None,
                   typeRules = Seq.empty,
                   propertyRules = Seq(
-                    DirectMapping(sourcePath = Path(uri("city")), mappingTarget = MappingTarget(uri("city"))),
-                    DirectMapping(sourcePath = Path(uri("country")), mappingTarget = MappingTarget(uri("country")))
+                    DirectMapping("city", sourcePath = Path(uri("city")), mappingTarget = MappingTarget(uri("city"))),
+                    DirectMapping("country", sourcePath = Path(uri("country")), mappingTarget = MappingTarget(uri("country")))
                   )
                 )
               )


### PR DESCRIPTION
Fixes two bugs:
-  The rule editors did not validate if operator identifiers are unique. Validate by giving two operators the same identifier.
- Long identifiers are now shortened in the UI. Validate by setting a very long identifier.
