### PR TITLE
Feature/late cache loading

### DIFF
--- a/silk-workspace/src/main/scala/org/silkframework/workspace/Module.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/Module.scala
@@ -79,7 +79,7 @@ class Module[TaskData <: TaskSpec: ClassTag](private[workspace] val provider: Wo
          (implicit userContext: UserContext): Unit = {
     val task = new ProjectTask(name, taskData, metaData, this)
     provider.putTask(project.name, task)
-    task.init()
+    task.startActivities()
     cachedTasks += ((name, task))
     logger.info(s"Added task '$name' to project ${project.name}. " + userContext.logInfo)
   }
@@ -102,7 +102,12 @@ class Module[TaskData <: TaskSpec: ClassTag](private[workspace] val provider: Wo
     logger.info(s"Removed task '$taskId' from project ${project.name}." + userContext.logInfo)
   }
 
-  private def load()
+  /**
+    * Loads the tasks in this module.
+    * Will be triggered automatically the first time a task is requested.
+    * Can be triggered manually to control when the tasks are loaded.
+    */
+  def load()
                   (implicit userContext: UserContext): Unit = synchronized {
     if(cachedTasks == null) {
       try {

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/Project.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/Project.scala
@@ -59,10 +59,14 @@ class Project(initialConfig: ProjectConfig = ProjectConfig(), provider: Workspac
   registerModule[Workflow]()
   registerModule[CustomTask]()
 
+  /** Can be called optionally to trigger early loading of tasks. */
+  def loadTasks()(implicit userContext: UserContext): Unit = {
+    modules.foreach(_.load())
+  }
+
   /** This must be executed once when the project was loaded into the workspace */
-  def initTasks()(implicit userContext: UserContext) {
-    // Initialize Tasks
-    allTasks.foreach(_.init())
+  def startActivities()(implicit userContext: UserContext) {
+    allTasks.foreach(_.startActivities())
   }
 
   /**

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/ProjectTask.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/ProjectTask.scala
@@ -88,8 +88,10 @@ class ProjectTask[TaskType <: TaskSpec : ClassTag](val id: Identifier,
     */
   override def metaData: MetaData = metaDataValueHolder()
 
-  def init()(implicit userContext: UserContext): Unit = {
-    // Start auto-run activities
+  /**
+    * Starts all autorun activities.
+    */
+  def startActivities()(implicit userContext: UserContext): Unit = {
     for (activity <- taskActivities if activity.autoRun && activity.status() == Status.Idle())
       activity.control.start()
   }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
@@ -188,7 +188,8 @@ class Workspace(val provider: WorkspaceProvider, val repository: ResourceReposit
     provider.readProject(id) match {
       case Some(projectConfig) =>
         val project = new Project(projectConfig, provider, repository.get(projectConfig.id))
-        project.initTasks()
+        project.loadTasks()
+        project.startActivities()
         cachedProjects :+= project
       case None =>
         log.warning(s"Project '$id' could not be reloaded in workspace, because it could not be read from the workspace provider!")
@@ -208,9 +209,13 @@ class Workspace(val provider: WorkspaceProvider, val repository: ResourceReposit
   private def loadProjects()(implicit userContext: UserContext): Unit = {
     cachedProjects = for(projectConfig <- provider.readProjects()) yield {
       log.info("Loading project: " + projectConfig.id)
-      val project = new Project(projectConfig, provider, repository.get(projectConfig.id))
-      project.initTasks()
-      project
+      new Project(projectConfig, provider, repository.get(projectConfig.id))
+    }
+    for(project <- cachedProjects) {
+      project.loadTasks()
+    }
+    for(project <- cachedProjects) {
+      project.startActivities()
     }
     reloadPrefixes()
   }

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceTest.scala
@@ -2,18 +2,29 @@ package org.silkframework.workspace
 
 import java.util.concurrent.atomic.AtomicBoolean
 
-import org.scalatest.FlatSpec
+import org.scalatest.{FlatSpec, MustMatchers}
 import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito._
-import org.silkframework.runtime.activity.TestUserContextTrait
+import org.silkframework.config.{CustomTask, PlainTask, Task, TaskSpec}
+import org.silkframework.dataset.rdf.SparqlEndpoint
+import org.silkframework.entity.EntitySchema
+import org.silkframework.runtime.activity.{Activity, ActivityContext, TestUserContextTrait, UserContext}
+import org.silkframework.runtime.plugin.PluginRegistry
+import org.silkframework.runtime.resource.ResourceManager
 import org.silkframework.runtime.validation.ServiceUnavailableException
-import org.silkframework.util.ConfigTestTrait
+import org.silkframework.util.{ConfigTestTrait, Identifier}
+import org.silkframework.workspace.WorkspaceTest.{TestActivity, TestActivityFactory, TestTask, TestWorkspaceProvider}
+import org.silkframework.workspace.activity.TaskActivityFactory
 import org.silkframework.workspace.resources.InMemoryResourceRepository
 
+import scala.collection.immutable.ListMap
+import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.reflect.ClassTag
+import scala.util.Try
 
-class WorkspaceTest extends FlatSpec with ConfigTestTrait with MockitoSugar with TestUserContextTrait {
+class WorkspaceTest extends FlatSpec with MustMatchers with ConfigTestTrait with MockitoSugar with TestUserContextTrait {
   behavior of "Workspace"
 
   it should "throw a 503 if it is loading and reaching its timeout" in {
@@ -43,7 +54,97 @@ class WorkspaceTest extends FlatSpec with ConfigTestTrait with MockitoSugar with
     }
   }
 
+  it should "load caches after all projects have been loaded" in {
+    val workspaceProvider = new TestWorkspaceProvider()
+    PluginRegistry.registerPlugin(classOf[TestActivityFactory])
+
+    val project1 = Identifier("project1")
+    val task1 = Identifier("task1")
+    workspaceProvider.putProject(ProjectConfig(project1))
+    workspaceProvider.putTask(project1, PlainTask(task1,  TestTask()))
+
+    val project2 = Identifier("project2")
+    val task2 = Identifier("task2")
+    workspaceProvider.putProject(ProjectConfig(project2))
+    workspaceProvider.putTask(project2, PlainTask(task2,  TestTask()))
+
+    val workspace = new Workspace(workspaceProvider, InMemoryResourceRepository())
+
+    // Make sure that all projects and tasks have been loaded
+    workspace.projects.map(_.config.id) mustBe Seq(project1, project2)
+    workspace.project(project1).allTasks.map(_.id) mustBe Seq(task1)
+    workspace.project(project2).allTasks.map(_.id) mustBe Seq(task2)
+
+    // Make sure that all projects and tasks have been loaded before starting any activity
+    val projectLoadTimes = workspaceProvider.taskReadTimes.values
+    val activityStartTimes = {
+      for {project <- workspace.projects
+           task <- project.tasks[TestTask]} yield {
+        task.activity[TestActivity].control.startTime.getOrElse {
+          fail("Autorun activity has not been started.")
+        }
+      }
+    }
+
+    projectLoadTimes.size mustBe 2
+    activityStartTimes.size mustBe 2
+    projectLoadTimes.max must be < activityStartTimes.min
+  }
+
   override def propertyMap: Map[String, Option[String]] = Map(
     "workspace.timeouts.waitForWorkspaceInitialization" -> Some("1")
   )
+}
+
+object WorkspaceTest {
+
+  // Workspace provider that keeps track on when projects and tasks have been loaded.
+  class TestWorkspaceProvider extends InMemoryWorkspaceProvider {
+
+    // The timestamp when projects have been loaded the last time
+    var projectTime: Long = 0
+
+    // The timestamps when the tasks for each project have been loaded
+    var taskReadTimes: ListMap[String, Long] = ListMap.empty
+
+    override def readProjects()(implicit user: UserContext): Seq[ProjectConfig] = {
+      projectTime = System.currentTimeMillis()
+      super.readProjects()
+    }
+
+    override def readTasks[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)
+                                                    (implicit user: UserContext): Seq[Task[T]] = {
+      taskReadTimes += ((project, System.currentTimeMillis()))
+      Thread.sleep(1000)
+      super.readTasks(project, projectResources)
+    }
+    override def readTasksSafe[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)
+                                                        (implicit user: UserContext): Seq[Try[Task[T]]] = {
+      taskReadTimes += ((project, System.currentTimeMillis()))
+      Thread.sleep(1000)
+      super.readTasksSafe(project, projectResources)
+    }
+  }
+
+  case class TestTask(testParam: String = "test value") extends CustomTask {
+    override def inputSchemataOpt: Option[Seq[EntitySchema]] = None
+    override def outputSchemaOpt: Option[EntitySchema] = None
+  }
+
+  case class TestActivityFactory() extends TaskActivityFactory[TestTask, TestActivity] {
+
+    override def autoRun: Boolean = true
+
+    def apply(task: ProjectTask[TestTask]): Activity[Unit] = {
+      new TestActivity
+    }
+  }
+
+  class TestActivity extends Activity[Unit] {
+    override def run(context: ActivityContext[Unit])
+                    (implicit userContext: UserContext): Unit = {
+      // Does nothing
+    }
+  }
+
 }


### PR DESCRIPTION
All projects are loaded first, before any cache or any other autorun activity is started. This improves loading when both the workspace provider and some caches load from the same database.
