### PR TITLE
Fix/dont swallow exceptions

### DIFF
--- a/silk-core/src/main/scala/org/silkframework/dataset/CloseableDataset.scala
+++ b/silk-core/src/main/scala/org/silkframework/dataset/CloseableDataset.scala
@@ -1,10 +1,52 @@
 package org.silkframework.dataset
 
 import org.silkframework.runtime.activity.UserContext
+import scala.util.control.NonFatal
 
 /**
   * Similar to Java's Closeable, but with user context.
   */
 trait CloseableDataset {
   def close()(implicit userContext: UserContext): Unit
+}
+
+object CloseableDataset {
+
+  /**
+    * Automatically closes a CloseableDataset instance.
+    *
+    * Example:
+    * {{{
+    * using(createDataset) { dataset =>
+    *   dataset.writeData(...)
+    * }
+    * }}}
+    *
+    */
+  def using[DatasetType <: CloseableDataset, ReturnType](create: => DatasetType)
+                                                        (f: DatasetType => ReturnType)
+                                                        (implicit userContext: UserContext): ReturnType = {
+    val dataset: DatasetType = create
+    var exception: Throwable = null
+    try {
+      f(dataset)
+    } catch {
+      case NonFatal(e) =>
+        exception = e
+        throw e
+    } finally {
+      if (exception != null) {
+        // We need to make sure that if close() is going to throw an exception,
+        // it's neither overwriting the original exception nor getting swallowed.
+        try {
+          dataset.close()
+        } catch {
+          case NonFatal(closeException) =>
+            exception.addSuppressed(closeException)
+        }
+      } else {
+        dataset.close()
+      }
+    }
+  }
 }

--- a/silk-core/src/test/scala/org/silkframework/dataset/CloseableDatasetTest.scala
+++ b/silk-core/src/test/scala/org/silkframework/dataset/CloseableDatasetTest.scala
@@ -1,0 +1,36 @@
+package org.silkframework.dataset
+
+import org.scalatest.{FlatSpec, Matchers, MustMatchers}
+import org.silkframework.runtime.activity.UserContext
+import CloseableDataset.using
+
+class CloseableDatasetTest extends FlatSpec with MustMatchers {
+
+  behavior of "CloseableDataset"
+
+  it must "autoclose dataset and don't swallow exceptions" in {
+    implicit val userContext = UserContext.Empty
+    val thrown = the[TestException] thrownBy {
+      using(new TestDataset) { dataset =>
+        dataset.doSomething()
+      }
+    }
+    thrown.getSuppressed mustBe Array(CloseException)
+  }
+
+  case class TestDataset() extends CloseableDataset {
+
+    def doSomething(): Unit = {
+      throw new TestException
+    }
+
+    override def close()(implicit userContext: UserContext): Unit = {
+      throw CloseException
+    }
+  }
+
+  class TestException extends Exception
+
+  object CloseException extends Exception
+
+}


### PR DESCRIPTION
If a dataset throws an exception during execution and gets closed. Exceptions thrown during closing don't overwrite the original exception.