### PR TITLE
Fix dependent tasks recursion 

### DIFF
--- a/silk-core/src/main/scala/org/silkframework/config/Task.scala
+++ b/silk-core/src/main/scala/org/silkframework/config/Task.scala
@@ -38,8 +38,9 @@ trait Task[+TaskType <: TaskSpec] {
     * Finds all tasks that reference this task.
     *
     * @param recursive Whether to return tasks that indirectly refer to this task.
+    * @param ignoreTasks Set of tasks to be ignored in the dependency search.
     */
-  def findDependentTasks(recursive: Boolean)
+  def findDependentTasks(recursive: Boolean, ignoreTasks: Set[Identifier] = Set.empty)
                         (implicit userContext: UserContext): Set[Identifier] = Set.empty
 
   /** Find tasks that are either input or output to this task. */

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/CircularDependencyException.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/CircularDependencyException.scala
@@ -3,7 +3,7 @@ package org.silkframework.workspace
 import org.silkframework.runtime.validation.ValidationException
 
 /**
-  * Throw if a task is created/updated that would create a circular dependency.
+  * Thrown if a task is created/updated that would create a circular dependency.
   *
   * @param circularTaskChain The labels of the tasks in the circular chain.
   */

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/CircularDependencyException.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/CircularDependencyException.scala
@@ -1,0 +1,11 @@
+package org.silkframework.workspace
+
+import org.silkframework.runtime.validation.ValidationException
+
+/**
+  * Throw if a task is created/updated that would create a circular dependency.
+  *
+  * @param circularTaskChain The labels of the tasks in the circular chain.
+  */
+case class CircularDependencyException(circularTaskChain: Seq[String])
+  extends ValidationException(s"Task contains a circular dependency: ${circularTaskChain.mkString("'", "'->'", "'")}.")

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/Module.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/Module.scala
@@ -63,7 +63,7 @@ class Module[TaskData <: TaskSpec: ClassTag](private[workspace] val provider: Wo
   def task(name: Identifier)
           (implicit userContext: UserContext): ProjectTask[TaskData] = {
     load()
-    cachedTasks.getOrElse(name, throw TaskNotFoundException(project.name, name, taskType.getName))
+    cachedTasks.getOrElse(name, throw TaskNotFoundException(project.name, name, taskType.getSimpleName))
   }
 
   def taskOption(name: Identifier)

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/Project.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/Project.scala
@@ -14,13 +14,10 @@
 
 package org.silkframework.workspace
 
-import java.util.logging.{Level, Logger}
-
 import org.silkframework.config._
 import org.silkframework.dataset.{Dataset, DatasetSpec}
 import org.silkframework.rule.{LinkSpec, TransformSpec}
-import org.silkframework.runtime.activity.HasValue
-import org.silkframework.runtime.activity.UserContext
+import org.silkframework.runtime.activity.{HasValue, UserContext}
 import org.silkframework.runtime.plugin.PluginRegistry
 import org.silkframework.runtime.resource.ResourceManager
 import org.silkframework.runtime.validation.{NotFoundException, ValidationException}
@@ -28,6 +25,8 @@ import org.silkframework.util.Identifier
 import org.silkframework.workspace.activity.workflow.Workflow
 import org.silkframework.workspace.activity.{ProjectActivity, ProjectActivityFactory}
 
+import java.util.logging.{Level, Logger}
+import scala.collection.immutable.ListMap
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
@@ -212,6 +211,7 @@ class Project(initialConfig: ProjectConfig, provider: WorkspaceProvider, val res
     if(allTasks.exists(_.id == name)) {
       throw IdentifierAlreadyExistsException(s"Task name '$name' is not unique as there is already a task in project '${this.name}' with this name.")
     }
+    checkForRecursion(name, taskData, metaData)
     module[T].add(name, taskData, metaData.asNewMetaData)
     provider.removeExternalTaskLoadingError(config.id, name)
   }
@@ -227,6 +227,7 @@ class Project(initialConfig: ProjectConfig, provider: WorkspaceProvider, val res
     if(allTasks.exists(_.id == name)) {
       throw IdentifierAlreadyExistsException(s"Task name '$name' is not unique as there is already a task in project '${this.name}' with this name.")
     }
+    checkForRecursion(name, taskData, metaData)
     modules.find(_.taskType.isAssignableFrom(taskData.getClass)) match {
       case Some(module) => module.asInstanceOf[Module[TaskSpec]].add(name, taskData, metaData.asNewMetaData)
       case None => throw new NoSuchElementException(s"No module for task type ${taskData.getClass} has been registered. Registered task types: ${modules.map(_.taskType).mkString(";")}")
@@ -247,6 +248,7 @@ class Project(initialConfig: ProjectConfig, provider: WorkspaceProvider, val res
     module[T].taskOption(name) match {
       case Some(task) =>
         val mergedMetaData = mergeMetaData(task.metaData, metaData)
+        checkForRecursion(name, taskData, mergedMetaData)
         task.update(taskData, Some(mergedMetaData.asUpdatedMetaData))
       case None =>
         addTask[T](name, taskData, metaData.getOrElse(MetaData(MetaData.labelFromId(name))).asNewMetaData)
@@ -274,6 +276,7 @@ class Project(initialConfig: ProjectConfig, provider: WorkspaceProvider, val res
         module.taskOption(name) match {
           case Some(task) =>
             val mergedMetaData = mergeMetaData(task.metaData, metaData)
+            checkForRecursion(name, taskData, mergedMetaData)
             task.asInstanceOf[ProjectTask[TaskSpec]].update(taskData, Some(mergedMetaData.asUpdatedMetaData))
           case None =>
             addAnyTask(name, taskData, metaData.getOrElse(MetaData.empty).asNewMetaData)
@@ -321,6 +324,29 @@ class Project(initialConfig: ProjectConfig, provider: WorkspaceProvider, val res
     // Find the module which holds the named task and remove it
     for(m <- modules.find(_.taskOption(taskName).isDefined)) {
       m.remove(taskName)
+    }
+  }
+
+  /**
+    * Checks if task references to a new task would create a circular chain of dependencies.
+    *
+    * @param referencingTaskChain The chain of tasks that reference this task.
+    * @throws CircularDependencyException If a circular dependency has been found.
+    */
+  def checkForRecursion(id: Identifier, task: TaskSpec, metaData: MetaData, referencingTaskChain: ListMap[Identifier, (TaskSpec, MetaData)] = ListMap.empty)
+                       (implicit userContext: UserContext): Unit = {
+    if(referencingTaskChain.contains(id)) {
+      val taskChain = referencingTaskChain.keys.toSeq :+ id
+      val taskLabels = taskChain.map(id => referencingTaskChain(id)._2.formattedLabel(id))
+      throw CircularDependencyException(taskLabels)
+    } else {
+      val updatedTaskChain = referencingTaskChain + (id -> (task, metaData))
+      for {
+        refTaskId <- task.referencedTasks
+        (refTask, refMetaData) <- referencingTaskChain.get(refTaskId).orElse(anyTaskOption(refTaskId).map(t => (t.data, t.metaData)))
+      } {
+        checkForRecursion(refTaskId, refTask, refMetaData, updatedTaskChain)
+      }
     }
   }
 

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/ProjectTask.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/ProjectTask.scala
@@ -178,15 +178,16 @@ class ProjectTask[TaskType <: TaskSpec : ClassTag](val id: Identifier,
     * Finds all project tasks that reference this task.
     *
     * @param recursive Whether to return tasks that indirectly refer to this task.
+    * @param ignoreTasks Set of tasks to be ignored in the dependency search.
     */
-  override def findDependentTasks(recursive: Boolean)
+  override def findDependentTasks(recursive: Boolean, ignoreTasks: Set[Identifier] = Set.empty)
                                  (implicit userContext: UserContext): Set[Identifier] = {
     // Find all tasks that reference this task
-    val dependentTasks = project.allTasks.filter(_.data.referencedTasks.contains(id))
+    val dependentTasks = project.allTasks.filter(t => !ignoreTasks.contains(t.id) && t.data.referencedTasks.contains(id))
 
     var allDependentTaskIds = dependentTasks.map(_.id)
     if(recursive) {
-      allDependentTaskIds ++= dependentTasks.flatMap(_.findDependentTasks(true))
+      allDependentTaskIds ++= dependentTasks.flatMap(_.findDependentTasks(recursive = true, ignoreTasks + id))
     }
     allDependentTaskIds.distinct.toSet
   }

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/ProjectTaskTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/ProjectTaskTest.scala
@@ -1,0 +1,40 @@
+package org.silkframework.workspace
+
+import org.scalatest.{FlatSpec, Matchers}
+import org.silkframework.rule.{DatasetSelection, TransformSpec}
+import org.silkframework.runtime.activity.TestUserContextTrait
+
+class ProjectTaskTest extends FlatSpec with Matchers with TestWorkspaceProviderTestTrait with TestUserContextTrait {
+
+  behavior of "ProjectTask"
+
+  it should "not allow circular dependencies" in {
+    val project = retrieveOrCreateProject("TestProject")
+
+    // Three tasks that create a forbidden circular dependency
+    val transform1 = TransformSpec(selection = DatasetSelection("transform2"))
+    val transform2 = TransformSpec(selection = DatasetSelection("transform3"))
+    val transform3 = TransformSpec(selection = DatasetSelection("transform1"))
+
+    // Adding the first two tasks is fine
+    project.addTask("transform1", transform1)
+    project.addTask("transform2", transform2)
+
+    // Try to add a task that would create a circular dependency
+    val thrown1 = the[CircularDependencyException] thrownBy project.addTask("transform3", transform3)
+    thrown1.circularTaskChain shouldBe Seq("transform3", "transform1", "transform2", "transform3")
+
+    val thrown2 = the[CircularDependencyException] thrownBy project.addAnyTask("transform3", transform3)
+    thrown2.circularTaskChain shouldBe Seq("transform3", "transform1", "transform2", "transform3")
+
+    // Try to update a task that would create a circular dependency
+    val thrown3 = the[CircularDependencyException] thrownBy project.updateTask("transform2", transform3)
+    thrown3.circularTaskChain shouldBe Seq("transform2", "transform1", "transform2")
+
+    val thrown4 = the[CircularDependencyException] thrownBy project.updateAnyTask("transform2", transform3)
+    thrown4.circularTaskChain shouldBe Seq("transform2", "transform1", "transform2")
+  }
+
+  override def workspaceProviderId: String = "inMemory"
+
+}

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/ProjectTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/ProjectTest.scala
@@ -4,12 +4,12 @@ import org.scalatest.{FlatSpec, Matchers}
 import org.silkframework.rule.{DatasetSelection, TransformSpec}
 import org.silkframework.runtime.activity.TestUserContextTrait
 
-class ProjectTaskTest extends FlatSpec with Matchers with TestWorkspaceProviderTestTrait with TestUserContextTrait {
+class ProjectTest extends FlatSpec with Matchers with TestWorkspaceProviderTestTrait with TestUserContextTrait {
 
-  behavior of "ProjectTask"
+  behavior of "Project"
 
-  it should "not allow circular dependencies" in {
-    val project = retrieveOrCreateProject("TestProject")
+  it should "not allow circular dependencies between tasks" in {
+    val project = retrieveOrCreateProject("CircularDependencyTest")
 
     // Three tasks that create a forbidden circular dependency
     val transform1 = TransformSpec(selection = DatasetSelection("transform2"))
@@ -33,6 +33,13 @@ class ProjectTaskTest extends FlatSpec with Matchers with TestWorkspaceProviderT
 
     val thrown4 = the[CircularDependencyException] thrownBy project.updateAnyTask("transform2", transform3)
     thrown4.circularTaskChain shouldBe Seq("transform2", "transform1", "transform2")
+  }
+
+  it should "not allow that a task references itself" in {
+    val project = retrieveOrCreateProject("SelfReferenceTest")
+    val transform1 = TransformSpec(selection = DatasetSelection("transform1"))
+    val thrown1 = the[CircularDependencyException] thrownBy project.addTask("transform1", transform1)
+    thrown1.circularTaskChain shouldBe Seq("transform1", "transform1")
   }
 
   override def workspaceProviderId: String = "inMemory"


### PR DESCRIPTION
- Fixed infinite recursion if there are circular references in between tasks.
- Do not allow adding or updating tasks that would create a new circular dependency.