### PR TITLE
execution report improvements

### DIFF
--- a/silk-core/src/main/scala/org/silkframework/execution/ExecutionReport.scala
+++ b/silk-core/src/main/scala/org/silkframework/execution/ExecutionReport.scala
@@ -18,6 +18,11 @@ trait ExecutionReport {
   def label: String = task.taskLabel()
 
   /**
+    * Short label for the operation thas has been executed, e.g., read or write.
+    */
+  def operation: Option[String] = None
+
+  /**
     * Generates a short summary of this report.
     *
     * @return A sequence of key-value pairs representing the summary table.

--- a/silk-core/src/main/scala/org/silkframework/execution/ExecutionReport.scala
+++ b/silk-core/src/main/scala/org/silkframework/execution/ExecutionReport.scala
@@ -18,7 +18,7 @@ trait ExecutionReport {
   def label: String = task.taskLabel()
 
   /**
-    * Short label for the operation thas has been executed, e.g., read or write.
+    * Short label for the executed operation, e.g., read or write (optional).
     */
   def operation: Option[String] = None
 

--- a/silk-core/src/main/scala/org/silkframework/execution/ExecutionReportUpdater.scala
+++ b/silk-core/src/main/scala/org/silkframework/execution/ExecutionReportUpdater.scala
@@ -1,10 +1,10 @@
 package org.silkframework.execution
 
-import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
-import java.time.{Instant, OffsetDateTime, ZoneOffset}
-
 import org.silkframework.config.{Task, TaskSpec}
 import org.silkframework.runtime.activity.ActivityContext
+
+import java.time.Instant
+import java.time.format.DateTimeFormatter
 
 /**
   * Base trait for simple execution report updates.
@@ -16,6 +16,8 @@ trait ExecutionReportUpdater {
   def task: Task[TaskSpec]
   /** The activity context of the task that is executed */
   def context: ActivityContext[ExecutionReport]
+  /** Short label for the operation, e.g., "read" or "write" */
+  def operationLabel: Option[String] = None
   /** What does the task emit, e.g. "entity", "query" etc. */
   def entityLabelSingle: String = "Entity"
   /** The plural of the entity label, e.g. "entities", "queries" */
@@ -83,7 +85,7 @@ trait ExecutionReportUpdater {
             s"Runtime since first ${entityLabelSingle.toLowerCase} $entityProcessVerb" -> s"${(firstEntityStart - start).toDouble / 1000} seconds") ++
           Seq("Number of executions" -> numberOfExecutions.toString).filter(_ => numberOfExecutions > 0) ++
           additionalFields()
-      context.value.update(SimpleExecutionReport(task, stats, Seq.empty))
+      context.value.update(SimpleExecutionReport(task, stats, Seq.empty, operationLabel))
       lastUpdate = System.currentTimeMillis()
     }
   }

--- a/silk-core/src/main/scala/org/silkframework/execution/SimpleExecutionReport.scala
+++ b/silk-core/src/main/scala/org/silkframework/execution/SimpleExecutionReport.scala
@@ -7,4 +7,5 @@ import org.silkframework.config.{Task, TaskSpec}
   */
 case class SimpleExecutionReport(task: Task[TaskSpec],
                                  summary: Seq[(String, String)],
-                                 warnings: Seq[String]) extends ExecutionReport
+                                 warnings: Seq[String],
+                                 override val operation: Option[String] = None) extends ExecutionReport

--- a/silk-core/src/main/scala/org/silkframework/execution/local/LocalDatasetExecutor.scala
+++ b/silk-core/src/main/scala/org/silkframework/execution/local/LocalDatasetExecutor.scala
@@ -153,6 +153,8 @@ abstract class LocalDatasetExecutor[DatasetType <: Dataset] extends DatasetExecu
   case class SparqlUpdateExecutionReportUpdater(task: Task[TaskSpec], context: ActivityContext[ExecutionReport]) extends ExecutionReportUpdater {
     var remainingQueries = 0
 
+    override def operationLabel: Option[String] = Some("generate queries")
+
     override def entityProcessVerb: String = "executed"
 
     override def entityLabelSingle: String = "Update query"

--- a/silk-core/src/main/scala/org/silkframework/execution/local/LocalDatasetExecutor.scala
+++ b/silk-core/src/main/scala/org/silkframework/execution/local/LocalDatasetExecutor.scala
@@ -374,10 +374,12 @@ abstract class LocalDatasetExecutor[DatasetType <: Dataset] extends DatasetExecu
   }
 
   case class WriteEntitiesReportUpdater(task: Task[TaskSpec], context: ActivityContext[ExecutionReport]) extends ExecutionReportUpdater {
+    override def operationLabel: Option[String] = Some("write")
     override def entityProcessVerb: String = "written"
   }
 
   case class ReadEntitiesReportUpdater(task: Task[TaskSpec], context: ActivityContext[ExecutionReport]) extends ExecutionReportUpdater {
+    override def operationLabel: Option[String] = Some("read")
     override def entityProcessVerb: String = "read"
   }
 

