### PR TITLE
Improved error message if a mapping failed due to too many entities.

### DIFF
--- a/silk-rules/src/main/scala/org/silkframework/rule/TransformRule.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/TransformRule.scala
@@ -69,6 +69,17 @@ sealed trait TransformRule extends Operator {
   }
 
   /**
+    * Generates a label for this rule.
+    * Will return the user-defined label, if any is defined.
+    * In case no label is defined, it falls back to the target property.
+    * If no target property is defined, the id will be returned.
+    */
+  def ruleLabel(maxLength: Int = MetaData.DEFAULT_LABEL_MAX_LENGTH)(implicit prefixes: Prefixes): String = {
+    val defaultLabel = target.map(_.propertyUri.serialize).filter(_.nonEmpty).getOrElse(id.toString)
+    metaData.formattedLabel(defaultLabel, maxLength)
+  }
+
+  /**
     * Collects all input paths in this rule.
     */
   def sourcePaths: Seq[TypedPath] = {
@@ -179,8 +190,6 @@ case class RootMappingRule(override val rules: MappingRules,
 object RootMappingRule {
 
   def defaultId: String = "root"
-
-  def defaultLabel: String = "Root Mapping"
 
   def defaultMappingTarget: MappingTarget = MappingTarget(propertyUri = "", valueType = ValueType.URI)
 

--- a/silk-rules/src/main/scala/org/silkframework/rule/execution/ExecuteTransform.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/execution/ExecuteTransform.scala
@@ -62,7 +62,7 @@ class ExecuteTransform(task: Task[TransformSpec],
     errorEntitySink.foreach(_.openTable(rule.outputSchema.typeUri, rule.outputSchema.typedPaths.map(_.property.get) :+ ErrorOutputWriter.errorProperty, singleEntity))
 
     val entityTable = dataSource.retrieve(rule.inputSchema)
-    val transformedEntities = new TransformedEntities(task, entityTable.entities, rule.transformRule.rules, rule.outputSchema,
+    val transformedEntities = new TransformedEntities(task, entityTable.entities, rule.transformRule.ruleLabel(), rule.transformRule.rules, rule.outputSchema,
       isRequestedSchema = false, abortIfErrorsOccur = task.data.abortIfErrorsOccur, context = context)
     var count = 0
     breakable {

--- a/silk-rules/src/main/scala/org/silkframework/rule/execution/local/TransformedEntities.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/execution/local/TransformedEntities.scala
@@ -27,6 +27,7 @@ import scala.util.control.NonFatal
   */
 class TransformedEntities(task: Task[TransformSpec],
                           entities: Traversable[Entity],
+                          ruleLabel: String,
                           rules: Seq[TransformRule],
                           outputSchema: EntitySchema,
                           isRequestedSchema: Boolean,
@@ -88,7 +89,7 @@ class TransformedEntities(task: Task[TransformSpec],
     if(uris.nonEmpty) {
       for (uri <- uris) {
         if(outputSchema.singleEntity && count > 1) {
-          throw new ValidationException("Tried to generate multiple entities, but the root mapping is configured to output a single entity.")
+          throw new ValidationException(s"Tried to generate multiple entities, but the '$ruleLabel' mapping is configured to output a single entity.")
         }
 
         lazy val objectEntity = { // Constructs an entity that only contains object source paths for object mappings
@@ -158,7 +159,7 @@ class TransformedEntities(task: Task[TransformSpec],
     errors.append(ex)
     errorFlag = true
     if(abortIfErrorsOccur) {
-      throw AbortExecutionException(s"Failed to transform entity '${entity.uri}' in rule '${rule.metaData.label}': ${ex.getMessage}", Some(ex))
+      throw AbortExecutionException(s"Failed to transform entity '${entity.uri}' in rule '$ruleLabel': ${ex.getMessage}", Some(ex))
     }
   }
 }


### PR DESCRIPTION
- Mapping execution shows misleading error message if an object mapping fails due to too many entities (CMEM-3767).
  - If an object mapping is configured to only allow a single entity, but the execution generated multiple entities, the error message referred to the root mapping.
  - The error message has been improved to point to the object mapping that caused the issue.
