### PR TITLE
Maintain thread pool parallelism if many activities are blocking

### DIFF
--- a/silk-core/src/main/scala/org/silkframework/runtime/activity/ActivityMonitor.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/activity/ActivityMonitor.scala
@@ -1,5 +1,5 @@
 package org.silkframework.runtime.activity
-import java.util.concurrent.ForkJoinPool
+import java.util.concurrent.{ForkJoinPool, ForkJoinTask}
 import java.util.concurrent.ForkJoinPool.ManagedBlocker
 import java.util.logging.Logger
 
@@ -70,6 +70,7 @@ class ActivityMonitor[T](name: String,
   def blockUntil(condition: () => Boolean): Unit = {
     val sleepTime = 500
     while(!condition()) {
+      ForkJoinTask.helpQuiesce()
       ForkJoinPool.managedBlock(
         new ManagedBlocker {
           @volatile

--- a/silk-core/src/test/scala/org/silkframework/runtime/activity/ActivityExecutionTest.scala
+++ b/silk-core/src/test/scala/org/silkframework/runtime/activity/ActivityExecutionTest.scala
@@ -41,17 +41,17 @@ class ActivityExecutionTest extends FlatSpec with MustMatchers {
   }
 
   it should "maintain parallelism if activities are blocking" in {
-    val parallism = Activity.forkJoinPool.getParallelism
+    val parallelism = Activity.forkJoinPool.getParallelism
 
     val blockingActivities =
-      for(i <- 0 until parallism) yield {
+      for(_ <- 0 until parallelism) yield {
         val running = new AtomicBoolean(false)
         Activity(new BlockingActivity(running)).start()
         running
       }
 
     val sleepingActivities =
-      for(i <- 0 until (parallism - 1)) yield {
+      for(_ <- 0 until (parallelism - 1)) yield {
         val running = new AtomicBoolean(false)
         Activity(new SleepingActivity(running)).start()
         running

--- a/silk-core/src/test/scala/org/silkframework/runtime/activity/ActivityExecutionTest.scala
+++ b/silk-core/src/test/scala/org/silkframework/runtime/activity/ActivityExecutionTest.scala
@@ -39,6 +39,29 @@ class ActivityExecutionTest extends FlatSpec with MustMatchers {
     result.metaData.startedByUser mustBe Some(testUser)
     result.metaData.cancelledBy mustBe Some(testUser)
   }
+
+  it should "maintain parallelism if activities are blocking" in {
+    val parallism = Activity.forkJoinPool.getParallelism
+
+    val blockingActivities =
+      for(i <- 0 until parallism) yield {
+        val running = new AtomicBoolean(false)
+        Activity(new BlockingActivity(running)).start()
+        running
+      }
+
+    val sleepingActivities =
+      for(i <- 0 until (parallism - 1)) yield {
+        val running = new AtomicBoolean(false)
+        Activity(new SleepingActivity(running)).start()
+        running
+      }
+
+    Thread.sleep(1000)
+
+    blockingActivities.forall(_.get()) mustBe true
+    sleepingActivities.forall(_.get()) mustBe true
+  }
 }
 
 class SleepingActivity(running: AtomicBoolean) extends Activity[Unit] {
@@ -46,5 +69,12 @@ class SleepingActivity(running: AtomicBoolean) extends Activity[Unit] {
     running.set(true)
     val LONG_TIME = 100000
     Thread.sleep(LONG_TIME)
+  }
+}
+
+class BlockingActivity(running: AtomicBoolean) extends Activity[Unit] {
+  override def run(context: ActivityContext[Unit])(implicit userContext: UserContext): Unit = {
+    running.set(true)
+    context.blockUntil(() => false)
   }
 }


### PR DESCRIPTION
Maintain thread pool parallelism if many activities are blocking