### PR TITLE
Use latest OpenJDK 8 jre for Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN \
   mkdir -p /build/app \
   && tar -xvzf /build/silk-workbench/target/universal/silk-workbench*.tgz -C /build/app
 
-FROM openjdk:8u151-jre
+FROM openjdk:8-jre
 ENV \
   SILK_HOME="/opt/silk" \
   WORKDIR="/opt/silk/workspace" \

--- a/README.md
+++ b/README.md
@@ -38,7 +38,12 @@ Downloading and installing sbt is not necessary as it is available from this dir
 ## Running the Silk Workbench as docker container
 
 - Build or pull the latest docker image:
-  - Build the docker image with: `docker build -t silkframework/silk-workbench:latest .` (This maybe take some minutes)
+  - Build the docker image with:
+    ```
+    sbt universal:packageZipTarball
+    docker build -t silkframework/silk-workbench:latest .
+    ```
+    (This maybe take some minutes)
   - Pull the docker image via: docker pull silkframework/silk-workbench
 - Run the docker container with: `docker run -d --name silk-workbench -p 80:80 silkframework/silk-workbench:latest`
 - In your browser, navigate to 'http://DOCKER_HOST:80'


### PR DESCRIPTION
- Use latest OpenJDK jre for Docker image
- Improve README regarding building the Docker image