### PR TITLE
Set batch size for SPARQL Update operator from 10 to 1, do not clear …

### DIFF
--- a/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/datasets/SparqlDataset.scala
+++ b/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/datasets/SparqlDataset.scala
@@ -39,7 +39,7 @@ case class SparqlDataset(
   useOrderBy: Boolean = true,
   @Param(label = "Clear graph before workflow execution",
     value = "If set to true this will clear the specified graph before executing a workflow that writes to it.")
-  clearGraphBeforeExecution: Boolean = true) extends RdfDataset with TripleSinkDataset {
+  clearGraphBeforeExecution: Boolean = false) extends RdfDataset with TripleSinkDataset {
 
   private val params =
     SparqlParams(

--- a/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/tasks/SparqlUpdateCustomTask.scala
+++ b/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/tasks/SparqlUpdateCustomTask.scala
@@ -194,5 +194,5 @@ And it will insert a plain literal serialization for the property values PROP_FR
 It is be possible to write something like ${"PROP"}^^<http://someDatatype> or ${"PROP"}@en.
     """
 
-  final val defaultBatchSize = 10
+  final val defaultBatchSize = 1
 }

--- a/silk-plugins/silk-plugins-rdf/src/test/scala/org/silkframework/plugins/dataset/rdf/SparqlUpdateCustomTaskTest.scala
+++ b/silk-plugins/silk-plugins-rdf/src/test/scala/org/silkframework/plugins/dataset/rdf/SparqlUpdateCustomTaskTest.scala
@@ -74,7 +74,7 @@ class SparqlUpdateCustomTaskTest extends FlatSpec with MustMatchers {
         |  INSERT DATA { <urn:some:uri> rdf:label "The new\nlabel with some \"'weird characters" } ;""".stripMargin
   }
 
-  def parse(sparqlUpdateTemplate: String, batchSize: Int = SparqlUpdateCustomTask.defaultBatchSize): Seq[SparqlUpdateTemplatePart] = {
+  def parse(sparqlUpdateTemplate: String, batchSize: Int = 2): Seq[SparqlUpdateTemplatePart] = {
     SparqlUpdateCustomTask(sparqlUpdateTemplate, batchSize).sparqlUpdateTemplateParts
   }
 }


### PR DESCRIPTION
…graphs from SPARQL endpoints before task execution by default