### PR TITLE
Document sparql select injection into SPARQL Select queries

### DIFF
--- a/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/endpoint/PagingSparqlTraversable.scala
+++ b/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/endpoint/PagingSparqlTraversable.scala
@@ -19,7 +19,6 @@ import scala.util.matching.Regex
 object PagingSparqlTraversable {
 
   val graphPatternRegex: Regex = """[Gg][Rr][Aa][Pp][Hh]\s+<""".r
-  private val xmlFactory = XMLInputFactory.newInstance()
 
   private val logger = Logger.getLogger(getClass.getName)
 
@@ -47,12 +46,12 @@ object PagingSparqlTraversable {
     override def foreach[U](f: SortedMap[String, RdfNode] => U): Unit = {
       val parsedQuery = QueryFactory.create(query)
       // Don't set graph if the query is already containing a GRAPH pattern (not easily possible to check with parsed query)
-      if(graphPatternRegex.findFirstIn(query).isEmpty) {
+      if(graphPatternRegex.findFirstIn(query).isEmpty && parsedQuery.getGraphURIs.size() == 0) {
         params.graph foreach { graphURI =>
           parsedQuery.addGraphURI(graphURI)
         }
       }
-
+      // FIXME: Also inject FROM NAMED when GRAPH pattern exists and no FROM NAMED was defined in the original query (breaking change).
       if (parsedQuery.hasLimit || parsedQuery.hasOffset) {
         val inputStream = executeQuery(parsedQuery.serialize(Syntax.syntaxSPARQL_11))
         try {

--- a/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/tasks/SparqlSelectCustomTask.scala
+++ b/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/tasks/SparqlSelectCustomTask.scala
@@ -20,7 +20,8 @@ import scala.collection.JavaConverters._
 @Plugin(
   id = "sparqlSelectOperator",
   label = "SPARQL Select query",
-  description = "A task that executes a SPARQL Select query on a SPARQL enabled data source and outputs the SPARQL result."
+  description = "A task that executes a SPARQL Select query on a SPARQL enabled data source and outputs the SPARQL result. If the SPARQL source is defined on a specific graph, " +
+  "a FROM clause will be added to the query at execution time, except when there already exists a GRAPH or FROM clause in the query. FROM NAMED clauses are not injected."
 )
 case class SparqlSelectCustomTask(@Param(label = "Select query", value = "A SPARQL 1.1 select query", example = "select * where { ?s ?p ?o }")
                                   selectQuery: MultilineStringParameter,

--- a/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/tasks/SparqlUpdateCustomTask.scala
+++ b/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/tasks/SparqlUpdateCustomTask.scala
@@ -12,7 +12,7 @@ import org.silkframework.runtime.plugin.MultilineStringParameter
   label = "SPARQL Update query",
   description =
 """A task that outputs SPARQL Update queries for every entity from the input based on a SPARQL Update template.
-The output of this operator should be connected to the SPARQL datasets to which the results should be written."""
+The output of this operator should be connected to the SPARQL datasets to which the results should be written. In contrast to the SPARQL select operator, no FROM clause gets injected into the query."""
 )
 case class SparqlUpdateCustomTask(@Param(label = "SPARQL update query", value = SparqlUpdateCustomTask.sparqlUpdateTemplateDescription,
                                          example = "DELETE DATA { ${<PROP_FROM_ENTITY_SCHEMA1>} rdf:label ${\"PROP_FROM_ENTITY_SCHEMA2\"} }")


### PR DESCRIPTION
- Do not inject FROM clause if there already exists a FROM clause in the query.
- Document FROM clause injection in SPARQL Select and Update (lack of) operators.