### PR TITLE
Allow literals as entities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,8 @@ lazy val commonSettings = Seq(
     case other =>
       val oldStrategy = (assembly / assemblyMergeStrategy).value
       oldStrategy(other)
-  }
+  },
+  javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
 )
 
 //////////////////////////////////////////////////////////////////////////////
@@ -100,7 +101,8 @@ lazy val core = (project in file("silk-core"))
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
     libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1",
     libraryDependencies += "commons-io" % "commons-io" % "2.4",
-    libraryDependencies += "org.lz4" % "lz4-java" % "1.4.0"
+    libraryDependencies += "org.lz4" % "lz4-java" % "1.4.0",
+    libraryDependencies += "javax.xml.bind" % "jaxb-api" % "2.3.1"
   )
 
 lazy val rules = (project in file("silk-rules"))

--- a/silk-core/src/main/scala/org/silkframework/dataset/rdf/RdfDataset.scala
+++ b/silk-core/src/main/scala/org/silkframework/dataset/rdf/RdfDataset.scala
@@ -1,7 +1,8 @@
 package org.silkframework.dataset.rdf
 
-import org.silkframework.dataset.DatasetCharacteristics.SupportedPathExpressions
-import org.silkframework.dataset.{DatasetCharacteristics, Dataset}
+import org.silkframework.dataset.DatasetCharacteristics.{SpecialPathInfo, SupportedPathExpressions}
+import org.silkframework.dataset.{Dataset, DatasetCharacteristics}
+import org.silkframework.entity.rdf.SparqlEntitySchema.specialPaths
 
 trait RdfDataset extends Dataset {
 
@@ -19,7 +20,11 @@ trait RdfDataset extends Dataset {
         multiHopPaths = true,
         backwardPaths = true,
         propertyFilter = true,
-        languageFilter = true
+        languageFilter = true,
+        specialPaths = Seq(
+          SpecialPathInfo(specialPaths.LANG, Some("Returns the language tag of a language-tagged literal.")),
+          SpecialPathInfo(specialPaths.TEXT, Some("Returns the lexical value of the resource or literal this is requested from."))
+        )
       )
     )
   }

--- a/silk-core/src/main/scala/org/silkframework/entity/rdf/SparqlEntitySchema.scala
+++ b/silk-core/src/main/scala/org/silkframework/entity/rdf/SparqlEntitySchema.scala
@@ -16,7 +16,7 @@ package org.silkframework.entity.rdf
 
 import org.silkframework.config.Prefixes
 import org.silkframework.entity.EntitySchema
-import org.silkframework.entity.paths.UntypedPath
+import org.silkframework.entity.paths.{Path, TypedPath, UntypedPath}
 import org.silkframework.runtime.serialization.{ReadContext, WriteContext, XmlFormat}
 import org.silkframework.util.Uri
 
@@ -109,5 +109,15 @@ object SparqlEntitySchema {
           }
         </Paths>
       </EntityDescription>
+  }
+
+  object specialPaths {
+    // Returns the lexical value of the resource/literal this is requested from, e.g. when using a literal for an object mapping.
+    final val TEXT = "#text"
+    // Special path to request the language tag of a literal when the literal is used as the subject of an entity retrieval request.
+    final val LANG = "#lang"
+
+    def isLangSpecialPath(typedPath: Path): Boolean = typedPath.serialize(stripForwardSlash = false).endsWith(s"/$LANG")
+    def isTextSpecialPath(typedPath: Path): Boolean = typedPath.serialize(stripForwardSlash = false).endsWith(s"/$TEXT")
   }
 }

--- a/silk-core/src/main/scala/org/silkframework/util/StreamUtils.scala
+++ b/silk-core/src/main/scala/org/silkframework/util/StreamUtils.scala
@@ -1,7 +1,7 @@
 package org.silkframework.util
 
 import java.io.{IOException, InputStream, OutputStream}
-import java.nio.ByteBuffer
+import java.nio.{Buffer, ByteBuffer}
 import java.nio.channels.{ReadableByteChannel, WritableByteChannel}
 import java.nio.channels.Channels
 
