### PR TITLE
While workspace is initializing with the first request let subsequent…

### DIFF
--- a/silk-core/src/main/resources/reference.conf
+++ b/silk-core/src/main/resources/reference.conf
@@ -68,3 +68,10 @@ optimizations.linking.execution.pushFilters.removeDisjunctionsWithInEqualities =
 # For some reasons different implementations are (sometimes) used on the CI server in the tests
 javax.xml.parsers.DocumentBuilderFactory=com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl
 javax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl
+
+
+###############################################
+### Workspace
+###############################################
+# The time in milliseconds that a DI client will wait for the workspace to be initialized. This does not apply for the client that triggered the init.
+workspace.timeouts.waitForWorkspaceInitialization = 5000 // 5 seconds

--- a/silk-core/src/main/scala/org/silkframework/runtime/validation/ServiceUnavailableException.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/validation/ServiceUnavailableException.scala
@@ -1,0 +1,12 @@
+package org.silkframework.runtime.validation
+
+/**
+  * Exception class to signal that a service is not ready, yet, or has other temporary issues and needs to be initialized first.
+  */
+case class ServiceUnavailableException(message: String) extends RequestException(message, None) {
+  final val serviceUnavailableStatusCode = 503
+
+  override def errorTitle: String = "Service Temporarily Unavailable"
+
+  override def httpErrorCode: Option[Int] = Some(serviceUnavailableStatusCode)
+}

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceTest.scala
@@ -1,0 +1,49 @@
+package org.silkframework.workspace
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import org.scalatest.FlatSpec
+import org.scalatestplus.mockito.MockitoSugar
+import org.mockito.Mockito._
+import org.silkframework.runtime.activity.TestUserContextTrait
+import org.silkframework.runtime.validation.ServiceUnavailableException
+import org.silkframework.util.ConfigTestTrait
+import org.silkframework.workspace.resources.InMemoryResourceRepository
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class WorkspaceTest extends FlatSpec with ConfigTestTrait with MockitoSugar with TestUserContextTrait {
+  behavior of "Workspace"
+
+  it should "throw a 503 if it is loading and reaching its timeout" in {
+    val slowSeq = new Seq[ProjectConfig] {
+      override def length: Int = 0
+      override def apply(idx: Int): ProjectConfig = ProjectConfig()
+      override def iterator: Iterator[ProjectConfig] = {
+        Thread.sleep(5000)
+        Iterator.empty
+      }
+    }
+    val providerMock = mock[WorkspaceProvider]
+    when(providerMock.readProjects()).thenReturn(slowSeq)
+    val inMemoryResourceRepository = InMemoryResourceRepository()
+    val workspace = new Workspace(providerMock, inMemoryResourceRepository)
+    val started = new AtomicBoolean(false)
+    Future {
+      started.set(true)
+      workspace.projects.headOption
+    }
+    while(!started.get()) {
+      Thread.sleep(1)
+    }
+    Thread.sleep(1)
+    intercept[ServiceUnavailableException] {
+      workspace.projects.headOption
+    }
+  }
+
+  override def propertyMap: Map[String, Option[String]] = Map(
+    "workspace.timeouts.waitForWorkspaceInitialization" -> Some("1")
+  )
+}


### PR DESCRIPTION
… requests timeout (default 5s)

Timeout can be configured via parameter: workspace.timeouts.waitForWorkspaceInitialization (in milliseconds, default: 5000ms)