### PR TITLE
Fix/mapping editor rule routing

### DIFF
--- a/silk-react-components/src/HierarchicalMapping/HierarchicalMapping.jsx
+++ b/silk-react-components/src/HierarchicalMapping/HierarchicalMapping.jsx
@@ -67,6 +67,21 @@ class HierarchicalMapping extends React.Component {
         EventEmitter.off(MESSAGES.RULE_VIEW.CLOSE, this.onCloseEdit);
     }
 
+    static updateMappingEditorUrl = (currentUrl, newRule) => {
+        const segments = currentUrl.segment();
+        const transformIdx = segments.findIndex((segment) => segment === "transform");
+        const editorIdx = transformIdx + 3;
+        console.assert(segments[editorIdx] === "editor", "Wrong URL structure, 'editor not at correct position!'");
+        for(let i = editorIdx + 1; i < segments.length; i++) {
+            // Remove everything after "editor"
+            currentUrl.segment(editorIdx + 1, "");
+        }
+        // add new rule suffix
+        currentUrl.segment("rule");
+        currentUrl.segment(newRule);
+        return currentUrl.toString();
+    };
+
     componentDidUpdate(prevProps, prevState) {
         if (
             prevState.currentRuleId !== this.state.currentRuleId &&
@@ -75,13 +90,8 @@ class HierarchicalMapping extends React.Component {
             const href = window.location.href;
             try {
                 const uriTemplate = new URI(href);
-
-                if (uriTemplate.segment(-2) !== 'rule') {
-                    uriTemplate.segment('rule');
-                }
-
-                uriTemplate.segment(-1, this.state.currentRuleId);
-                history.pushState(null, '', uriTemplate.toString());
+                const updatedUrl = HierarchicalMapping.updateMappingEditorUrl(uriTemplate, this.state.currentRuleId);
+                history.pushState(null, '', updatedUrl);
             } catch (e) {
                 console.debug(`HierarchicalMapping: ${href} is not an URI, cannot update the window state`);
             }

--- a/silk-react-components/src/HierarchicalMapping/containers/MappingRule/MappingRule.jsx
+++ b/silk-react-components/src/HierarchicalMapping/containers/MappingRule/MappingRule.jsx
@@ -166,6 +166,7 @@ export class MappingRule extends React.Component {
                     handleCopy={this.props.handleCopy}
                     handleClone={this.props.handleClone}
                     onClickedRemove={this.props.onClickedRemove}
+                    type={type}
                 />
             ) : (
                 <ValueMappingRule

--- a/silk-react-components/src/HierarchicalMapping/containers/MappingsTree.jsx
+++ b/silk-react-components/src/HierarchicalMapping/containers/MappingsTree.jsx
@@ -100,7 +100,6 @@ class MappingsTree extends React.Component {
         // also expand all parent nodes
         const parentRuleIds = MappingsTree.extractParentIds(tree, this.props.currentRuleId);
         _.forEach(parentRuleIds, ruleId => { expanded[ruleId] = true});
-        console.log(expanded);
         return expanded;
     }
 

--- a/silk-react-components/src/HierarchicalMapping/containers/MappingsTree.jsx
+++ b/silk-react-components/src/HierarchicalMapping/containers/MappingsTree.jsx
@@ -53,7 +53,6 @@ class MappingsTree extends React.Component {
         getHierarchyAsync()
             .subscribe(
                 ({ hierarchy }) => {
-                    const topLevelId = hierarchy.id;
                     this.setState({
                         navigationLoading: false,
                         data: hierarchy,
@@ -96,7 +95,11 @@ class MappingsTree extends React.Component {
         const expanded = {
             ...currentExpanded,
         };
-        expanded[this.props.currentRuleId] = true;
+        if(this.props.currentRuleId) {
+            expanded[this.props.currentRuleId] = true;
+        } else {
+            expanded[tree.id] = true; // Expand root rule
+        }
         // also expand all parent nodes
         const parentRuleIds = MappingsTree.extractParentIds(tree, this.props.currentRuleId);
         _.forEach(parentRuleIds, ruleId => { expanded[ruleId] = true});

--- a/silk-react-components/src/HierarchicalMapping/containers/RootMappingRule.jsx
+++ b/silk-react-components/src/HierarchicalMapping/containers/RootMappingRule.jsx
@@ -14,7 +14,7 @@ import { ThingIcon } from '../components/ThingIcon';
 import RuleTitle from '../elements/RuleTitle';
 import RuleTypes from '../elements/RuleTypes';
 import ObjectRule from './MappingRule/ObjectRule/ObjectRule';
-import { MAPPING_RULE_TYPE_COMPLEX_URI, MESSAGES, MAPPING_RULE_TYPE_URI } from '../utils/constants';
+import { MAPPING_RULE_TYPE_COMPLEX_URI, MESSAGES, MAPPING_RULE_TYPE_URI, MAPPING_RULE_TYPE_ROOT } from '../utils/constants';
 import EventEmitter from '../utils/EventEmitter';
 import ExpandButton from '../elements/buttons/ExpandButton';
 
@@ -170,6 +170,7 @@ class RootMappingRule extends React.Component {
                         handleCopy={this.props.handleCopy}
                         handleClone={this.props.handleClone}
                         onClickedRemove={this.props.onClickedRemove}
+                        type={this.props.rule.type}
                     />}
                 </Card>
             </div>

--- a/silk-react-components/test/HierarchicalMapping/HierarchicalMapping.test.jsx
+++ b/silk-react-components/test/HierarchicalMapping/HierarchicalMapping.test.jsx
@@ -1,0 +1,30 @@
+import HierarchicalMapping from '../../src/HierarchicalMapping/HierarchicalMapping';
+import {URI} from "ecc-utils";
+
+
+
+describe("Hierarchical Mapping Component", () => {
+    describe("Rule routing",() => {
+        it("should route correctly", () => {
+            const updatedUrl = (currentUrl, newRuleId) => {
+                return HierarchicalMapping.updateMappingEditorUrl(new URI(currentUrl), newRuleId);
+            };
+            expect(updatedUrl("/transform/project1/transform2/editor/", "test"))
+                .toEqual('/transform/project1/transform2/editor/rule/test');
+            expect(updatedUrl("/transform/project1/transform2/editor", "test"))
+                .toEqual('/transform/project1/transform2/editor/rule/test');
+            expect(updatedUrl("/transform/project1/transform2/editor/rule/old", "test"))
+                .toEqual('/transform/project1/transform2/editor/rule/test');
+            expect(updatedUrl("/transform/project1/transform2/editor/rule/editor", "test"))
+                .toEqual('/transform/project1/transform2/editor/rule/test');
+            expect(updatedUrl("/transform/project1/transform2/editor/rule/editor/", "test"))
+                .toEqual('/transform/project1/transform2/editor/rule/test');
+            expect(updatedUrl("/transform/project1/transform2/editor/x/y/z", "test"))
+                .toEqual('/transform/project1/transform2/editor/rule/test');
+            expect(updatedUrl("/transform/project1/transform2/editor/illegal", "test"))
+                .toEqual('/transform/project1/transform2/editor/rule/test');
+            expect(updatedUrl("/transform/project1/transform2/editor/rule/transform", "test"))
+                .toEqual('/transform/project1/transform2/editor/rule/test');
+        });
+    });
+});

--- a/silk-react-components/test/HierarchicalMapping/containers/MappingsTree.test.jsx
+++ b/silk-react-components/test/HierarchicalMapping/containers/MappingsTree.test.jsx
@@ -1,0 +1,20 @@
+import MappingsTree from '../../../src/HierarchicalMapping/containers/MappingsTree';
+
+describe("Mappings Tree Component", () => {
+    it("should calculate expanded parent nodes based on current rule", () => {
+        const objectMapping = (id, propertyMappings = [], type = "object") => {
+            return {
+                id: id,
+                rules: {
+                    propertyRules: propertyMappings
+                },
+                type: type
+            };
+        };
+        const currentId = "current";
+        const objectMapping1 = objectMapping("object1", [objectMapping("object1b", [objectMapping(currentId)])]);
+        const objectMapping2 = objectMapping("object2", [objectMapping("object2b", [objectMapping("notCurrent")])]);
+        const tree = objectMapping("root", [objectMapping1, objectMapping2], "root");
+        expect(MappingsTree.extractParentIds(tree, currentId)).toEqual(["root", "object1", "object1b"])
+    });
+});


### PR DESCRIPTION
Fixes:
  - Rule routing generates invalid URLs
  - Navigation tree does not expand parent rules on page reload
  - Root rule displays 'Remove' button and target property widget, but should not