@@ -14,7 +14,8 @@ object StreamUtils {
   def fastChannelCopy(src: ReadableByteChannel, dest: WritableByteChannel): Unit = {
     val buffer = ByteBuffer.allocateDirect(16 * 1024)
     while (src.read(buffer) != -1) { // prepare the buffer to be drained
-      buffer.flip
+      // Casting to Buffer to avoid conflict mentioned here: https://stackoverflow.com/questions/61267495/exception-in-thread-main-java-lang-nosuchmethoderror-java-nio-bytebuffer-flip
+      buffer.asInstanceOf[Buffer].flip()
       // write to the channel, may block
       dest.write(buffer)
       // If partial transfer, shift remainder down
@@ -22,7 +23,8 @@ object StreamUtils {
       buffer.compact
     }
     // EOF will leave buffer in fill state
-    buffer.flip
+    // Casting to Buffer to avoid conflict mentioned here: https://stackoverflow.com/questions/61267495/exception-in-thread-main-java-lang-nosuchmethoderror-java-nio-bytebuffer-flip
+    buffer.asInstanceOf[Buffer].flip()
     // make sure the buffer is fully drained.
     while (buffer.hasRemaining) {
       dest.write(buffer)

--- a/silk-plugins/silk-persistent-caching/src/main/scala/org/silkframework/runtime/caching/PersistentSortedKeyValueStore.scala
+++ b/silk-plugins/silk-persistent-caching/src/main/scala/org/silkframework/runtime/caching/PersistentSortedKeyValueStore.scala
@@ -9,7 +9,7 @@ import org.silkframework.util.FileUtils.toFileUtils
 import org.silkframework.util.Identifier
 
 import java.io.{File, IOException}
-import java.nio.ByteBuffer
+import java.nio.{Buffer, ByteBuffer}
 import java.nio.ByteBuffer.allocateDirect
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
@@ -97,7 +97,8 @@ case class PersistentSortedKeyValueStore(databaseId: Identifier,
     } else {
       keyBuffer.put(Array(Byte.MinValue)) // TODO: How to better handle empty strings? An empty byte buffer evokes an error being raised later on.
     }
-    keyBuffer.flip()
+    // Casting to Buffer to avoid conflict mentioned here: https://stackoverflow.com/questions/61267495/exception-in-thread-main-java-lang-nosuchmethoderror-java-nio-bytebuffer-flip
+    keyBuffer.asInstanceOf[Buffer].flip()
     keyBuffer
   }
 
@@ -114,7 +115,8 @@ case class PersistentSortedKeyValueStore(databaseId: Identifier,
       valueBytes = CompressionHelper.lz4Compress(valueBytes, addLengthPreamble = true)
     }
     val valueBuffer = allocateDirect(valueBytes.length)
-    valueBuffer.put(valueBytes).flip()
+    // Casting to Buffer to avoid conflict mentioned here: https://stackoverflow.com/questions/61267495/exception-in-thread-main-java-lang-nosuchmethoderror-java-nio-bytebuffer-flip
+    valueBuffer.put(valueBytes).asInstanceOf[Buffer].flip()
     valueBuffer
   }
 

--- a/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/sparql/ParallelEntityRetriever.scala
+++ b/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/sparql/ParallelEntityRetriever.scala
@@ -14,16 +14,17 @@
 
 package org.silkframework.plugins.dataset.rdf.sparql
 
-import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
-import java.util.logging.{Level, Logger}
-
-import org.silkframework.dataset.rdf.{RdfNode, Resource, SparqlEndpoint, SparqlResults}
+import org.silkframework.dataset.rdf._
 import org.silkframework.entity.paths.UntypedPath
+import org.silkframework.entity.rdf.SparqlEntitySchema.specialPaths
 import org.silkframework.entity.rdf.{SparqlEntitySchema, SparqlPathBuilder, SparqlRestriction}
 import org.silkframework.entity.{Entity, EntitySchema}
 import org.silkframework.plugins.dataset.rdf.sparql.ParallelEntityRetriever.{ExceptionPathValues, ExistingPathValues, PathValues, QueueEndMarker}
 import org.silkframework.runtime.activity.UserContext
 import org.silkframework.util.Uri
+
+import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
+import java.util.logging.{Level, Logger}
 
 /**
  * EntityRetriever which executes multiple SPARQL queries (one for each property path) in parallel and merges the results into single entities.
@@ -173,10 +174,15 @@ class ParallelEntityRetriever(endpoint: SparqlEndpoint,
 
     private val QUEUE_OFFER_TIMEOUT = 3600 // 1 hour, just a high number
     private def queueElement(pathValues: PathValues): Boolean = queue.offer(pathValues, QUEUE_OFFER_TIMEOUT, TimeUnit.SECONDS)
+    private val isSpecialLangPath = specialPaths.isLangSpecialPath(path)
+    private val isSpecialTextPath = specialPaths.isTextSpecialPath(path)
 
     private def parseResults(sparqlResults: Traversable[Map[String, RdfNode]]): Unit = {
       var currentSubject: Option[String] = None
       var currentValues: Seq[String] = Seq.empty
+      def addCurrentValue(value: String): Unit = {
+        currentValues = currentValues :+ value
+      }
 
       for (result <- sparqlResults) {
         if (canceled) {
@@ -184,10 +190,7 @@ class ParallelEntityRetriever(endpoint: SparqlEndpoint,
         }
 
         //Check if we are still reading values for the current subject
-        val subject = result.get(entityDesc.variable) match {
-          case Some(Resource(value)) => Some(value)
-          case _ => None
-        }
+        val subject = EntityRetriever.extractSubject(result, entityDesc.variable)
 
         if (currentSubject.isEmpty) {
           currentSubject = subject
@@ -199,9 +202,7 @@ class ParallelEntityRetriever(endpoint: SparqlEndpoint,
         }
 
         if (currentSubject.isDefined) {
-          for (node <- result.get(varPrefix + "0")) {
-            currentValues = currentValues :+ node.value
-          }
+          addValues(addCurrentValue, result)
         }
       }
 
@@ -209,6 +210,40 @@ class ParallelEntityRetriever(endpoint: SparqlEndpoint,
         queueElement(ExistingPathValues(s, currentValues))
       }
       queueElement(QueueEndMarker)
+    }
+
+    // Adds the requested values via the given add function.
+    private def addValues(addCurrentValue: String => Unit,
+                          result: Map[String, RdfNode]): Unit = {
+      if(path.size == 1 && (isSpecialTextPath || isSpecialLangPath)) {
+        // If the path is only a special path itself it must be evaluated against the subject
+        result.get(entityDesc.variable) match {
+          case Some(LanguageLiteral(_, lang)) if isSpecialLangPath =>
+            addCurrentValue(lang)
+          case Some(rdfNode) =>
+            addCurrentValue(rdfNode.value)
+          case _ =>
+        }
+      } else {
+        // Else the value variable contains the value
+        for (node <- result.get(varPrefix + "0")) {
+          if (isSpecialLangPath) {
+            addLangTagValue(addCurrentValue, node)
+          } else {
+            addCurrentValue(node.value)
+          }
+        }
+      }
+    }
+
+    private def addLangTagValue(addCurrentValue: String => Unit,
+                                node: RdfNode): Unit = {
+      node match {
+        case LanguageLiteral(_, langTag) =>
+          addCurrentValue(langTag)
+        case _ =>
+        // node has no lang tag, do not append anything
+      }
     }
   }
 }

--- a/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/sparql/SimpleEntityRetriever.scala
+++ b/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/sparql/SimpleEntityRetriever.scala
@@ -15,12 +15,13 @@
 package org.silkframework.plugins.dataset.rdf.sparql
 
 import java.util.logging.Logger
-
-import org.silkframework.dataset.rdf.{RdfNode, Resource, SparqlEndpoint}
+import org.silkframework.dataset.rdf.{LanguageLiteral, RdfNode, Resource, SparqlEndpoint}
 import org.silkframework.entity.rdf.{SparqlEntitySchema, SparqlPathBuilder}
 import org.silkframework.entity.{Entity, EntitySchema}
 import org.silkframework.runtime.activity.UserContext
 import org.silkframework.util.Uri
+
+import scala.collection.SortedMap
 
 /**
  * EntityRetriever which executes a single SPARQL query to retrieve the entities.
@@ -58,7 +59,7 @@ class SimpleEntityRetriever(endpoint: SparqlEndpoint,
 
     val sparqlResults = endpoint.select(sparqlQuery, limit.getOrElse(Int.MaxValue))
 
-    new EntityTraversable(sparqlResults.bindings, entitySchema, None, limit, sparqlEntitySchema)
+    new EntityTraversable(sparqlResults.bindings, entitySchema, limit, sparqlEntitySchema)
   }
 
   def buildSparqlQuery(sparqlEntitySchema: SparqlEntitySchema, useDistinct: Boolean): String = {
@@ -120,12 +121,64 @@ class SimpleEntityRetriever(endpoint: SparqlEndpoint,
    */
   private class EntityTraversable(sparqlResults: Traversable[Map[String, RdfNode]],
                                   entitySchema: EntitySchema,
-                                  subject: Option[Uri],
                                   limit: Option[Int],
                                   sparqlEntitySchema: SparqlEntitySchema) extends Traversable[Entity] {
+    // If path with a specific index is a language tag special path, also validates the special paths usage
+    private val specialPathMap: Map[Int, (Boolean, Boolean)] = {
+      entitySchema.typedPaths.zipWithIndex.map { case (typedPath, idx) =>
+        val isLangSpecialPath = SparqlEntitySchema.specialPaths.isLangSpecialPath(typedPath)
+        val isTextSpecialPath = SparqlEntitySchema.specialPaths.isTextSpecialPath(typedPath)
+        (idx, (isLangSpecialPath, isTextSpecialPath))
+      }.toMap
+    }
+
+    private def isLangSpecialPath(pathIdx: Int): Boolean = {
+      specialPathMap.get(pathIdx).exists(_._1)
+    }
+
+    private def isTextSpecialPath(pathIdx: Int): Boolean = {
+      specialPathMap.get(pathIdx).exists(_._2)
+    }
+
+    private val specialPathOnlyMap: Map[Int, Boolean] = {
+      entitySchema.typedPaths.zipWithIndex.map { case (typedPath, idx) =>
+        val isSpecialPathOnly = typedPath.size == 1 && (isTextSpecialPath(idx) || isLangSpecialPath(idx))
+        (idx, isSpecialPathOnly)
+      }.toMap
+    }
+
+    private def isSpecialPathOnly(pathIdx: Int): Boolean = {
+      specialPathOnlyMap.getOrElse(pathIdx, false)
+    }
+
+    private def extractSpecialPathValue(pathIdx: Int, subject: RdfNode): String = {
+      subject match {
+        case LanguageLiteral(_, lang) if isLangSpecialPath(pathIdx) =>
+          lang
+        case rdfNode: RdfNode =>
+          rdfNode.value
+      }
+    }
+
+    private def variableValue(pathIdx: Int,
+                              valueNode: RdfNode): Option[String] = {
+      if (isLangSpecialPath(pathIdx)) {
+        // Handle #lang special path
+        valueNode match {
+          case LanguageLiteral(_, lang) =>
+            Some(lang)
+          case _ =>
+            None
+        }
+      } else {
+        Some(valueNode.value)
+      }
+    }
+
     override def foreach[U](f: Entity => U): Unit = {
       //Remember current subject
-      var curSubject: Option[String] = subject.map(_.uri)
+      var curSubject: Option[String] = None
+      var curSubjectNode: Option[RdfNode] = None
 
       //Collect values of the current subject
       var values = Array.fill(entitySchema.typedPaths.size)(Seq[String]())
@@ -136,32 +189,32 @@ class SimpleEntityRetriever(endpoint: SparqlEndpoint,
 
       for (result <- sparqlResults) {
         //If the subject is unknown, find binding for subject variable
-        if (subject.isEmpty) {
-          //Check if we are still reading values for the current subject
-          val resultSubject = result.get(sparqlEntitySchema.variable) match {
-            case Some(Resource(value)) => Some(value)
-            case _ => None
-          }
+        //Check if we are still reading values for the current subject
+        val resultSubject = EntityRetriever.extractSubject(result, sparqlEntitySchema.variable)
 
-          if (resultSubject != curSubject) {
-            for (curSubjectUri <- curSubject) {
-              f(Entity(curSubjectUri, values.map(_.distinct).toIndexedSeq, entitySchema))
-              counter += 1
-              if(limit.exists(counter >= _))
-                return
+        if (resultSubject != curSubject) {
+          for (curSubjectUri <- curSubject) {
+            f(Entity(curSubjectUri, values.map(_.distinct).toIndexedSeq, entitySchema))
+            counter += 1
+            if(limit.exists(counter >= _)) {
+              return
             }
-
-            curSubject = resultSubject
-            values = Array.fill(entitySchema.typedPaths.size)(Seq[String]())
           }
+          curSubject = resultSubject
+          curSubjectNode = result.get(sparqlEntitySchema.variable)
+          values = Array.fill(entitySchema.typedPaths.size)(Seq[String]())
         }
-
         //Find results for values for the current subject
         if (curSubject.isDefined) {
           for ((variable, node) <- result if variable.startsWith(varPrefix)) {
             val id = variable.substring(varPrefix.length).toInt
-
-            values(id) = values(id) :+ node.value
+            variableValue(id, node) foreach { value =>
+              values(id) = values(id) :+ value
+            }
+          }
+          // Special-path-only handling
+          for(idx <- sparqlEntitySchema.paths.indices if isSpecialPathOnly(idx)) {
+            values(idx) = values(idx) :+ extractSpecialPathValue(idx, curSubjectNode.get)
           }
         }
       }
@@ -175,7 +228,6 @@ class SimpleEntityRetriever(endpoint: SparqlEndpoint,
           s"${graphUri.map(g => s" from graph '$g'").getOrElse("")} in ${System.currentTimeMillis() - startTime}ms.")
     }
   }
-
 }
 
 object SimpleEntityRetriever {

--- a/silk-workbench/silk-workbench-rules/test/controllers/transform/PartialAutoCompletionApiTest.scala
+++ b/silk-workbench/silk-workbench-rules/test/controllers/transform/PartialAutoCompletionApiTest.scala
@@ -3,6 +3,7 @@ package controllers.transform
 import controllers.transform.autoCompletion._
 import helper.IntegrationTestTrait
 import org.scalatest.{FlatSpec, MustMatchers}
+import org.silkframework.entity.rdf.SparqlEntitySchema.specialPaths
 import org.silkframework.plugins.dataset.json.JsonDataset
 import org.silkframework.rule.TransformSpec
 import org.silkframework.serialization.json.JsonHelpers
@@ -25,9 +26,9 @@ class PartialAutoCompletionApiTest extends FlatSpec with MustMatchers with Singl
   private val jsonOps = Seq("/", "\\", "[")
 
   private val RDF_NS = "https://ns.eccenca.com/source"
-  private val allPersonRdfPaths = Seq("rdf:type", s"<$RDF_NS/address>", s"<$RDF_NS/age>", s"<$RDF_NS/name>")
+  private val allPersonRdfPaths = Seq("rdf:type", s"<$RDF_NS/address>", s"<$RDF_NS/age>", s"<$RDF_NS/name>", specialPaths.LANG, specialPaths.TEXT)
   private val allForwardRdfPaths = Seq("rdf:type", "<https://ns.eccenca.com/source/address>", "<https://ns.eccenca.com/source/age>",
-    "<https://ns.eccenca.com/source/city>", "<https://ns.eccenca.com/source/country>", "<https://ns.eccenca.com/source/name>")
+    "<https://ns.eccenca.com/source/city>", "<https://ns.eccenca.com/source/country>", "<https://ns.eccenca.com/source/name>", specialPaths.LANG, specialPaths.TEXT)
   private val allBackwardRdfPaths = Seq("\\rdf:type", "\\<https://ns.eccenca.com/source/address>")
   // Full serialization of paths
   private def fullPaths(paths: Seq[String]) = paths.map(p => if(p.startsWith("\\")) p else "/" + p)


### PR DESCRIPTION
- Literals can thus be mapped in object mappings
- Add special path #text to fetch the lexical value of the currently selected RDF node. This is mostly needed when mapping literals in object mappings.
- Add special path #lang to get the language tag of a language tag literal.