### PR TITLE
Consistent resource deletion behaviour for resource repositories

### DIFF
--- a/silk-core/src/main/scala/org/silkframework/runtime/resource/InMemoryResourceManager.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/resource/InMemoryResourceManager.scala
@@ -58,6 +58,13 @@ class InMemoryResourceManagerBase(val basePath: String = "", parentMgr: Option[I
   override def parent: Option[ResourceManager] = parentMgr
 
   override def delete(name: String): Unit = {
+    val childToDelete = child(name)
+    for(childFolders <- childToDelete.listChildren) {
+      childToDelete.delete(childFolders)
+    }
+    for(childResources <- childToDelete.list) {
+      childToDelete.get(childResources).delete()
+    }
     resources -= name
     children -= name
   }

--- a/silk-core/src/main/scala/org/silkframework/runtime/resource/ResourceWriter.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/resource/ResourceWriter.scala
@@ -16,9 +16,9 @@ trait ResourceWriter {
   def get(name: String, mustExist: Boolean = false): WritableResource
 
   /**
-    * Deletes a resource by name.
+    * Deletes a resource or child resource manager by name.
     *
-    * @param name The name of the resource.
+    * @param name The name of the resource or child resource manager.
     */
   def delete(name: String)
 }

--- a/silk-tools/silk-singlemachine/src/main/scala/org/silkframework/Silk.scala
+++ b/silk-tools/silk-singlemachine/src/main/scala/org/silkframework/Silk.scala
@@ -29,7 +29,7 @@ import org.silkframework.runtime.serialization.{ReadContext, XmlSerialization}
 import org.silkframework.util.StringUtils._
 import org.silkframework.util.{CollectLogs, Identifier}
 import org.silkframework.workspace.activity.workflow.{LocalWorkflowExecutor, Workflow}
-import org.silkframework.workspace.resources.FileRepository
+import org.silkframework.workspace.resources.SharedFileRepository
 import org.silkframework.workspace.{InMemoryWorkspaceProvider, Project, ProjectMarshallerRegistry, Workspace}
 
 import scala.math.max
@@ -199,7 +199,7 @@ object Silk {
     // Create workspace provider
     val projectId = Identifier("project")
     val workspaceProvider = new InMemoryWorkspaceProvider()
-    val resourceRepository = FileRepository(".")
+    val resourceRepository = SharedFileRepository(".")
 
     // Import project
     val marshaller = ProjectMarshallerRegistry.marshallerForFile(projectFile.getName)

--- a/silk-workbench/silk-workbench-workspace/app/controllers/workspace/WorkspaceController.scala
+++ b/silk-workbench/silk-workbench-workspace/app/controllers/workspace/WorkspaceController.scala
@@ -32,8 +32,8 @@ class WorkspaceController @Inject() () extends InjectedController{
     Ok(views.html.workspace.importProjectDialog())
   }
 
-  def removeProjectDialog(project: String): Action[AnyContent] = Action {
-    Ok(views.html.workspace.removeProjectDialog(project))
+  def removeProjectDialog(project: String): Action[AnyContent] = UserContextAction { implicit userContext =>
+    Ok(views.html.workspace.removeProjectDialog(project, WorkspaceFactory().workspace.repository.sharedResources))
   }
 
   def removeTaskDialog(projectName: String, taskName: String): Action[AnyContent] = UserContextAction { implicit userContext =>

--- a/silk-workbench/silk-workbench-workspace/app/views/workspace/removeProjectDialog.scala.html
+++ b/silk-workbench/silk-workbench-workspace/app/views/workspace/removeProjectDialog.scala.html
@@ -1,10 +1,14 @@
-@(project: String)
+@(project: String, sharedResources: Boolean)
 
 @widgets.dialog(title = "Delete Project", submitLabel = "Yes, delete it") {
 
-<p>
-  Delete project: <span class="delete-dialog-resource">@project</span>
-</p>
+  <p>
+    @if(sharedResources) {
+      Delete project <span class="delete-dialog-resource">@project</span>? Note that resources will not be deleted because they are shared across projects.
+    } else {
+      Delete project <span class="delete-dialog-resource">@project</span> including all resources?
+    }
+  </p>
 
   <script type="text/javascript">//<![CDATA[
 

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
@@ -113,6 +113,7 @@ class Workspace(val provider: WorkspaceProvider, val repository: ResourceReposit
       activity.control.cancel()
     }
     provider.deleteProject(name)
+    repository.removeProjectResources(name)
     cachedProjects = cachedProjects.filterNot(_.name == name)
     log.info(s"Removed project '$name'. " + userContext.logInfo)
   }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/resources/EmptyResourceRepository.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/resources/EmptyResourceRepository.scala
@@ -11,5 +11,9 @@ import org.silkframework.util.Identifier
 )
 case class EmptyResourceRepository() extends ResourceRepository {
 
+  override def sharedResources: Boolean = false
+
   override def get(project: Identifier): ResourceManager = EmptyResourceManager()
+
+  override def removeProjectResources(project: Identifier): Unit = {}
 }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/resources/FileRepository.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/resources/FileRepository.scala
@@ -11,9 +11,7 @@ import org.silkframework.util.Identifier
   label = "File resources",
   description = "Holds all resources in a specified folder."
 )
-case class FileRepository(dir: String) extends ResourceRepository {
+case class FileRepository(dir: String) extends ResourceRepository with SharedResourceRespository {
 
   val resourceManager = UrlResourceManager(FileResourceManager(new File(dir)))
-
-  override def get(project: Identifier): ResourceManager = resourceManager
 }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/resources/InMemoryResourceRepository.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/resources/InMemoryResourceRepository.scala
@@ -9,9 +9,7 @@ import org.silkframework.util.Identifier
   label = "In-memory resources",
   description = "Holds all resource in-memory."
 )
-case class InMemoryResourceRepository() extends ResourceRepository {
+case class InMemoryResourceRepository() extends ResourceRepository with PerProjectResourceRepository {
 
   val resourceManager = InMemoryResourceManager()
-
-  override def get(project: Identifier): ResourceManager = resourceManager.child(project).child("resources")
 }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/resources/PerProjectFileRepository.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/resources/PerProjectFileRepository.scala
@@ -11,9 +11,7 @@ import org.silkframework.util.Identifier
   label = "Per-project file resources",
   description = "Holds all resources in project specific directories."
 )
-case class PerProjectFileRepository(dir: String) extends ResourceRepository {
+case class PerProjectFileRepository(dir: String) extends ResourceRepository with PerProjectResourceRepository {
 
   val resourceManager = UrlResourceManager(FileResourceManager(new File(dir)))
-
-  override def get(project: Identifier): ResourceManager = resourceManager.child(project).child("resources")
 }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/resources/ResourceRepository.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/resources/ResourceRepository.scala
@@ -70,7 +70,7 @@ trait SharedResourceRespository { self: ResourceRepository =>
   /**
     * Returns true, because projects share resources.
     */
-  def sharedResources: Boolean = false
+  def sharedResources: Boolean = true
 
   /**
     * Retrieves all resources.

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/resources/ResourceRepository.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/resources/ResourceRepository.scala
@@ -9,8 +9,79 @@ import org.silkframework.util.Identifier
 trait ResourceRepository {
 
   /**
+    * If true, all projects share the same resources.
+    */
+  def sharedResources: Boolean
+
+  /**
     * Retrieves all resources for a given project.
     */
   def get(project: Identifier): ResourceManager
+
+  /**
+    * Removes project resources that are not shared between projects.
+    * Does not delete any resources for repositories that share resources between projects.
+    */
+  def removeProjectResources(project: Identifier): Unit
+
+}
+
+/**
+  * Resource repository for which each project manages its own resources.
+  */
+trait PerProjectResourceRepository { self: ResourceRepository =>
+
+  /**
+    * Base resource manager.
+    */
+  protected def resourceManager: ResourceManager
+
+  /**
+    * Returns false, because projects do not share resources.
+    */
+  def sharedResources: Boolean = false
+
+  /**
+    * Retrieves all resources for a given project.
+    */
+  def get(project: Identifier): ResourceManager = {
+    resourceManager.child(project).child("resources")
+  }
+
+  /**
+    * Removes project resources.
+    */
+  override def removeProjectResources(project: Identifier): Unit = {
+    resourceManager.delete(project)
+  }
+
+}
+
+/**
+  * Resource repository for which all projects share the same resources.
+  */
+trait SharedResourceRespository { self: ResourceRepository =>
+
+  /**
+    * Base resource manager.
+    */
+  protected def resourceManager: ResourceManager
+
+  /**
+    * Returns true, because projects share resources.
+    */
+  def sharedResources: Boolean = false
+
+  /**
+    * Retrieves all resources.
+    */
+  def get(project: Identifier): ResourceManager = {
+    resourceManager
+  }
+
+  /**
+    * Does not delete any resources, since resources are shared.
+    */
+  override def removeProjectResources(project: Identifier): Unit = { }
 
 }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/resources/ResourceRepositoryPlugins.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/resources/ResourceRepositoryPlugins.scala
@@ -5,5 +5,5 @@ import org.silkframework.runtime.plugin.PluginModule
 class ResourceRepositoryPlugins extends PluginModule {
 
   override def pluginClasses: Seq[Class[_]] =
-    Seq(classOf[PerProjectFileRepository], classOf[FileRepository], classOf[InMemoryResourceRepository], classOf[EmptyResourceRepository])
+    Seq(classOf[PerProjectFileRepository], classOf[SharedFileRepository], classOf[InMemoryResourceRepository], classOf[EmptyResourceRepository])
 }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/resources/SharedFileRepository.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/resources/SharedFileRepository.scala
@@ -11,7 +11,7 @@ import org.silkframework.util.Identifier
   label = "File resources",
   description = "Holds all resources in a specified folder."
 )
-case class FileRepository(dir: String) extends ResourceRepository with SharedResourceRespository {
+case class SharedFileRepository(dir: String) extends ResourceRepository with SharedResourceRespository {
 
   val resourceManager = UrlResourceManager(FileResourceManager(new File(dir)))
 }

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/TestWorkspaceProviderTestTrait.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/TestWorkspaceProviderTestTrait.scala
@@ -8,7 +8,7 @@ import org.silkframework.runtime.activity.UserContext
 import org.silkframework.runtime.plugin.PluginRegistry
 import org.silkframework.runtime.resource.InMemoryResourceManager
 import org.silkframework.util.Identifier
-import org.silkframework.workspace.resources.FileRepository
+import org.silkframework.workspace.resources.SharedFileRepository
 
 /**
   * Setups a test workspace with an in-memory workspace provider and temporary file based resource repository.
@@ -44,7 +44,7 @@ trait TestWorkspaceProviderTestTrait extends BeforeAndAfterAll { this: TestSuite
   // Workaround for config problem, this should make sure that the workspace is a fresh in-memory RDF workspace
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    val replacementWorkspace = new Workspace(workspaceProvider, FileRepository(tmpDir.getAbsolutePath))
+    val replacementWorkspace = new Workspace(workspaceProvider, SharedFileRepository(tmpDir.getAbsolutePath))
     val rdfWorkspaceFactory = new WorkspaceFactory {
       /**
         * The current workspace of this user.

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/resources/InMemoryResourceRepositoryTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/resources/InMemoryResourceRepositoryTest.scala
@@ -1,0 +1,6 @@
+package org.silkframework.workspace.resources
+
+class InMemoryResourceRepositoryTest extends PerProjectResourceRepositoryTest {
+
+  override protected lazy val repository: ResourceRepository = InMemoryResourceRepository()
+}

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/resources/PerProjectFileRepositoryTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/resources/PerProjectFileRepositoryTest.scala
@@ -1,0 +1,12 @@
+package org.silkframework.workspace.resources
+
+import java.nio.file.Files
+import org.silkframework.util.FileUtils._
+
+class PerProjectFileRepositoryTest extends PerProjectResourceRepositoryTest {
+
+  private val tempFile = Files.createTempDirectory("SharedFileRepositoryTest").toFile
+  tempFile.deleteRecursiveOnExit()
+
+  override protected lazy val repository: ResourceRepository = PerProjectFileRepository(tempFile.getAbsolutePath)
+}

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/resources/PerProjectResourceRepositoryTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/resources/PerProjectResourceRepositoryTest.scala
@@ -3,6 +3,8 @@ package org.silkframework.workspace.resources
 abstract class PerProjectResourceRepositoryTest extends ResourceRepositoryTest {
 
   it should "separate files from different projects" in {
+    repository.sharedResources mustBe false
+
     val resourceA = repository.get("projectA").get("resource")
     val resourceB = repository.get("projectB").get("resource")
 

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/resources/PerProjectResourceRepositoryTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/resources/PerProjectResourceRepositoryTest.scala
@@ -1,0 +1,51 @@
+package org.silkframework.workspace.resources
+
+abstract class PerProjectResourceRepositoryTest extends ResourceRepositoryTest {
+
+  it should "separate files from different projects" in {
+    val resourceA = repository.get("projectA").get("resource")
+    val resourceB = repository.get("projectB").get("resource")
+
+    resourceA.exists mustBe false
+    resourceB.exists mustBe false
+
+    resourceA.writeString("A")
+
+    resourceA.exists mustBe true
+    resourceB.exists mustBe false
+
+    resourceB.writeString("B")
+
+    resourceA.exists mustBe true
+    resourceB.exists mustBe true
+
+    resourceA.loadAsString mustBe "A"
+    resourceB.loadAsString mustBe "B"
+
+    resourceA.delete()
+    resourceB.delete()
+  }
+
+  it should "delete all project resources if requested" in {
+    val resourceA1 = repository.get("projectA").get("resource")
+    val resourceA2 = repository.get("projectA").child("folder").get("resource")
+    val resourceB = repository.get("projectB").get("resource")
+
+    resourceA1.writeString("A1")
+    resourceA2.writeString("A2")
+    resourceB.writeString("B")
+
+    resourceA1.exists mustBe true
+    resourceA2.exists mustBe true
+    resourceB.exists mustBe true
+
+    repository.removeProjectResources("projectA")
+
+    resourceA1.exists mustBe false
+    resourceA2.exists mustBe false
+    resourceB.exists mustBe true
+
+    resourceB.delete()
+  }
+
+}

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/resources/ResourceRepositoryTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/resources/ResourceRepositoryTest.scala
@@ -1,0 +1,52 @@
+package org.silkframework.workspace.resources
+
+import org.scalatest.{FlatSpec, MustMatchers}
+import org.silkframework.runtime.resource.ResourceNotFoundException
+
+/**
+  * Executes basic tests on a given resource repository.
+  */
+abstract class ResourceRepositoryTest extends FlatSpec with MustMatchers  {
+
+  protected def repository: ResourceRepository
+
+  private lazy val project = repository.get("myProject")
+
+  private val testContent = "my resource"
+
+  behavior of getClass.getSimpleName.stripSuffix("Test")
+
+  it should "allow reading and writing resources" in {
+    val testResource = project.get("resource")
+    project.list mustBe Seq.empty
+    testResource.exists mustBe false
+    testResource.writeString(testContent)
+    testResource.exists mustBe true
+    project.list mustBe Seq("resource")
+    testResource.name mustBe "resource"
+    testResource.loadAsString mustBe testContent
+    testResource.delete()
+    testResource.exists mustBe false
+  }
+
+  it should "allow reading and writing nested resources" in {
+    val testResource = project.child("child1").child("child2").get("resource")
+    val testContent = "my resource"
+    testResource.writeString(testContent)
+
+    project.listChildren mustBe Seq("child1")
+    project.child("child1").listChildren mustBe Seq("child2")
+
+    // Retrieve the resource manager again and do some navigation
+    val testResourceRead = project.child("child1").parent.get.child("child1").child("child2").get("resource")
+    testResourceRead.loadAsString mustBe testContent
+    testResource.delete()
+    testResource.exists mustBe false
+  }
+
+  it should "not allow to open resources that do not exist" in {
+    intercept[ResourceNotFoundException] {
+      project.get("nonExistingResource", mustExist = true)
+    }
+  }
+}

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/resources/SharedFileRepositoryTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/resources/SharedFileRepositoryTest.scala
@@ -1,0 +1,12 @@
+package org.silkframework.workspace.resources
+
+import java.nio.file.Files
+import org.silkframework.util.FileUtils._
+
+class SharedFileRepositoryTest extends SharedResourceRepositoryTest {
+
+  private val tempFile = Files.createTempDirectory("SharedFileRepositoryTest").toFile
+  tempFile.deleteRecursiveOnExit()
+
+  override protected lazy val repository: ResourceRepository = SharedFileRepository(tempFile.getAbsolutePath)
+}

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/resources/SharedResourceRepositoryTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/resources/SharedResourceRepositoryTest.scala
@@ -1,0 +1,33 @@
+package org.silkframework.workspace.resources
+
+abstract class SharedResourceRepositoryTest extends ResourceRepositoryTest {
+
+  it should "share files from different projects" in {
+    val resourceA = repository.get("projectA").get("resource")
+    val resourceB = repository.get("projectB").get("resource")
+
+    resourceA.exists mustBe false
+    resourceB.exists mustBe false
+
+    resourceA.writeString("A")
+
+    resourceA.loadAsString mustBe "A"
+    resourceB.loadAsString mustBe "A"
+    resourceA.exists mustBe true
+    resourceB.exists mustBe true
+
+    resourceA.delete()
+    resourceA.exists mustBe false
+    resourceB.exists mustBe false
+  }
+
+  it should "not delete shared files" in {
+    val resource = repository.get("projectA").get("resource")
+    resource.writeString("A")
+    resource.exists mustBe true
+
+    repository.removeProjectResources("projectA")
+    resource.exists mustBe true
+  }
+
+}

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/resources/SharedResourceRepositoryTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/resources/SharedResourceRepositoryTest.scala
@@ -3,6 +3,8 @@ package org.silkframework.workspace.resources
 abstract class SharedResourceRepositoryTest extends ResourceRepositoryTest {
 
   it should "share files from different projects" in {
+    repository.sharedResources mustBe true
+
     val resourceA = repository.get("projectA").get("resource")
     val resourceB = repository.get("projectB").get("resource")
 


### PR DESCRIPTION
- Consistent resource deletion behaviour for resource repositories:
   - For resource repositories that do not share resources between projects, resources are removed on project deletion.
   - For resource repositories that do share resources between projects, resources are NOT removed on project deletion.
   - In both cases, the user is informed in the UI about the behaviour of the configured resource repository.