### PR TITLE
Fix loading large files into memory

### DIFF
--- a/silk-core/src/main/scala/org/silkframework/runtime/resource/ResourceTooLargeException.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/resource/ResourceTooLargeException.scala
@@ -1,0 +1,8 @@
+package org.silkframework.runtime.resource
+
+import java.io.IOException
+
+/**
+  * Thrown if a resource is too large to be loaded into memory.
+  */
+class ResourceTooLargeException(msg: String) extends IOException(msg)

--- a/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/JsonDataset.scala
+++ b/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/JsonDataset.scala
@@ -30,8 +30,5 @@ case class JsonDataset(
 
   override def linkSink(implicit userContext: UserContext): LinkSink = throw new NotImplementedError("JSON files cannot be written at the moment")
 
-  override def entitySink(implicit userContext: UserContext): EntitySink = {
-    file.checkSizeForInMemory()
-    new JsonSink(file, topLevelObject = makeFirstEntityJsonObject)
-  }
+  override def entitySink(implicit userContext: UserContext): EntitySink = new JsonSink(file, topLevelObject = makeFirstEntityJsonObject)
 }

--- a/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/JsonDataset.scala
+++ b/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/JsonDataset.scala
@@ -3,9 +3,7 @@ package org.silkframework.plugins.dataset.json
 import org.silkframework.dataset._
 import org.silkframework.runtime.activity.UserContext
 import org.silkframework.runtime.plugin.annotations.{Param, Plugin}
-import org.silkframework.runtime.resource.{Resource, WritableResource}
-
-import scala.io.Codec
+import org.silkframework.runtime.resource.WritableResource
 
 @Plugin(
   id = "json",
@@ -25,9 +23,15 @@ case class JsonDataset(
   @Param(label = "Output first entity as JSON object", value = "Specifies whether an Array or JSON objects is returned or a single object is returned for the first entity when writing to JSON files.", advanced = true)
   makeFirstEntityJsonObject: Boolean = false) extends Dataset with ResourceBasedDataset {
 
-  override def source(implicit userContext: UserContext): DataSource = JsonSource(file, basePath, uriPattern)
+  override def source(implicit userContext: UserContext): DataSource = {
+    file.checkSizeForInMemory()
+    JsonSource(file, basePath, uriPattern)
+  }
 
   override def linkSink(implicit userContext: UserContext): LinkSink = throw new NotImplementedError("JSON files cannot be written at the moment")
 
-  override def entitySink(implicit userContext: UserContext): EntitySink = new JsonSink(file, topLevelObject = makeFirstEntityJsonObject)
+  override def entitySink(implicit userContext: UserContext): EntitySink = {
+    file.checkSizeForInMemory()
+    new JsonSink(file, topLevelObject = makeFirstEntityJsonObject)
+  }
 }

--- a/silk-plugins/silk-plugins-json/src/test/scala/org/silkframework/plugins/dataset/json/JsonDatasetTest.scala
+++ b/silk-plugins/silk-plugins-json/src/test/scala/org/silkframework/plugins/dataset/json/JsonDatasetTest.scala
@@ -26,7 +26,6 @@ class JsonDatasetTest extends FlatSpec with Matchers with TestUserContextTrait {
 
     val dataset = JsonDataset(resource)
     an[ResourceTooLargeException] should be thrownBy dataset.source
-    an[ResourceTooLargeException] should be thrownBy dataset.entitySink
   }
 
 }

--- a/silk-plugins/silk-plugins-json/src/test/scala/org/silkframework/plugins/dataset/json/JsonDatasetTest.scala
+++ b/silk-plugins/silk-plugins-json/src/test/scala/org/silkframework/plugins/dataset/json/JsonDatasetTest.scala
@@ -1,0 +1,32 @@
+package org.silkframework.plugins.dataset.json
+
+import org.scalatest.{FlatSpec, Matchers}
+import org.silkframework.runtime.activity.TestUserContextTrait
+import org.silkframework.runtime.resource.{ResourceTooLargeException, WritableResource}
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
+import java.time.Instant
+
+class JsonDatasetTest extends FlatSpec with Matchers with TestUserContextTrait {
+
+  behavior of "JSON dataset"
+
+  it should "not load large files into memory" in {
+    val resource = new WritableResource {
+      override def name: String = "largeResource"
+      override def path: String = "path"
+      override def size: Option[Long] = Some(1000000000L)
+
+      override def createOutputStream(append: Boolean): OutputStream = new ByteArrayOutputStream()
+      override def delete(): Unit = {}
+      override def exists: Boolean = true
+      override def modificationTime: Option[Instant] = None
+      override def inputStream: InputStream = new ByteArrayInputStream(Array.emptyByteArray)
+    }
+
+    val dataset = JsonDataset(resource)
+    an[ResourceTooLargeException] should be thrownBy dataset.source
+    an[ResourceTooLargeException] should be thrownBy dataset.entitySink
+  }
+
+}

