### PR TITLE
Improve workflow saving

### DIFF
--- a/silk-react-components/silk-workbench/silk-workbench-workflow/public/editor/editor.js
+++ b/silk-react-components/silk-workbench/silk-workbench-workflow/public/editor/editor.js
@@ -343,5 +343,7 @@ $(function() {
         editor = new WorkflowEditor();
         // Load workflow from backend
         editor.loadWorkflow();
+        // Enable the save button only after the workflow has been loaded
+        $('#saveButton').removeAttr("disabled");
     });
 });

--- a/silk-react-components/silk-workbench/silk-workbench-workflow/public/editor/serializeWorkflow.js
+++ b/silk-react-components/silk-workbench/silk-workbench-workflow/public/editor/serializeWorkflow.js
@@ -3,6 +3,11 @@
 silk-workbench/silk-workbench-workflow/app/views/workflow/editor/editor.scala.html
  */
 function commitWorkflow() {
+    const saveSpinner = $('#saveSpinner');
+    const saveButton = $('#saveButton');
+    saveSpinner.show();
+    saveButton.attr("disabled", true);
+
     $.ajax({
         type: 'PUT',
         url: apiUrl,
@@ -10,9 +15,13 @@ function commitWorkflow() {
         processData: false,
         data: serializeWorkflow(),
         success() {
+            saveSpinner.hide();
+            saveButton.removeAttr("disabled");
             notifyParentWindow();
         },
         error(req) {
+            saveSpinner.hide();
+            saveButton.removeAttr("disabled");
             alert(`Error committing workflow to backend: ${req.responseText}`);
         },
     });

--- a/silk-react-components/silk-workbench/silk-workbench-workflow/public/editor/serializeWorkflow.js
+++ b/silk-react-components/silk-workbench/silk-workbench-workflow/public/editor/serializeWorkflow.js
@@ -1,13 +1,15 @@
-// Commit workflow xml to backend
-/* exported commitWorkflow
-silk-workbench/silk-workbench-workflow/app/views/workflow/editor/editor.scala.html
- */
-function commitWorkflow() {
-    const saveSpinner = $('#saveSpinner');
-    const saveButton = $('#saveButton');
-    saveSpinner.show();
-    saveButton.attr("disabled", true);
+// Warn the user when he leaves the editor while the workflow is still being saved
+window.onbeforeunload = confirmExit;
 
+// True, while the workflow is being saved
+let saveInProgress = false
+
+// True, if window has been unloaded
+let windowUnloaded = false
+
+// Commit workflow xml to backend
+function commitWorkflow() {
+    savingStarted();
     $.ajax({
         type: 'PUT',
         url: apiUrl,
@@ -15,16 +17,35 @@ function commitWorkflow() {
         processData: false,
         data: serializeWorkflow(),
         success() {
-            saveSpinner.hide();
-            saveButton.removeAttr("disabled");
+            savingStopped();
             notifyParentWindow();
         },
         error(req) {
-            saveSpinner.hide();
-            saveButton.removeAttr("disabled");
-            alert(`Error committing workflow to backend: ${req.responseText}`);
+            if(!windowUnloaded) {
+                savingStopped();
+                alert(`Error committing workflow to backend: ${req.responseText}`);
+            }
         },
     });
+}
+
+function confirmExit() {
+    windowUnloaded = true;
+    if (saveInProgress) {
+        return 'The workflow is still being saved.';
+    }
+}
+
+function savingStarted() {
+    saveInProgress = true;
+    $('#saveSpinner').show();
+    $('#saveButton').attr("disabled", true);
+}
+
+function savingStopped() {
+    $('#saveSpinner').hide();
+    $('#saveButton').removeAttr("disabled");
+    saveInProgress = false;
 }
 
 // Send a message event that the workflow has been saved

--- a/silk-workbench/silk-workbench-workflow/app/views/workflow/editor/editor.scala.html
+++ b/silk-workbench/silk-workbench-workflow/app/views/workflow/editor/editor.scala.html
@@ -26,7 +26,7 @@
 @toolbar = {
 <ul>
   <li>
-    <button id="saveButton" class="mdl-button mdl-js-button mdl-button--raised" onclick="commitWorkflow()" >Save</button>
+    <button id="saveButton" class="mdl-button mdl-js-button mdl-button--raised" onclick="commitWorkflow()" disabled="disabled" >Save</button>
   </li>
   <li style="width: 20px">
     <div id="saveSpinner" class="mdl-spinner mdl-js-spinner is-active" style="display: none"></div>

--- a/silk-workbench/silk-workbench-workflow/app/views/workflow/editor/editor.scala.html
+++ b/silk-workbench/silk-workbench-workflow/app/views/workflow/editor/editor.scala.html
@@ -26,10 +26,10 @@
 @toolbar = {
 <ul>
   <li>
-    <button class="mdl-button mdl-js-button mdl-button--raised" onclick="commitWorkflow()" >Save</button>
+    <button id="saveButton" class="mdl-button mdl-js-button mdl-button--raised" onclick="commitWorkflow()" >Save</button>
   </li>
-  <li>
-    <div class="spacer"/>
+  <li style="width: 20px">
+    <div id="saveSpinner" class="mdl-spinner mdl-js-spinner is-active" style="display: none"></div>
   </li>
   <li>
     @taskActivityControl(context.task.activity(WorkflowConfig.executorName), showButtons = true)


### PR DESCRIPTION
 - On loading, the save button is only enabled after the workflow has been loaded to prevent the user from saving an empty workflow.
  - A spinner is shown while the workflow is saved.
  - The save button is disabled while the workflow is saved.
  - A confirm dialog is shown, if the user tries to leave while a save is in progress.