--- a/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/executors/LocalSparqlSelectExecutor.scala
+++ b/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/executors/LocalSparqlSelectExecutor.scala
@@ -3,7 +3,7 @@ package org.silkframework.plugins.dataset.rdf.executors
 import org.silkframework.config.{Prefixes, Task, TaskSpec}
 import org.silkframework.dataset.DataSource
 import org.silkframework.dataset.rdf.{SparqlEndpointEntityTable, SparqlResults}
-import org.silkframework.entity.{Entity, EntitySchema}
+import org.silkframework.entity.Entity
 import org.silkframework.execution.local.{GenericEntityTable, LocalEntities, LocalExecution, LocalExecutor}
 import org.silkframework.execution.{ExecutionReport, ExecutionReportUpdater, ExecutorOutput, TaskException}
 import org.silkframework.plugins.dataset.rdf.tasks.SparqlSelectCustomTask
@@ -88,6 +88,9 @@ case class LocalSparqlSelectExecutor() extends LocalExecutor[SparqlSelectCustomT
 
 case class SparqlSelectExecutionReportUpdater(task: Task[TaskSpec],
                                               context: ActivityContext[ExecutionReport]) extends ExecutionReportUpdater {
+
+  override def operationLabel: Option[String] = Some("generate queries")
+
   override def entityLabelSingle: String = "Row"
 
   override def entityLabelPlural: String = "Rows"

--- a/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/executors/LocalSparqlUpdateExecutor.scala
+++ b/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/executors/LocalSparqlUpdateExecutor.scala
@@ -98,6 +98,9 @@ case class LocalSparqlUpdateExecutor() extends LocalExecutor[SparqlUpdateCustomT
 
 case class SparqlUpdateExecutionReportUpdater(task: Task[TaskSpec],
                                               context: ActivityContext[ExecutionReport]) extends ExecutionReportUpdater {
+
+  override def operationLabel: Option[String] = Some("generate queries")
+
   override def entityLabelSingle: String = "Query"
 
   override def entityLabelPlural: String = "Queries"

--- a/silk-plugins/silk-serialization-json/src/main/scala/org/silkframework/serialization/json/ExecutionReportSerializers.scala
+++ b/silk-plugins/silk-serialization-json/src/main/scala/org/silkframework/serialization/json/ExecutionReportSerializers.scala
@@ -39,7 +39,8 @@ object ExecutionReportSerializers {
         SimpleExecutionReport(
           task = GenericTaskJsonFormat.read(requiredValue(value, TASK)),
           summary = arrayValue(value, SUMMARY).value.map(deserializeValue),
-          warnings = arrayValue(value, WARNINGS).value.map(_.as[String])
+          warnings = arrayValue(value, WARNINGS).value.map(_.as[String]),
+          operation = stringValueOption(value, OPERATION))
         )
       }
     }
@@ -47,9 +48,10 @@ object ExecutionReportSerializers {
     def serializeBasicValues(value: ExecutionReport)(implicit writeContext: WriteContext[JsValue]): JsObject = {
       Json.obj(
         LABEL -> value.task.taskLabel(),
+        OPERATION -> value.operation,
         TASK -> GenericTaskJsonFormat.write(value.task),
         SUMMARY -> value.summary.map(serializeValue),
-        WARNINGS -> value.warnings
+        WARNINGS -> value.warnings,
       )
     }
 
@@ -190,6 +192,7 @@ object ExecutionReportSerializers {
 
   object Keys {
 
+    final val OPERATION = "operation"
     final val TASK = "task"
     final val LABEL = "label"
     final val SUMMARY = "summary"

--- a/silk-plugins/silk-serialization-json/src/main/scala/org/silkframework/serialization/json/ExecutionReportSerializers.scala
+++ b/silk-plugins/silk-serialization-json/src/main/scala/org/silkframework/serialization/json/ExecutionReportSerializers.scala
@@ -40,7 +40,7 @@ object ExecutionReportSerializers {
           task = GenericTaskJsonFormat.read(requiredValue(value, TASK)),
           summary = arrayValue(value, SUMMARY).value.map(deserializeValue),
           warnings = arrayValue(value, WARNINGS).value.map(_.as[String]),
-          operation = stringValueOption(value, OPERATION))
+          operation = stringValueOption(value, OPERATION)
         )
       }
     }

--- a/silk-react-components/src/ExecutionReport/ExecutionReport.jsx
+++ b/silk-react-components/src/ExecutionReport/ExecutionReport.jsx
@@ -21,12 +21,51 @@ export default class ExecutionReport extends React.Component {
     }
     
     renderSummary() {
+        let executionMetaData = [];
+        if(this.props.executionMetaData != null) {
+            executionMetaData = executionMetaData.concat([
+                <tr key="startedAt">
+                    <td className="silk-report-table-bold">Started at</td>
+                    <td>{this.props.executionMetaData.startedAt}</td>
+                </tr>,
+                <tr key="startedByUser">
+                    <td className="silk-report-table-bold">Started by</td>
+                    <td>{(this.props.executionMetaData.startedByUser == null) ? "Unknown" : this.props.executionMetaData.startedByUser}</td>
+                </tr>,
+                <tr key="finishedAt">
+                    <td className="silk-report-table-bold">Finished at</td>
+                    <td>{this.props.executionMetaData.finishedAt}</td>
+                </tr>,
+                <tr key="finishStatus">
+                    <td className="silk-report-table-bold">Finish status</td>
+                    <td>{this.props.executionMetaData.finishStatus.message}</td>
+                </tr>
+            ]);
+            if(this.props.executionMetaData.cancelledAt != null) {
+                executionMetaData.push(
+                    <tr key="cancelledAt">
+                        <td className="silk-report-table-bold">Cancelled at</td>
+                        <td>{this.props.executionMetaData.cancelledAt}</td>
+                    </tr>
+                )
+            }
+            if(this.props.executionMetaData.cancelledBy != null) {
+                executionMetaData.push(
+                    <tr key="cancelledBy">
+                        <td className="silk-report-table-bold">Cancelled by</td>
+                        <td>{this.props.executionMetaData.cancelledBy}</td>
+                    </tr>
+                )
+            }
+        }
+
         const summaryRows = this.props.executionReport.summary.map(v =>
             <tr key={v.key}>
                 <td className="silk-report-table-bold">{v.key}</td>
                 <td>{v.value}</td>
             </tr>
         );
+
         return <Card className="silk-report-card">
             <CardTitle>
                 Execution Report
@@ -37,6 +76,7 @@ export default class ExecutionReport extends React.Component {
                         <thead>
                         </thead>
                         <tbody>
+                        {executionMetaData}
                         {summaryRows}
                         </tbody>
                     </table>
@@ -152,5 +192,6 @@ ExecutionReport.propTypes = {
     baseUrl: PropTypes.string.isRequired, // Base URL of the DI service
     project: PropTypes.string.isRequired, // project ID
     nodeId: PropTypes.string.isRequired, // workflow node ID
-    executionReport: PropTypes.object // The execution report to render
+    executionReport: PropTypes.object, // The execution report to render
+    executionMetaData: PropTypes.object // Optional execution meta data that includes start time, user, etc.
 };

--- a/silk-react-components/src/ExecutionReport/ExecutionReport.jsx
+++ b/silk-react-components/src/ExecutionReport/ExecutionReport.jsx
@@ -152,5 +152,5 @@ ExecutionReport.propTypes = {
     baseUrl: PropTypes.string.isRequired, // Base URL of the DI service
     project: PropTypes.string.isRequired, // project ID
     nodeId: PropTypes.string.isRequired, // workflow node ID
-    executionReport: PropTypes.object // The transform execution report to render
+    executionReport: PropTypes.object // The execution report to render
 };

--- a/silk-react-components/src/ExecutionReport/ExecutionReport.jsx
+++ b/silk-react-components/src/ExecutionReport/ExecutionReport.jsx
@@ -71,6 +71,7 @@ export default class ExecutionReport extends React.Component {
                 Execution Report
             </CardTitle>
             <CardContent>
+                {this.renderWarning()}
                 <div>
                     <table className="silk-report-table">
                         <thead>
@@ -81,31 +82,36 @@ export default class ExecutionReport extends React.Component {
                         </tbody>
                     </table>
                 </div>
-                {this.renderWarning()}
             </CardContent>
         </Card>
     }
 
     renderWarning() {
-        if(this.props.executionReport.warnings.length > 0) {
-            const warnings = this.props.executionReport.warnings.map(warning =>
-                <div className="mdl-alert mdl-alert--info mdl-alert--border mdl-alert--spacing">
+        let messages = [];
+        let alertClass = "mdl-alert--info"
+        if(this.props.executionMetaData != null && this.props.executionMetaData.finishStatus.cancelled) {
+            messages = [ `Task '${this.props.executionReport.label}' has been cancelled.` ];
+            alertClass = "mdl-alert--warning";
+        } else if(this.props.executionMetaData != null && this.props.executionMetaData.finishStatus.failed) {
+            messages = [ `Task '${this.props.executionReport.label}' failed to execute.` ]
+            alertClass = "mdl-alert--danger"
+        } else if(this.props.executionReport.warnings.length > 0) {
+            messages = this.props.executionReport.warnings;
+            alertClass = "mdl-alert--info"
+        } else {
+            messages = [ `Task '${this.props.executionReport.label}' has been executed without any issues.` ];
+            alertClass = "mdl-alert--success";
+        }
+
+        return <div className="silk-report-warning">{
+            messages.map(warning =>
+                <div className={alertClass + " mdl-alert mdl-alert--border mdl-alert--spacing"}>
                     <div className="mdl-alert__content">
                         <p>{warning}</p>
                     </div>
                 </div>
-            );
-
-            return <div className="silk-report-warning">{warnings}</div>
-        } else {
-            return <div className="silk-report-warning">
-                        <div className="mdl-alert mdl-alert--info mdl-alert--border mdl-alert--spacing">
-                            <div className="mdl-alert__content">
-                                <p>Task '{this.props.executionReport.label}' has been executed without any issues.</p>
-                            </div>
-                        </div>
-                   </div>
-        }
+            )
+        }</div>
     }
     
     renderTransformReport() {

--- a/silk-react-components/src/ExecutionReport/ExecutionReport.scss
+++ b/silk-react-components/src/ExecutionReport/ExecutionReport.scss
@@ -3,6 +3,31 @@
   margin: 0.5rem;
 }
 
+.silk-report-sidebar {
+  display: flex;
+  flex-flow: column nowrap;
+  max-height: calc(100vh - 70px);
+}
+
+.silk-report-sidebar-overview {
+  margin: 0.5rem;
+  flex-shrink: 0;
+  flex-grow: 0;
+}
+
+.silk-report-sidebar-tasks {
+  margin: 0.5rem;
+  flex-grow: 1;
+}
+
+.silk-report-sidebar-tasks-title {
+  flex-shrink: 0
+}
+
+.silk-report-sidebar-tasks-content {
+  overflow-y: auto
+}
+
 .silk-report-table {
   border: none;
   float: left;

--- a/silk-react-components/src/ExecutionReport/WorkflowExecutionReport.jsx
+++ b/silk-react-components/src/ExecutionReport/WorkflowExecutionReport.jsx
@@ -64,8 +64,8 @@ export default class WorkflowExecutionReport extends React.Component {
       }
 
       return  <div className="mdl-grid mdl-grid--no-spacing">
-                <div className="mdl-cell mdl-cell--2-col">
-                  <Card className="silk-report-card">
+                <div className="mdl-cell mdl-cell--2-col silk-report-sidebar">
+                  <Card className="silk-report-sidebar-overview">
                     <CardTitle>
                       Workflow
                     </CardTitle>
@@ -75,11 +75,11 @@ export default class WorkflowExecutionReport extends React.Component {
                       </ul>
                     </CardContent>
                   </Card>
-                  <Card className="silk-report-card">
-                    <CardTitle>
+                  <Card className="silk-report-sidebar-tasks">
+                    <CardTitle className="silk-report-sidebar-tasks-title">
                       Tasks
                     </CardTitle>
-                    <CardContent>
+                    <CardContent className="silk-report-sidebar-tasks-content">
                       <ul className="mdl-list">
                         { this.state.executionReport.taskReports.map((report, index) => this.renderTaskItem(report, index, report.warnings)) }
                       </ul>

--- a/silk-react-components/src/ExecutionReport/WorkflowExecutionReport.jsx
+++ b/silk-react-components/src/ExecutionReport/WorkflowExecutionReport.jsx
@@ -14,6 +14,11 @@ export default class WorkflowExecutionReport extends React.Component {
     this.displayName = 'WorkflowExecutionReport';
     this.state = {
       executionReport: {
+        summary: [],
+        warnings: [],
+        task: {
+          id: "workflow"
+        },
         taskReports: {}
       },
       selectedNode: null
@@ -39,8 +44,27 @@ export default class WorkflowExecutionReport extends React.Component {
         this.props.task,
         this.props.time)
         .then((report) => {
+          let executionReport = report.value;
+          executionReport.summary = [
+            {
+              key: "Started",
+              value: report.metaData.startedAt
+            },
+            {
+              key: "Finished",
+              value: report.metaData.finishedAt
+            },
+            {
+              key: "User",
+              value: (report.metaData.startedByUser == null) ? "Unknown" : report.metaData.startedByUser
+            },
+            {
+              key: "Final status",
+              value: report.metaData.finishStatus.message
+            }
+          ]
           this.setState({
-            executionReport: report.value
+            executionReport: executionReport,
           });
         })
         .catch((error) => {
@@ -57,6 +81,7 @@ export default class WorkflowExecutionReport extends React.Component {
                   </CardTitle>
                   <CardContent>
                     <ul className="mdl-list">
+                      { this.renderTaskItem(this.state.executionReport.task.id, this.state.executionReport) }
                       { Object.entries(this.state.executionReport.taskReports).map(e => this.renderTaskItem(e[0], e[1])) }
                     </ul>
                   </CardContent>
@@ -103,11 +128,10 @@ export default class WorkflowExecutionReport extends React.Component {
                               nodeId={nodeId}
                               executionReport={this.state.executionReport.taskReports[this.state.selectedNode]}/>
     } else {
-      return  <div className="silk-report-card mdl-card mdl-shadow--2dp mdl-card--stretch">
-                <div className="mdl-card__supporting-text">
-                  Select a task for detailed results.
-                </div>
-              </div>
+      return <ExecutionReport baseUrl={this.props.baseUrl}
+                              project={this.props.project}
+                              nodeId={this.state.executionReport.task.id}
+                              executionReport={this.state.executionReport}/>
     }
   }
 }

--- a/silk-react-components/src/ExecutionReport/WorkflowExecutionReport.jsx
+++ b/silk-react-components/src/ExecutionReport/WorkflowExecutionReport.jsx
@@ -67,11 +67,20 @@ export default class WorkflowExecutionReport extends React.Component {
                 <div className="mdl-cell mdl-cell--2-col">
                   <Card className="silk-report-card">
                     <CardTitle>
-                      Tasks
+                      Workflow
                     </CardTitle>
                     <CardContent>
                       <ul className="mdl-list">
                         { this.renderTaskItem(this.state.executionReport, -1, executionWarnings) }
+                      </ul>
+                    </CardContent>
+                  </Card>
+                  <Card className="silk-report-card">
+                    <CardTitle>
+                      Tasks
+                    </CardTitle>
+                    <CardContent>
+                      <ul className="mdl-list">
                         { this.state.executionReport.taskReports.map((report, index) => this.renderTaskItem(report, index, report.warnings)) }
                       </ul>
                     </CardContent>

--- a/silk-react-components/src/ExecutionReport/WorkflowExecutionReport.jsx
+++ b/silk-react-components/src/ExecutionReport/WorkflowExecutionReport.jsx
@@ -56,48 +56,55 @@ export default class WorkflowExecutionReport extends React.Component {
   }
 
   render() {
-    return  <div className="mdl-grid mdl-grid--no-spacing">
-              <div className="mdl-cell mdl-cell--2-col">
-                <Card className="silk-report-card">
-                  <CardTitle>
-                    Tasks
-                  </CardTitle>
-                  <CardContent>
-                    <ul className="mdl-list">
-                      { this.renderTaskItem(this.state.executionReport, -1) }
-                      { this.state.executionReport.taskReports.map((report, index) => this.renderTaskItem(report, index)) }
-                    </ul>
-                  </CardContent>
-                </Card>
+      let executionWarnings = [];
+      if(this.state.executionMetaData != null && this.state.executionMetaData.finishStatus.cancelled) {
+        executionWarnings = [ "Executed cancelled" ]
+      } else if(this.state.executionMetaData != null && this.state.executionMetaData.finishStatus.failed) {
+        executionWarnings = [ "Executed failed" ]
+      }
+
+      return  <div className="mdl-grid mdl-grid--no-spacing">
+                <div className="mdl-cell mdl-cell--2-col">
+                  <Card className="silk-report-card">
+                    <CardTitle>
+                      Tasks
+                    </CardTitle>
+                    <CardContent>
+                      <ul className="mdl-list">
+                        { this.renderTaskItem(this.state.executionReport, -1, executionWarnings) }
+                        { this.state.executionReport.taskReports.map((report, index) => this.renderTaskItem(report, index, report.warnings)) }
+                      </ul>
+                    </CardContent>
+                  </Card>
+                </div>
+                <div className="mdl-cell mdl-cell--10-col">
+                  { this.renderReport(this.state.executionReport.nodeId) }
+                </div>
               </div>
-              <div className="mdl-cell mdl-cell--10-col">
-                { this.renderReport(this.state.executionReport.nodeId) }
-              </div>
-            </div>
   }
 
-  renderTaskItem(report, index) {
+  renderTaskItem(report, index, warnings) {
     return <li key={"report-" + index} className="mdl-list__item mdl-list__item--two-line silk-report-list-item" onClick={() => this.setState({selectedIndex: index})} >
              <span className="mdl-list__item-primary-content">
                { report.label } { (report.operation != null) ? '(' + report.operation + ')' : ''}
-               { this.renderTaskDescription(report) }
+               { this.renderTaskDescription(warnings) }
              </span>
              <span className="mdl-list__item-secondary-content">
-               { this.renderTaskIcon(report) }
+               { this.renderTaskIcon(warnings) }
              </span>
            </li>
   }
 
-  renderTaskDescription(report) {
-    if(report.hasOwnProperty("warnings") && report.warnings.length > 0) {
-      return <span className="mdl-list__item-sub-title">{report.warnings.length} warnings</span>
+  renderTaskDescription(warnings) {
+    if(warnings != null && warnings.length > 0) {
+      return <span className="mdl-list__item-sub-title">{warnings.length} warnings</span>
     } else {
       return <span className="mdl-list__item-sub-title">no issues</span>
     }
   }
 
-  renderTaskIcon(report) {
-    if(report.hasOwnProperty("warnings") && report.warnings.length > 0) {
+  renderTaskIcon(warnings) {
+    if(warnings != null && warnings.length > 0) {
       return <Icon name="warning" className="silk-report-list-item-icon-red" />
     } else {
       return <Icon name="done" className="silk-report-list-item-icon-green" />
@@ -106,11 +113,13 @@ export default class WorkflowExecutionReport extends React.Component {
 
   renderReport(nodeId) {
     if(this.state.selectedIndex >= 0) {
+      // Render the report of the selected task
       return <ExecutionReport baseUrl={this.props.baseUrl}
                               project={this.props.project}
                               nodeId={nodeId}
                               executionReport={this.state.executionReport.taskReports[this.state.selectedIndex]}/>
     } else {
+      // Render the report of the workflow itself
       return <ExecutionReport baseUrl={this.props.baseUrl}
                               project={this.props.project}
                               nodeId={this.state.executionReport.task.id}

--- a/silk-react-components/src/ExecutionReport/WorkflowExecutionReport.jsx
+++ b/silk-react-components/src/ExecutionReport/WorkflowExecutionReport.jsx
@@ -79,7 +79,7 @@ export default class WorkflowExecutionReport extends React.Component {
   renderTaskItem(report, index) {
     return <li key={"report-" + index} className="mdl-list__item mdl-list__item--two-line silk-report-list-item" onClick={() => this.setState({selectedIndex: index})} >
              <span className="mdl-list__item-primary-content">
-               { report.label } { (report.task.id !== report.nodeId) ? '(' + report.nodeId + ')' : ''}
+               { report.label } { (report.operation != null) ? '(' + report.operation + ')' : ''}
                { this.renderTaskDescription(report) }
              </span>
              <span className="mdl-list__item-secondary-content">

--- a/silk-react-components/src/ExecutionReport/WorkflowExecutionReport.jsx
+++ b/silk-react-components/src/ExecutionReport/WorkflowExecutionReport.jsx
@@ -20,9 +20,9 @@ export default class WorkflowExecutionReport extends React.Component {
         task: {
           id: "workflow"
         },
-        taskReports: {}
+        taskReports: []
       },
-      selectedNode: null
+      selectedIndex: -1 // the index of the selected task report or -1 for the workflow itself
     };
   }
 
@@ -64,22 +64,22 @@ export default class WorkflowExecutionReport extends React.Component {
                   </CardTitle>
                   <CardContent>
                     <ul className="mdl-list">
-                      { this.renderTaskItem(this.state.executionReport.task.id, this.state.executionReport) }
-                      { Object.entries(this.state.executionReport.taskReports).map(e => this.renderTaskItem(e[0], e[1])) }
+                      { this.renderTaskItem(this.state.executionReport, -1) }
+                      { this.state.executionReport.taskReports.map((report, index) => this.renderTaskItem(report, index)) }
                     </ul>
                   </CardContent>
                 </Card>
               </div>
               <div className="mdl-cell mdl-cell--10-col">
-                { this.renderReport(this.state.selectedNode) }
+                { this.renderReport(this.state.executionReport.nodeId) }
               </div>
             </div>
   }
 
-  renderTaskItem(nodeId, report) {
-    return <li key={nodeId} className="mdl-list__item mdl-list__item--two-line silk-report-list-item" onClick={() => this.setState({selectedNode: nodeId})} >
+  renderTaskItem(report, index) {
+    return <li key={"report-" + index} className="mdl-list__item mdl-list__item--two-line silk-report-list-item" onClick={() => this.setState({selectedIndex: index})} >
              <span className="mdl-list__item-primary-content">
-               { report.label } { (report.task.id !== nodeId) ? '(' + nodeId + ')' : ''}
+               { report.label } { (report.task.id !== report.nodeId) ? '(' + report.nodeId + ')' : ''}
                { this.renderTaskDescription(report) }
              </span>
              <span className="mdl-list__item-secondary-content">
@@ -105,11 +105,11 @@ export default class WorkflowExecutionReport extends React.Component {
   }
 
   renderReport(nodeId) {
-    if(this.state.executionReport.taskReports.hasOwnProperty(this.state.selectedNode)) {
+    if(this.state.selectedIndex >= 0) {
       return <ExecutionReport baseUrl={this.props.baseUrl}
                               project={this.props.project}
                               nodeId={nodeId}
-                              executionReport={this.state.executionReport.taskReports[this.state.selectedNode]}/>
+                              executionReport={this.state.executionReport.taskReports[this.state.selectedIndex]}/>
     } else {
       return <ExecutionReport baseUrl={this.props.baseUrl}
                               project={this.props.project}

--- a/silk-react-components/src/ExecutionReport/WorkflowExecutionReport.jsx
+++ b/silk-react-components/src/ExecutionReport/WorkflowExecutionReport.jsx
@@ -13,6 +13,7 @@ export default class WorkflowExecutionReport extends React.Component {
     super(props);
     this.displayName = 'WorkflowExecutionReport';
     this.state = {
+      executionMetaData: null,
       executionReport: {
         summary: [],
         warnings: [],
@@ -44,27 +45,9 @@ export default class WorkflowExecutionReport extends React.Component {
         this.props.task,
         this.props.time)
         .then((report) => {
-          let executionReport = report.value;
-          executionReport.summary = [
-            {
-              key: "Started",
-              value: report.metaData.startedAt
-            },
-            {
-              key: "Finished",
-              value: report.metaData.finishedAt
-            },
-            {
-              key: "User",
-              value: (report.metaData.startedByUser == null) ? "Unknown" : report.metaData.startedByUser
-            },
-            {
-              key: "Final status",
-              value: report.metaData.finishStatus.message
-            }
-          ]
           this.setState({
-            executionReport: executionReport,
+            executionReport: report.value,
+            executionMetaData: report.metaData
           });
         })
         .catch((error) => {
@@ -131,7 +114,8 @@ export default class WorkflowExecutionReport extends React.Component {
       return <ExecutionReport baseUrl={this.props.baseUrl}
                               project={this.props.project}
                               nodeId={this.state.executionReport.task.id}
-                              executionReport={this.state.executionReport}/>
+                              executionReport={this.state.executionReport}
+                              executionMetaData={this.state.executionMetaData}/>
     }
   }
 }

--- a/silk-react-components/src/ExecutionReport/WorkflowReportManager.jsx
+++ b/silk-react-components/src/ExecutionReport/WorkflowReportManager.jsx
@@ -36,8 +36,8 @@ export default class WorkflowReportManager extends React.Component {
                     // Select the report provided in the props
                     selectedReport = this.props.report;
                 } else {
-                    // Select last (i.e., most recent) report
-                    selectedReport = reports[reports.length-1].time;
+                    // Select the first (i.e., most recent) report
+                    selectedReport = reports[0].time;
                 }
                 // Set initial state
                 this.setState({

--- a/silk-workbench/silk-workbench-workflow/app/controllers/workflow/WorkflowApi.scala
+++ b/silk-workbench/silk-workbench-workflow/app/controllers/workflow/WorkflowApi.scala
@@ -3,6 +3,7 @@ package controllers.workflow
 import controllers.core.{RequestUserContextAction, UserContextAction}
 import controllers.util.ProjectUtils._
 import controllers.util.SerializationUtils
+
 import javax.inject.Inject
 import org.silkframework.config.Task
 import org.silkframework.rule.execution.TransformReport
@@ -13,7 +14,7 @@ import org.silkframework.util.Identifier
 import org.silkframework.workbench.utils.UnsupportedMediaTypeException
 import org.silkframework.workbench.workflow.WorkflowWithPayloadExecutor
 import org.silkframework.workspace.WorkspaceFactory
-import org.silkframework.workspace.activity.workflow.{LocalWorkflowExecutorGeneratingProvenance, Workflow}
+import org.silkframework.workspace.activity.workflow.{LocalWorkflowExecutorGeneratingProvenance, Workflow, WorkflowTaskReport}
 import play.api.libs.json.{JsArray, JsString, _}
 import play.api.mvc.{Action, AnyContent, AnyContentAsXml, _}
 
@@ -81,7 +82,7 @@ class WorkflowApi @Inject() () extends InjectedController {
     lines :+= "Dataset;EntityCount;EntityErrorCount;Column;ColumnErrorCount"
 
     for {
-      (name, res: TransformReport) <- report.report.taskReports
+      WorkflowTaskReport(name, res: TransformReport) <- report.report.taskReports
       (column, RuleResult(count, _)) <- res.ruleResults
     } {
       lines :+= s"$name;${res.entityCounter};${res.entityErrorCounter};$column;$count"

--- a/silk-workbench/silk-workbench-workspace/app/controllers/workspaceApi/ReportsApi.scala
+++ b/silk-workbench/silk-workbench-workspace/app/controllers/workspaceApi/ReportsApi.scala
@@ -16,7 +16,7 @@ class ReportsApi @Inject() () extends InjectedController {
   def listReports(projectId: Option[String], taskId: Option[String]): Action[AnyContent] = Action(parse.json) {
     val reports = ExecutionReportManager().listReports(projectId.map(Identifier(_)), taskId.map(Identifier(_)))
     val jsonObjects =
-      for(report <- reports.sortBy(_.time)) yield {
+      for(report <- reports.sortBy(_.time)(Ordering[Instant].reverse)) yield {
         Json.obj(
           "project" -> report.projectId.toString,
           "task" -> report.taskId.toString,

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/activity/workflow/WorkflowExecutionReport.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/activity/workflow/WorkflowExecutionReport.scala
@@ -10,19 +10,33 @@ import org.silkframework.util.Identifier
   * @param task The workflow that was executed
   * @param taskReports A map from each workflow operator id to its corresponding report
   */
-case class WorkflowExecutionReport(task: Task[TaskSpec], taskReports: Map[Identifier, ExecutionReport] = Map.empty) extends ExecutionReport {
+case class WorkflowExecutionReport(task: Task[TaskSpec], taskReports: IndexedSeq[WorkflowTaskReport] = IndexedSeq.empty) extends ExecutionReport {
 
-  def withReport(nodeId: String, executionReport: ExecutionReport): WorkflowExecutionReport = {
-    copy(taskReports = taskReports + ((nodeId, executionReport)))
+  def withReport(index: Int, nodeId: Identifier, report: ExecutionReport): WorkflowExecutionReport = {
+    if(index < taskReports.size) {
+      copy(taskReports = taskReports.updated(index, WorkflowTaskReport(nodeId, report)))
+    } else if(index == taskReports.size) {
+      copy(taskReports = taskReports :+ WorkflowTaskReport(nodeId, report))
+    } else {
+      throw new IndexOutOfBoundsException(s"Invalid task report index: $index")
+    }
   }
 
   override def summary: Seq[(String, String)] = Seq.empty
 
   override def warnings: Seq[String] = {
-    if(taskReports.values.exists(_.warnings.nonEmpty)) {
+    if(taskReports.exists(_.report.warnings.nonEmpty)) {
       Seq("Some tasks generated warnings.")
     } else {
       Seq.empty
     }
   }
 }
+
+/**
+  * Report of a single workflow operator execution.
+  *
+  * @param nodeId The node identifier within the workflow
+  * @param report The execution report.
+  */
+case class WorkflowTaskReport(nodeId: Identifier, report: ExecutionReport)

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/activity/workflow/LocalWorkflowExecutorTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/activity/workflow/LocalWorkflowExecutorTest.scala
@@ -1,7 +1,6 @@
 package org.silkframework.workspace.activity.workflow
 
 import org.scalatest.{FlatSpec, Matchers}
-import org.silkframework.config.ConfigTest
 import org.silkframework.rule.execution.TransformReport
 import org.silkframework.util.ConfigTestTrait
 import org.silkframework.workspace.SingleProjectWorkspaceProviderTestTrait
@@ -33,7 +32,7 @@ class LocalWorkflowExecutorTest extends FlatSpec with Matchers with SingleProjec
     // Retrieve transform report
     val lastReport = executionMgr.retrieveReport(availableReports.last)
     val workflowReport = lastReport.resultValue.get.asInstanceOf[WorkflowExecutionReport]
-    val transformReport = workflowReport.taskReports("transform").asInstanceOf[TransformReport]
+    val transformReport = workflowReport.taskReports.find(_.nodeId.toString == "transform").get.report.asInstanceOf[TransformReport]
 
     // Check if expected errors have been recorded
     transformReport.ruleResults("uri").errorCount shouldBe 1


### PR DESCRIPTION
- Improvements to execution reports (CMEM-3383)
  - Added an overview section, which displays general information about the execution:
      - Final workflow status
      - Start, finish and cancellation times
      - Users account which started and canceled (if any) the execution
  - All operator executions are persisted. For instance, workflow reports will contain separate task reports for writing and reading a dataset.
  - For each operator execution, an optional operation label can be shown (e.g., read, write, generate queries). 
  - The order of the task reports is stable now and reflects the order of execution.
  - Added a scrollbar to the task list, if it is too large to be displayed.