--- a/silk-plugins/silk-plugins-rdf/src/test/scala/org/silkframework/plugins/dataset/rdf/RdfFileDatasetTest.scala
+++ b/silk-plugins/silk-plugins-rdf/src/test/scala/org/silkframework/plugins/dataset/rdf/RdfFileDatasetTest.scala
@@ -3,7 +3,10 @@ package org.silkframework.plugins.dataset.rdf
 import org.scalatest.{FlatSpec, MustMatchers}
 import org.silkframework.plugins.dataset.rdf.datasets.RdfFileDataset
 import org.silkframework.runtime.activity.UserContext
-import org.silkframework.runtime.resource.InMemoryResourceManager
+import org.silkframework.runtime.resource.{InMemoryResourceManager, ResourceTooLargeException, WritableResource}
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
+import java.time.Instant
 
 class RdfFileDatasetTest extends FlatSpec with MustMatchers {
   behavior of "RDF file dataset"
@@ -13,22 +16,21 @@ class RdfFileDatasetTest extends FlatSpec with MustMatchers {
   implicit val userContext: UserContext = UserContext.Empty
 
   it should "not load files larger than 'max. read size'" in {
-    val largeResource = resourceManager.get("largeResource")
-    largeResource.writeString(getString(1000 * 1000 -1))
-    val rdfDataset = RdfFileDataset(largeResource, "Turtle", maxReadSize = 1)
-    rdfDataset.source.retrieveTypes()
-    largeResource.writeString(getString(1000 * 1000 + 1))
-    val rdfDataset2 = RdfFileDataset(largeResource, "Turtle", maxReadSize = 1)
-    intercept[RuntimeException] {
-      rdfDataset2.source.retrieveTypes()
-    }
-  }
+    val largeResource = new WritableResource {
+      override def name: String = "largeResource"
+      override def path: String = "path"
+      override def size: Option[Long] = Some(1000000000L)
 
-  private def getString(size: Int) = {
-    val sb = new StringBuilder()
-    for (_ <- 1 to size) {
-      sb.append("#")
+      override def createOutputStream(append: Boolean): OutputStream = new ByteArrayOutputStream()
+      override def delete(): Unit = {}
+      override def exists: Boolean = true
+      override def modificationTime: Option[Instant] = None
+      override def inputStream: InputStream = new ByteArrayInputStream(Array.emptyByteArray)
     }
-    sb.toString()
+
+    val rdfDataset = RdfFileDataset(largeResource, "Turtle")
+    intercept[ResourceTooLargeException] {
+      rdfDataset.source.retrieveTypes()
+    }
   }
 }

--- a/silk-plugins/silk-plugins-xml/src/main/scala/org/silkframework/plugins/dataset/xml/XmlDataset.scala
+++ b/silk-plugins/silk-plugins-xml/src/main/scala/org/silkframework/plugins/dataset/xml/XmlDataset.scala
@@ -48,10 +48,7 @@ case class XmlDataset( @Param("The XML file. This may also be a zip archive of m
 
   override def linkSink(implicit userContext: UserContext): LinkSink = throw new NotImplementedError("Links cannot be written at the moment")
 
-  override def entitySink(implicit userContext: UserContext): EntitySink = {
-    file.checkSizeForInMemory()
-    new XmlSink(file, outputTemplate.str)
-  }
+  override def entitySink(implicit userContext: UserContext): EntitySink = new XmlSink(file, outputTemplate.str)
 
   /**
     * Validates the output template parameter

--- a/silk-plugins/silk-plugins-xml/src/main/scala/org/silkframework/plugins/dataset/xml/XmlDataset.scala
+++ b/silk-plugins/silk-plugins-xml/src/main/scala/org/silkframework/plugins/dataset/xml/XmlDataset.scala
@@ -41,13 +41,17 @@ case class XmlDataset( @Param("The XML file. This may also be a zip archive of m
       new XmlSourceStreaming(resource, basePath, uriPattern)
     }
     else {
+      resource.checkSizeForInMemory()
       new XmlSourceInMemory(resource, basePath, uriPattern)
     }
   }
 
   override def linkSink(implicit userContext: UserContext): LinkSink = throw new NotImplementedError("Links cannot be written at the moment")
 
-  override def entitySink(implicit userContext: UserContext): EntitySink = new XmlSink(file, outputTemplate.str)
+  override def entitySink(implicit userContext: UserContext): EntitySink = {
+    file.checkSizeForInMemory()
+    new XmlSink(file, outputTemplate.str)
+  }
 
   /**
     * Validates the output template parameter

--- a/silk-plugins/silk-plugins-xml/src/test/scala/org/silkframework/plugins/dataset/xml/XmlDatasetTest.scala
+++ b/silk-plugins/silk-plugins-xml/src/test/scala/org/silkframework/plugins/dataset/xml/XmlDatasetTest.scala
@@ -72,11 +72,9 @@ class XmlDatasetTest extends FlatSpec with MustMatchers with TestUserContextTrai
 
     val streamingDataset = XmlDataset(resource, streaming = true)
     noException should be thrownBy streamingDataset.source
-    an[ResourceTooLargeException] should be thrownBy streamingDataset.entitySink
 
     val nonStreamingDataset = XmlDataset(resource, streaming = false)
     an[ResourceTooLargeException] should be thrownBy nonStreamingDataset.source
-    an[ResourceTooLargeException] should be thrownBy nonStreamingDataset.entitySink
   }
 
   private def retrieveIDs(dataset: XmlDataset) = {

--- a/silk-plugins/silk-plugins-xml/src/test/scala/org/silkframework/plugins/dataset/xml/XmlDatasetTest.scala
+++ b/silk-plugins/silk-plugins-xml/src/test/scala/org/silkframework/plugins/dataset/xml/XmlDatasetTest.scala
@@ -5,9 +5,11 @@ import org.silkframework.entity.EntitySchema
 import org.silkframework.entity.paths.UntypedPath
 import org.silkframework.runtime.activity.TestUserContextTrait
 import org.silkframework.runtime.plugin.MultilineStringParameter
-import org.silkframework.runtime.resource.{ClasspathResource, InMemoryResourceManager, ReadOnlyResource}
+import org.silkframework.runtime.resource._
 import org.silkframework.runtime.validation.ValidationException
 
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
+import java.time.Instant
 import scala.util.Try
 
 class XmlDatasetTest extends FlatSpec with MustMatchers with TestUserContextTrait {
@@ -53,6 +55,28 @@ class XmlDatasetTest extends FlatSpec with MustMatchers with TestUserContextTrai
     val errorMessage = failedExecution.failed.get.getMessage
     errorMessage must include ("brokenXml.broken")
     errorMessage must include ("persons.zip")
+  }
+
+  it should "not load large files into memory" in {
+    val resource = new WritableResource {
+      override def name: String = "largeResource"
+      override def path: String = "path"
+      override def size: Option[Long] = Some(1000000000L)
+
+      override def createOutputStream(append: Boolean): OutputStream = new ByteArrayOutputStream()
+      override def delete(): Unit = {}
+      override def exists: Boolean = true
+      override def modificationTime: Option[Instant] = None
+      override def inputStream: InputStream = new ByteArrayInputStream(Array.emptyByteArray)
+    }
+
+    val streamingDataset = XmlDataset(resource, streaming = true)
+    noException should be thrownBy streamingDataset.source
+    an[ResourceTooLargeException] should be thrownBy streamingDataset.entitySink
+
+    val nonStreamingDataset = XmlDataset(resource, streaming = false)
+    an[ResourceTooLargeException] should be thrownBy nonStreamingDataset.source
+    an[ResourceTooLargeException] should be thrownBy nonStreamingDataset.entitySink
   }
 
   private def retrieveIDs(dataset: XmlDataset) = {


### PR DESCRIPTION
XML and JSON: Files larger than the configured resource maxInMemorySize are not loaded into memory returning an error instead