### PR TITLE
Fixed linking validation errors

### DIFF
--- a/silk-rules/src/main/scala/org/silkframework/rule/similarity/Comparison.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/similarity/Comparison.scala
@@ -21,6 +21,7 @@ import org.silkframework.runtime.serialization.{ReadContext, WriteContext, XmlFo
 import org.silkframework.runtime.validation.ValidationException
 import org.silkframework.util.{DPair, Identifier}
 
+import scala.util.Try
 import scala.xml.Node
 
 /**
@@ -45,8 +46,8 @@ case class Comparison(id: Identifier = Operator.generateId,
    * @return The confidence as a value between -1.0 and 1.0.
    */
   override def apply(entities: DPair[Entity], limit: Double): Option[Double] = {
-    val values1 = inputs.source(entities.source)
-    val values2 = inputs.target(entities.target)
+    val values1 = Try(inputs.source(entities.source)).getOrElse(Seq.empty)
+    val values2 = Try(inputs.target(entities.target)).getOrElse(Seq.empty)
 
     if (values1.isEmpty || values2.isEmpty)
       None
@@ -73,7 +74,7 @@ case class Comparison(id: Identifier = Operator.generateId,
     * @return A set of (multidimensional) indexes. Entities within the threshold will always get the same index.
     */
   override def index(entity: Entity, sourceOrTarget: Boolean, limit: Double): Index = {
-    val values = if(sourceOrTarget) inputs.source(entity) else inputs.target(entity)
+    val values = Try(inputs.select(sourceOrTarget)(entity)).getOrElse(Seq.empty)
 
     val distanceLimit = threshold * (1.0 - limit)
 

--- a/silk-workbench/silk-workbench-rules/app/controllers/linking/EvaluateLinkingController.scala
+++ b/silk-workbench/silk-workbench-rules/app/controllers/linking/EvaluateLinkingController.scala
@@ -2,9 +2,8 @@ package controllers.linking
 
 import akka.actor.ActorSystem
 import akka.stream.Materializer
-import controllers.core.{RequestUserContextAction, UserContextAction}
+ import controllers.core.RequestUserContextAction
 import controllers.util.AkkaUtils
-import javax.inject.Inject
 import models.linking.EvalLink.{Correct, Generated, Incorrect, Unknown}
 import models.linking.{EvalLink, LinkResolver, LinkSorter}
 import org.silkframework.rule.LinkSpec
@@ -17,6 +16,8 @@ import org.silkframework.workspace.activity.linking.EvaluateLinkingActivity
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, InjectedController, WebSocket}
 
+import javax.inject.Inject
+
 class EvaluateLinkingController @Inject() (implicit system: ActorSystem, mat: Materializer, accessMonitor: WorkbenchAccessMonitor) extends InjectedController {
 
   def generateLinks(project: String, task: String): Action[AnyContent] = RequestUserContextAction { implicit request => implicit userContext =>
@@ -25,7 +26,7 @@ class EvaluateLinkingController @Inject() (implicit system: ActorSystem, mat: Ma
     Ok(views.html.evaluateLinking.evaluateLinking(context))
   }
 
-  def links(projectName: String, taskName: String, sorting: String, filter: String, page: Int): Action[AnyContent] = UserContextAction { implicit userContext =>
+  def links(projectName: String, taskName: String, sorting: String, filter: String, page: Int): Action[AnyContent] = RequestUserContextAction { implicit request => implicit userContext =>
     val project = WorkspaceFactory().workspace.project(projectName)
     val task = project.task[LinkSpec](taskName)
     val linkSorter = LinkSorter.fromId(sorting)

--- a/silk-workbench/silk-workbench-rules/app/controllers/linking/Learning.scala
+++ b/silk-workbench/silk-workbench-rules/app/controllers/linking/Learning.scala
@@ -1,15 +1,12 @@
 package controllers.linking
 
-import java.util.logging.Logger
-
 import akka.stream.Materializer
 import controllers.core.{RequestUserContextAction, UserContextAction}
-import javax.inject.Inject
 import models.learning.{PathValue, PathValues}
 import models.linking.EvalLink.{Correct, Generated, Incorrect, Unknown}
 import models.linking._
+import org.silkframework.entity.Link
 import org.silkframework.entity.paths.{Path, TypedPath}
-import org.silkframework.entity.{Link, MinimalLink}
 import org.silkframework.learning.LearningActivity
 import org.silkframework.learning.active.ActiveLearning
 import org.silkframework.learning.individual.Population
@@ -17,7 +14,6 @@ import org.silkframework.rule.evaluation.ReferenceLinks
 import org.silkframework.rule.input.PathInput
 import org.silkframework.rule.similarity.Comparison
 import org.silkframework.rule.{LinkSpec, LinkageRule, RuleTraverser}
-import org.silkframework.runtime.activity.UserContext
 import org.silkframework.runtime.validation.BadUserInputException
 import org.silkframework.util.Identifier._
 import org.silkframework.workbench.Context
@@ -26,7 +22,8 @@ import org.silkframework.workspace.activity.linking.ReferenceEntitiesCache
 import org.silkframework.workspace.{ProjectTask, WorkspaceFactory}
 import play.api.mvc.{Action, AnyContent, InjectedController}
 
-import scala.util.Random
+import java.util.logging.Logger
+import javax.inject.Inject
 
 class Learning @Inject() (implicit mat: Materializer) extends InjectedController {
 
@@ -73,9 +70,9 @@ class Learning @Inject() (implicit mat: Materializer) extends InjectedController
       */
     def sortedPaths(sourceOrTarget: Boolean): Seq[TypedPath] = {
       val rules = activeLearn.value().population.individuals.map(_.node.build)
-      val allSourcePaths = rules.map(rule => collectPaths(rule, sourceOrTarget))
+      val allSourcePaths = rules.flatMap(rule => collectPaths(rule, sourceOrTarget))
       val schemaPaths = activeLearn.value().pool.entityDescs.select(sourceOrTarget).typedPaths
-      val sortedSchemaPaths = schemaPaths.sortBy(p => allSourcePaths.count(_ == p))
+      val sortedSchemaPaths = schemaPaths.sortBy(p => allSourcePaths.count(_.normalizedSerialization == p.normalizedSerialization))
       sortedSchemaPaths
     }
 

--- a/silk-workbench/silk-workbench-rules/app/views/widgets/linksTable.scala.html
+++ b/silk-workbench/silk-workbench-rules/app/views/widgets/linksTable.scala.html
@@ -9,6 +9,8 @@
 @import org.silkframework.runtime.activity.UserContext
 @import org.silkframework.util.DPair
 @import org.silkframework.workspace.{Project, ProjectTask}
+@import java.util.UUID
+@import org.silkframework.workbench.Context
 
 @(project: Project,
   task: ProjectTask[LinkSpec],
@@ -20,17 +22,17 @@
   page: Int,
   showStatus: Boolean, showDetails: Boolean, showEntities: Boolean, rateButtons: Boolean)(implicit userContext: UserContext)
 
+@render(getPageLinks())
+@for(statistics <- linkingStatistics) {
+  @linkingReport(statistics, links.size)
+}
+
 @getPageLinks() = @{
   val pageSize = 100
   val filteredLinks = LinkFilter(links, filter.stripPrefix("filter:"))
   val sortedLinks = sorting(filteredLinks)
   val pageLinks = sortedLinks.view(page * pageSize, (page + 1) * pageSize)
   pageLinks
-}
-
-@render(getPageLinks())
-@for(statistics <- linkingStatistics) {
-  @linkingReport(statistics, links.size)
 }
 
 @render(pageLinks: Seq[EvalLink]) = {
@@ -240,6 +242,7 @@
       <span class="input">
         Transform: @transform.transformer.pluginSpec.id (@transform.id)
         @values.map(v => <span class={divClassPrefix + "-value"}>{v}</span>)
+        @renderError(value.error)
       </span>
       <ul>
         @children.map(v => renderValue(v, divClassPrefix))
@@ -253,6 +256,7 @@
         @for(v <- values) {
           <span class="@(divClassPrefix)-value">@convertToLinkIfDetected(v)</span>
         }
+        @renderError(value.error)
       </span>
     </li>
   }
@@ -287,6 +291,14 @@
   }
   case None => {}
 }}
+
+@renderError(error: Option[Throwable], id: String = UUID.randomUUID.toString) = {
+  @for(e <- error) {
+    <span id="error-@id" title="@e.getMessage">
+      <img src="@Assets.at("img/exclamation.png")" style="cursor: help;" />
+    </span>
+  }
+}
 
 @id(link: EvalLink, prefix: String = "") = @{
   prefix + link.hashCode


### PR DESCRIPTION
- Substring transformer should generate an empty value, if an index is out of range and 'stringMustBeInRange' is false.
- If a transformer inside a linkage rule throws a validation error, it will no longer fail the entire linking task, but just not generate a link for that single entity.