### PR TITLE
Improved WorkspaceProvider API

### DIFF
--- a/silk-core/src/main/scala/org/silkframework/config/HasMetaData.scala
+++ b/silk-core/src/main/scala/org/silkframework/config/HasMetaData.scala
@@ -34,4 +34,11 @@ trait HasMetaData {
     */
   def fullLabel(implicit prefixes: Prefixes = Prefixes.empty): String = label(Int.MaxValue)
 
+  /**
+    * Returns a string containing both the full label and the identifier, e.g., to be used for logging.
+    */
+  def labelAndId(implicit prefixes: Prefixes = Prefixes.empty): String = {
+    s"'${fullLabel()}' ($id)"
+  }
+
 }

--- a/silk-core/src/main/scala/org/silkframework/dataset/rdf/GraphStoreTrait.scala
+++ b/silk-core/src/main/scala/org/silkframework/dataset/rdf/GraphStoreTrait.scala
@@ -226,7 +226,7 @@ case class ConnectionClosingInputStream(createConnection: () => HttpURLConnectio
   private lazy val inputStream: InputStream = {
     var tries = 0
     var is: InputStream = null
-    while(tries < 2) {
+    while(is == null && tries < 2) {
       tries += 1
       connection = createConnection()
       connection.connect()

--- a/silk-core/src/main/scala/org/silkframework/workspace/WorkspaceProvider.scala
+++ b/silk-core/src/main/scala/org/silkframework/workspace/WorkspaceProvider.scala
@@ -46,20 +46,14 @@ trait WorkspaceProvider {
   def projectCache(name: Identifier): ResourceManager
 
   /**
-   * Reads all tasks of a specific type from a project.
-    *
-    * Use readTasksSafe instead of this method.
-   */
+    * Reads all tasks of a specific type from a project.
+    **/
   def readTasks[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)
-                                         (implicit user: UserContext): Seq[Task[T]] = {
-    readTasksSafe[T](project, projectResources).map(_.task)
-  }
+                                         (implicit user: UserContext): Seq[LoadedTask[T]]
 
   /**
-    * Version of readTasks that returns a Seq[Try[Task[T]]]
+    * Reads all tasks of all types from a project.
     **/
-  def readTasksSafe[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)(implicit user: UserContext): Seq[LoadedTask[T]]
-
   def readAllTasks(project: Identifier, projectResources: ResourceManager)
                   (implicit user: UserContext): Seq[LoadedTask[_]]
 

--- a/silk-core/src/main/scala/org/silkframework/workspace/WorkspaceProvider.scala
+++ b/silk-core/src/main/scala/org/silkframework/workspace/WorkspaceProvider.scala
@@ -118,7 +118,7 @@ trait WorkspaceProvider {
 
 /**
   * The result of loading a task.
-  * Holds either the loaded tasks or the loading error.
+  * Holds either the loaded task or the loading error.
   */
 case class LoadedTask[T <: TaskSpec : ClassTag](taskOrError: Either[TaskLoadingError, Task[T]]) {
 

--- a/silk-core/src/main/scala/org/silkframework/workspace/WorkspaceProvider.scala
+++ b/silk-core/src/main/scala/org/silkframework/workspace/WorkspaceProvider.scala
@@ -52,13 +52,16 @@ trait WorkspaceProvider {
    */
   def readTasks[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)
                                          (implicit user: UserContext): Seq[Task[T]] = {
-    readTasksSafe[T](project, projectResources).map(t => t.left.getOrElse(throw t.right.get.throwable))
+    readTasksSafe[T](project, projectResources).map(_.task)
   }
 
   /**
     * Version of readTasks that returns a Seq[Try[Task[T]]]
     **/
-  def readTasksSafe[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)(implicit user: UserContext): Seq[Either[Task[T], TaskLoadingError]]
+  def readTasksSafe[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)(implicit user: UserContext): Seq[LoadedTask[T]]
+
+  def readAllTasks(project: Identifier, projectResources: ResourceManager)
+                  (implicit user: UserContext): Seq[LoadedTask[_]]
 
   /**
    * Adds/Updates a task in a project.
@@ -116,6 +119,51 @@ trait WorkspaceProvider {
     val loadingErrors = externalLoadingErrors.getOrElse(projectId, Vector.empty)
     externalLoadingErrors.put(projectId, loadingErrors.filter(_.taskId != taskId))
   }
+}
+
+
+/**
+  * The result of loading a task.
+  * Holds either the loaded tasks or the loading error.
+  */
+case class LoadedTask[T <: TaskSpec : ClassTag](taskOrError: Either[TaskLoadingError, Task[T]]) {
+
+  /**
+    * The task type.
+    */
+  val taskType: Class[_] = implicitly[ClassTag[T]].runtimeClass
+
+  /**
+    * Retrieves the task if it could be loaded or throws an exception containing the tasks loading error.
+    */
+  def task: Task[T] = {
+    taskOrError.right.getOrElse(throw taskOrError.left.get.throwable)
+  }
+
+  /**
+    * Returns the task if it could be loaded or None otherwise.
+    */
+  def taskOption: Option[Task[T]] = {
+    taskOrError.toOption
+  }
+
+  /**
+    * Retrieves the loading error, if any.
+    */
+  def error: Option[TaskLoadingError] = taskOrError.swap.toOption
+
+}
+
+object LoadedTask {
+
+  def success[T <: TaskSpec : ClassTag](task: Task[T]): LoadedTask[T] = {
+    LoadedTask(Right(task))
+  }
+
+  def failed[T <: TaskSpec : ClassTag](error: TaskLoadingError): LoadedTask[T] = {
+    LoadedTask(Left(error))
+  }
+
 }
 
 /** Task loading error. */

--- a/silk-workbench/silk-workbench-workspace/app/controllers/projectApi/ProjectApi.scala
+++ b/silk-workbench/silk-workbench-workspace/app/controllers/projectApi/ProjectApi.scala
@@ -222,11 +222,12 @@ class ProjectApi @Inject()(accessMonitor: WorkbenchAccessMonitor) extends Inject
                                schema = new Schema(implementation = classOf[String])
                              )
                              projectId: String): Action[JsValue] = RequestUserContextAction(parse.json) { implicit request => implicit userContext =>
+    val project = workspace.project(projectId)
     validateJson[ItemMetaData] { newMetaData =>
       val cleanedNewMetaData = newMetaData
-      val oldProjectMetaData = workspace.project(projectId).config.metaData
+      val oldProjectMetaData = project.config.metaData
       val mergedMetaData = oldProjectMetaData.copy(label = Some(cleanedNewMetaData.label), description = cleanedNewMetaData.description)
-      val updatedMetaData = workspace.updateProjectMetaData(projectId, mergedMetaData.asUpdatedMetaData)
+      val updatedMetaData = project.updateMetaData(mergedMetaData.asUpdatedMetaData)
       Ok(JsonSerializers.toJson(updatedMetaData))
     }
   }

--- a/silk-workbench/silk-workbench-workspace/test/controllers/workspace/ExportIntegrationTestTrait.scala
+++ b/silk-workbench/silk-workbench-workspace/test/controllers/workspace/ExportIntegrationTestTrait.scala
@@ -1,9 +1,5 @@
 package controllers.workspace
 
-import java.io.{ByteArrayInputStream, InputStream}
-import java.util.UUID
-import java.util.zip.ZipInputStream
-
 import helper.IntegrationTestTrait
 import org.scalatest.{MustMatchers, TestSuite}
 import org.silkframework.config.{Task, TaskSpec}
@@ -12,9 +8,11 @@ import org.silkframework.runtime.resource.ResourceManager
 import org.silkframework.util.Identifier
 import org.silkframework.workspace._
 
+import java.io.{ByteArrayInputStream, InputStream}
+import java.util.UUID
+import java.util.zip.ZipInputStream
 import scala.io.Source
 import scala.reflect.ClassTag
-import scala.util.Try
 
 
 /**
@@ -99,7 +97,7 @@ trait ExportIntegrationTestTrait
       }
 
       override def readTasksSafe[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)
-                                                          (implicit user: UserContext): Option[Seq[Either[Task[T], TaskLoadingError]]] = {
+                                                          (implicit user: UserContext): Option[Seq[LoadedTask[T]]] = {
         throw new RuntimeException("Cannot read tasks safely. Workspace provider is broken!")
       }
     }

--- a/silk-workbench/silk-workbench-workspace/test/controllers/workspace/ExportIntegrationTestTrait.scala
+++ b/silk-workbench/silk-workbench-workspace/test/controllers/workspace/ExportIntegrationTestTrait.scala
@@ -2,7 +2,7 @@ package controllers.workspace
 
 import helper.IntegrationTestTrait
 import org.scalatest.{MustMatchers, TestSuite}
-import org.silkframework.config.{Task, TaskSpec}
+import org.silkframework.config.TaskSpec
 import org.silkframework.runtime.activity.UserContext
 import org.silkframework.runtime.resource.ResourceManager
 import org.silkframework.util.Identifier
@@ -92,13 +92,14 @@ trait ExportIntegrationTestTrait
         throw new RuntimeException("Cannot read projects. Workspace provider is broken!")
       }
 
-      override def readTasks[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)(implicit user: UserContext): Option[Seq[Task[T]]] = {
+      override def readTasks[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)
+                                                          (implicit user: UserContext): Option[Seq[LoadedTask[T]]] = {
         throw new RuntimeException("Cannot read tasks. Workspace provider is broken!")
       }
 
-      override def readTasksSafe[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)
-                                                          (implicit user: UserContext): Option[Seq[LoadedTask[T]]] = {
-        throw new RuntimeException("Cannot read tasks safely. Workspace provider is broken!")
+      override def readAllTasks(project: Identifier, projectResources: ResourceManager)
+                               (implicit user: UserContext): Option[Seq[LoadedTask[_]]] = {
+        throw new RuntimeException("Cannot read all tasks. Workspace provider is broken!")
       }
     }
     MockableWorkspaceProvider.configWorkspace(workspaceId, brokenWorkspace)

--- a/silk-workbench/silk-workbench-workspace/test/controllers/workspace/MockableWorkspaceProvider.scala
+++ b/silk-workbench/silk-workbench-workspace/test/controllers/workspace/MockableWorkspaceProvider.scala
@@ -1,17 +1,15 @@
 package controllers.workspace
 
-import java.util.UUID
-import java.util.concurrent.ConcurrentHashMap
-
 import org.silkframework.config.{Task, TaskSpec}
 import org.silkframework.runtime.activity.UserContext
 import org.silkframework.runtime.plugin.annotations.Plugin
 import org.silkframework.runtime.resource.ResourceManager
 import org.silkframework.util.Identifier
-import org.silkframework.workspace.{InMemoryWorkspaceProvider, ProjectConfig, TaskLoadingError}
+import org.silkframework.workspace.{InMemoryWorkspaceProvider, LoadedTask, ProjectConfig}
 
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import scala.reflect.ClassTag
-import scala.util.Try
 
 @Plugin(
   id = "mockableInMemoryWorkspace",
@@ -39,7 +37,7 @@ class MockableWorkspaceProvider extends InMemoryWorkspaceProvider {
 
   override def readTasksSafe[T <: TaskSpec : ClassTag](project: Identifier,
                                                        projectResources: ResourceManager)
-                                                      (implicit user: UserContext): Seq[Either[Task[T], TaskLoadingError]] = {
+                                                      (implicit user: UserContext): Seq[LoadedTask[T]] = {
     config.readTasksSafe[T](project, projectResources).getOrElse(
       super.readTasksSafe[T](project, projectResources)
     )
@@ -74,5 +72,5 @@ class BreakableWorkspaceProviderConfig {
                                          (implicit user: UserContext): Option[Seq[Task[T]]] = None
 
   def readTasksSafe[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)
-                                             (implicit user: UserContext): Option[Seq[Either[Task[T], TaskLoadingError]]] = None
+                                             (implicit user: UserContext): Option[Seq[LoadedTask[T]]] = None
 }

--- a/silk-workbench/silk-workbench-workspace/test/controllers/workspace/MockableWorkspaceProvider.scala
+++ b/silk-workbench/silk-workbench-workspace/test/controllers/workspace/MockableWorkspaceProvider.scala
@@ -1,6 +1,6 @@
 package controllers.workspace
 
-import org.silkframework.config.{Task, TaskSpec}
+import org.silkframework.config.TaskSpec
 import org.silkframework.runtime.activity.UserContext
 import org.silkframework.runtime.plugin.annotations.Plugin
 import org.silkframework.runtime.resource.ResourceManager
@@ -32,7 +32,7 @@ class MockableWorkspaceProvider extends InMemoryWorkspaceProvider {
   override def readTasks[T <: TaskSpec : ClassTag](project: Identifier,
                                                    projectResources: ResourceManager)
                                                   (implicit user: UserContext): Seq[LoadedTask[T]] = {
-    config.readTasksSafe[T](project, projectResources).getOrElse(
+    config.readTasks[T](project, projectResources).getOrElse(
       super.readTasks[T](project, projectResources)
     )
   }
@@ -63,8 +63,9 @@ class BreakableWorkspaceProviderConfig {
                   (implicit user: UserContext): Option[Seq[ProjectConfig]] = None
 
   def readTasks[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)
-                                         (implicit user: UserContext): Option[Seq[Task[T]]] = None
+                                         (implicit user: UserContext): Option[Seq[LoadedTask[T]]] = None
 
-  def readTasksSafe[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)
-                                             (implicit user: UserContext): Option[Seq[LoadedTask[T]]] = None
+  def readAllTasks(project: Identifier, projectResources: ResourceManager)
+                  (implicit user: UserContext): Option[Seq[LoadedTask[_]]] = None
+
 }

--- a/silk-workbench/silk-workbench-workspace/test/controllers/workspace/MockableWorkspaceProvider.scala
+++ b/silk-workbench/silk-workbench-workspace/test/controllers/workspace/MockableWorkspaceProvider.scala
@@ -29,17 +29,11 @@ class MockableWorkspaceProvider extends InMemoryWorkspaceProvider {
     )
   }
 
-  override def readTasks[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)(implicit userContext: UserContext): Seq[Task[T]] = {
-    config.readTasks[T](project, projectResources).getOrElse(
-      super.readTasks[T](project, projectResources)
-    )
-  }
-
-  override def readTasksSafe[T <: TaskSpec : ClassTag](project: Identifier,
-                                                       projectResources: ResourceManager)
-                                                      (implicit user: UserContext): Seq[LoadedTask[T]] = {
+  override def readTasks[T <: TaskSpec : ClassTag](project: Identifier,
+                                                   projectResources: ResourceManager)
+                                                  (implicit user: UserContext): Seq[LoadedTask[T]] = {
     config.readTasksSafe[T](project, projectResources).getOrElse(
-      super.readTasksSafe[T](project, projectResources)
+      super.readTasks[T](project, projectResources)
     )
   }
 }

--- a/silk-workbench/silk-workbench-workspace/test/controllers/workspace/SearchApiIntegrationTest.scala
+++ b/silk-workbench/silk-workbench-workspace/test/controllers/workspace/SearchApiIntegrationTest.scala
@@ -237,11 +237,11 @@ class SearchApiIntegrationTest extends FlatSpec
     val newTask = "newTask"
     val metaData = MetaData(None, Some("A" + uniqueId + "Z"))
 
-    val project = retrieveOrCreateProject(newProject)
+    retrieveOrCreateProject(newProject)
     try {
       WorkspaceFactory().workspace.updateProjectMetaData(newProject, metaData)
       val workflow = Workflow(Seq.empty, Seq.empty)
-      project.addAnyTask(newTask, workflow, metaData)
+      retrieveOrCreateProject(newProject).addAnyTask(newTask, workflow, metaData)
       resultItemIds(facetedSearchRequest(
         FacetedSearchRequest(itemType = Some(ItemType.workflow), textQuery = Some(uniqueId))
       )._1) mustBe Seq(newTask)

--- a/silk-workbench/silk-workbench-workspace/test/controllers/workspace/SearchApiIntegrationTest.scala
+++ b/silk-workbench/silk-workbench-workspace/test/controllers/workspace/SearchApiIntegrationTest.scala
@@ -237,11 +237,11 @@ class SearchApiIntegrationTest extends FlatSpec
     val newTask = "newTask"
     val metaData = MetaData(None, Some("A" + uniqueId + "Z"))
 
-    retrieveOrCreateProject(newProject)
+    val project = retrieveOrCreateProject(newProject)
     try {
-      WorkspaceFactory().workspace.updateProjectMetaData(newProject, metaData)
+      project.updateMetaData(metaData)
       val workflow = Workflow(Seq.empty, Seq.empty)
-      retrieveOrCreateProject(newProject).addAnyTask(newTask, workflow, metaData)
+      project.addAnyTask(newTask, workflow, metaData)
       resultItemIds(facetedSearchRequest(
         FacetedSearchRequest(itemType = Some(ItemType.workflow), textQuery = Some(uniqueId))
       )._1) mustBe Seq(newTask)

--- a/silk-workbench/silk-workbench-workspace/test/controllers/workspaceApi/ProjectLoadingErrorIntegrationTest.scala
+++ b/silk-workbench/silk-workbench-workspace/test/controllers/workspaceApi/ProjectLoadingErrorIntegrationTest.scala
@@ -19,7 +19,7 @@ class ProjectLoadingErrorIntegrationTest extends FlatSpec with SingleProjectWork
   override def workspaceProviderId: String = "inMemory"
 
   private def updateProjectMetaData(): Unit = {
-    WorkspaceFactory().workspace.updateProjectMetaData(projectId, MetaData(Some(projectLabel)))
+    WorkspaceFactory().workspace.project(projectId).updateMetaData(MetaData(Some(projectLabel)))
   }
 
   private lazy val tasksReportEndpoint = {

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/CombinedWorkspaceProvider.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/CombinedWorkspaceProvider.scala
@@ -1,7 +1,5 @@
 package org.silkframework.workspace
 
-import java.util.logging.{Level, Logger}
-
 import org.silkframework.config.{Task, TaskSpec}
 import org.silkframework.dataset.rdf.SparqlEndpoint
 import org.silkframework.runtime.activity.UserContext
@@ -9,8 +7,8 @@ import org.silkframework.runtime.resource.ResourceManager
 import org.silkframework.util.Identifier
 import org.silkframework.workspace.io.WorkspaceIO
 
+import java.util.logging.{Level, Logger}
 import scala.reflect.ClassTag
-import scala.util.Try
 import scala.util.control.NonFatal
 
 /**
@@ -95,8 +93,13 @@ class CombinedWorkspaceProvider(val primaryWorkspace: WorkspaceProvider,
     **/
   override def readTasksSafe[T <: TaskSpec : ClassTag](project: Identifier,
                                                        projectResources: ResourceManager)
-                                                      (implicit user: UserContext): Seq[Either[Task[T], TaskLoadingError]] = {
+                                                      (implicit user: UserContext): Seq[LoadedTask[T]] = {
     primaryWorkspace.readTasksSafe[T](project, projectResources)
+  }
+
+  override def readAllTasks(project: Identifier, projectResources: ResourceManager)
+                           (implicit user: UserContext): Seq[LoadedTask[_]] = {
+    primaryWorkspace.readAllTasks(project, projectResources)
   }
 
   /**

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/CombinedWorkspaceProvider.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/CombinedWorkspaceProvider.scala
@@ -91,10 +91,10 @@ class CombinedWorkspaceProvider(val primaryWorkspace: WorkspaceProvider,
   /**
     * Version of readTasks that returns a Seq[Try[Task[T]]]
     **/
-  override def readTasksSafe[T <: TaskSpec : ClassTag](project: Identifier,
-                                                       projectResources: ResourceManager)
-                                                      (implicit user: UserContext): Seq[LoadedTask[T]] = {
-    primaryWorkspace.readTasksSafe[T](project, projectResources)
+  override def readTasks[T <: TaskSpec : ClassTag](project: Identifier,
+                                                   projectResources: ResourceManager)
+                                                  (implicit user: UserContext): Seq[LoadedTask[T]] = {
+    primaryWorkspace.readTasks[T](project, projectResources)
   }
 
   override def readAllTasks(project: Identifier, projectResources: ResourceManager)

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/InMemoryWorkspaceProvider.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/InMemoryWorkspaceProvider.scala
@@ -68,19 +68,16 @@ class InMemoryWorkspaceProvider() extends WorkspaceProvider {
     * Reads all tasks of a specific type from a project.
     */
   override def readTasks[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)
-                                                  (implicit userContext: UserContext): Seq[Task[T]] = {
-    val taskClass = implicitly[ClassTag[T]].runtimeClass
-    projects(project).tasks.values.filter(task => taskClass.isAssignableFrom(task.task.data.getClass)).map(_.asInstanceOf[Task[T]]).toSeq
-  }
-
-  override def readTasksSafe[T <: TaskSpec : ClassTag](project: Identifier,
-                                                       projectResources: ResourceManager)(implicit user: UserContext): Seq[LoadedTask[T]] = {
+                                                  (implicit user: UserContext): Seq[LoadedTask[T]] = {
     val taskClass = implicitly[ClassTag[T]].runtimeClass
     projects(project).tasks.values.filter(task => taskClass.isAssignableFrom(task.task.data.getClass)).map(task => LoadedTask.success(task.asInstanceOf[Task[T]])).toSeq
   }
 
+  /**
+    * Reads all tasks of all types from a project.
+    **/
   override def readAllTasks(project: Identifier, projectResources: ResourceManager)
-                  (implicit user: UserContext): Seq[LoadedTask[_]] = {
+                           (implicit user: UserContext): Seq[LoadedTask[_]] = {
     projects(project).tasks.values.toSeq
   }
 

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/Project.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/Project.scala
@@ -153,6 +153,19 @@ class Project(initialConfig: ProjectConfig, provider: WorkspaceProvider, val res
     cachedConfig = cachedConfig.copy(prefixes = cachedConfig.prefixes ++ additionalPrefixes)
   }
 
+  /** Update the meta data of a project. */
+  def updateMetaData(metaData: MetaData)
+                    (implicit userContext: UserContext): MetaData = synchronized {
+    val projectConfig = config
+    val oldMetaData = config.metaData
+    val mergedMetaData = oldMetaData.copy(label = metaData.label, description = metaData.description)
+    val updatedProjectConfig = projectConfig.copy(metaData = mergedMetaData.asUpdatedMetaData)
+    config = updatedProjectConfig
+    provider.putProject(updatedProjectConfig)
+    logger.info(s"Project meta data updated for ${projectConfig.labelAndId()}.")
+    updatedProjectConfig.metaData
+  }
+
   /**
    * Retrieves all tasks in this project.
    */

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
@@ -273,7 +273,6 @@ class Workspace(val provider: WorkspaceProvider, val repository: ResourceReposit
     provider.readProject(id) match {
       case Some(projectConfig) =>
         val project = new Project(projectConfig, provider, repository.get(projectConfig.id))
-        project.loadTasks()
         project.startActivities()
         addProjectToCache(project)
       case None =>
@@ -299,7 +298,6 @@ class Workspace(val provider: WorkspaceProvider, val repository: ResourceReposit
     cachedProjects = for(projectConfig <- provider.readProjects()) yield {
       log.info("Loading project: " + projectConfig.id)
       val project = new Project(projectConfig, provider, repository.get(projectConfig.id))
-      project.loadTasks()
       log.info("Finished loading project '" + projectConfig.id + "'.")
       project
     }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
@@ -14,11 +14,7 @@
 
 package org.silkframework.workspace
 
-import java.io._
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.locks.ReentrantLock
-import java.util.logging.{Level, Logger}
-import org.silkframework.config.{DefaultConfig, MetaData, Prefixes}
+import org.silkframework.config.{DefaultConfig, Prefixes}
 import org.silkframework.runtime.activity.{HasValue, UserContext}
 import org.silkframework.runtime.plugin.PluginRegistry
 import org.silkframework.runtime.validation.{NotFoundException, ServiceUnavailableException}
@@ -27,6 +23,10 @@ import org.silkframework.workspace.activity.{GlobalWorkspaceActivity, GlobalWork
 import org.silkframework.workspace.exceptions.{IdentifierAlreadyExistsException, ProjectNotFoundException}
 import org.silkframework.workspace.resources.ResourceRepository
 
+import java.io._
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+import java.util.logging.{Level, Logger}
 import scala.reflect.ClassTag
 import scala.util.Try
 import scala.util.control.NonFatal
@@ -153,23 +153,6 @@ class Workspace(val provider: WorkspaceProvider, val repository: ResourceReposit
     newProject.setAdditionalPrefixes(additionalPrefixes)
     log.info(s"Created new project '${creationConfig.id}'. " + userContext.logInfo)
     newProject
-  }
-
-  /** Update the meta data of a project. */
-  def updateProjectMetaData(projectId: Identifier,
-                            metaData: MetaData)
-                           (implicit userContext: UserContext): MetaData = synchronized {
-    loadUserProjects()
-    val diProject = project(projectId)
-    val projectConfig = diProject.config
-    val oldMetaData = projectConfig.metaData
-    val mergedMetaData = oldMetaData.copy(label = metaData.label, description = metaData.description)
-    val updatedProjectConfig = projectConfig.copy(metaData = mergedMetaData.asUpdatedMetaData)
-    provider.putProject(updatedProjectConfig)
-    removeProjectFromCache(projectId)
-    addProjectToCache(new Project(updatedProjectConfig, provider, repository.get(projectId)))
-    log.info(s"Project meta data updated for '$projectId'.")
-    updatedProjectConfig.metaData
   }
 
   def removeProject(name: Identifier)

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/io/WorkspaceIO.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/io/WorkspaceIO.scala
@@ -71,7 +71,7 @@ object WorkspaceIO {
                                                   resources: ResourceManager,
                                                   projectName: Identifier)
                                                  (implicit userContext: UserContext): Unit = {
-    for(taskTry <- inputWorkspace.readTasksSafe[T](projectName, resources)) {
+    for(taskTry <- inputWorkspace.readTasks[T](projectName, resources)) {
       taskTry.taskOrError match {
         case Right(task) =>
           outputWorkspace.putTask(projectName, task)

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/io/WorkspaceIO.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/io/WorkspaceIO.scala
@@ -1,7 +1,5 @@
 package org.silkframework.workspace.io
 
-import java.util.logging.Logger
-
 import org.silkframework.config.{CustomTask, TaskSpec}
 import org.silkframework.dataset.{Dataset, DatasetSpec}
 import org.silkframework.rule.{LinkSpec, TransformSpec}
@@ -12,8 +10,8 @@ import org.silkframework.workspace.activity.workflow.Workflow
 import org.silkframework.workspace.resources.ResourceRepository
 import org.silkframework.workspace.{ProjectConfig, WorkspaceProvider}
 
+import java.util.logging.Logger
 import scala.reflect.ClassTag
-import scala.util.{Failure, Success}
 
 /**
   * Transfers projects between workspaces.
@@ -74,10 +72,10 @@ object WorkspaceIO {
                                                   projectName: Identifier)
                                                  (implicit userContext: UserContext): Unit = {
     for(taskTry <- inputWorkspace.readTasksSafe[T](projectName, resources)) {
-      taskTry match {
-        case Left(task) =>
+      taskTry.taskOrError match {
+        case Right(task) =>
           outputWorkspace.putTask(projectName, task)
-        case Right(taskLoadingError) =>
+        case Left(taskLoadingError) =>
           outputWorkspace.retainExternalTaskLoadingError(projectName, taskLoadingError)
           log.warning("Invalid task encountered while copying task between workspace providers. Error message: " + taskLoadingError.throwable.getMessage)
       }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/xml/CustomTaskXmlSerializer.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/xml/CustomTaskXmlSerializer.scala
@@ -14,14 +14,14 @@
 
 package org.silkframework.workspace.xml
 
-import java.io.OutputStreamWriter
-import java.util.logging.Logger
-
 import org.silkframework.config._
 import org.silkframework.runtime.resource.{ResourceLoader, ResourceManager}
 import org.silkframework.runtime.serialization.XmlSerialization
 import org.silkframework.util.Identifier
-import org.silkframework.workspace.TaskLoadingError
+import org.silkframework.workspace.LoadedTask
+
+import java.io.OutputStreamWriter
+import java.util.logging.Logger
 
 /**
  * Holds custom tasks.
@@ -53,8 +53,8 @@ private class CustomTaskXmlSerializer extends XmlSerializer[CustomTask] {
     resources.delete(name.toString + "_cache.xml")
   }
 
-  override def loadTasksSafe(resources: ResourceLoader,
-                             projectResources: ResourceManager): Seq[Either[Task[CustomTask], TaskLoadingError]] = {
+  override def loadTasks(resources: ResourceLoader,
+                         projectResources: ResourceManager): Seq[LoadedTask[CustomTask]] = {
     val names = taskNames(resources)
     val tasks = for (name <- names) yield {
       loadTaskSafelyFromXML(name, Some(name.stripSuffix(".xml")), resources, projectResources)

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/xml/DatasetXmlSerializer.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/xml/DatasetXmlSerializer.scala
@@ -14,8 +14,6 @@
 
 package org.silkframework.workspace.xml
 
-import java.util.logging.Logger
-
 import org.silkframework.config.Task
 import org.silkframework.dataset.DatasetSpec.GenericDatasetSpec
 import org.silkframework.dataset.{Dataset, DatasetSpec}
@@ -23,9 +21,9 @@ import org.silkframework.runtime.resource.{ResourceLoader, ResourceManager}
 import org.silkframework.runtime.serialization.{ReadContext, XmlSerialization}
 import org.silkframework.util.Identifier
 import org.silkframework.util.XMLUtils._
-import org.silkframework.workspace.TaskLoadingError
+import org.silkframework.workspace.LoadedTask
 
-import scala.util.Try
+import java.util.logging.Logger
 
 /**
  * The source module which encapsulates all data sources.
@@ -42,7 +40,7 @@ private class DatasetXmlSerializer extends XmlSerializer[DatasetSpec[Dataset]] {
 
   private def loadTask(resourceName: String,
                        resources: ResourceLoader,
-                       projectResources: ResourceManager): Either[Task[DatasetSpec[Dataset]], TaskLoadingError] = {
+                       projectResources: ResourceManager): LoadedTask[DatasetSpec[Dataset]] = {
     // Load the data set
     implicit val res: ResourceManager = projectResources
     implicit val readContext: ReadContext = ReadContext(projectResources)
@@ -64,7 +62,7 @@ private class DatasetXmlSerializer extends XmlSerializer[DatasetSpec[Dataset]] {
     resources.delete(name.toString + "_cache.xml")
   }
 
-  override def loadTasksSafe(resources: ResourceLoader, projectResources: ResourceManager): Seq[Either[Task[GenericDatasetSpec], TaskLoadingError]] = {
+  override def loadTasks(resources: ResourceLoader, projectResources: ResourceManager): Seq[LoadedTask[GenericDatasetSpec]] = {
     // Read dataset tasks
     val names = taskNames(resources)
     var tasks = for (name <- names) yield {

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/xml/TransformXmlSerializer.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/xml/TransformXmlSerializer.scala
@@ -1,18 +1,16 @@
 package org.silkframework.workspace.xml
 
-import java.util.logging.Logger
-
 import org.silkframework.config._
-import org.silkframework.rule.{DatasetSelection, TransformRule, TransformSpec}
+import org.silkframework.rule.TransformSpec
 import org.silkframework.runtime.resource.{ResourceLoader, ResourceManager}
 import org.silkframework.runtime.serialization.ReadContext
 import org.silkframework.runtime.serialization.XmlSerialization._
 import org.silkframework.runtime.validation.ValidationException
 import org.silkframework.util.Identifier
 import org.silkframework.util.XMLUtils._
-import org.silkframework.workspace.TaskLoadingError
+import org.silkframework.workspace.LoadedTask
 
-import scala.util.Try
+import java.util.logging.Logger
 import scala.xml.{Attribute, Null, Text, XML}
 
 /**
@@ -40,14 +38,14 @@ private class TransformXmlSerializer extends XmlSerializer[TransformSpec] {
   /**
    * Loads all tasks of this module.
    */
-  override def loadTasksSafe(resources: ResourceLoader, projectResources: ResourceManager): Seq[Either[Task[TransformSpec], TaskLoadingError]] = {
+  override def loadTasks(resources: ResourceLoader, projectResources: ResourceManager): Seq[LoadedTask[TransformSpec]] = {
     val tasks =
       for(name <- resources.listChildren) yield
         loadTask(name, resources.child(name), projectResources)
     tasks
   }
 
-  private def loadTask(name: Identifier, taskResources: ResourceLoader, projectResources: ResourceManager): Either[Task[TransformSpec], TaskLoadingError] = {
+  private def loadTask(name: Identifier, taskResources: ResourceLoader, projectResources: ResourceManager): LoadedTask[TransformSpec] = {
     try {
       implicit val resources = projectResources
       implicit val readContext = ReadContext(resources)

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/xml/WorkflowXmlSerializer.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/xml/WorkflowXmlSerializer.scala
@@ -3,14 +3,12 @@ package org.silkframework.workspace.xml
 import org.silkframework.config._
 import org.silkframework.runtime.resource.{ResourceLoader, ResourceManager}
 import org.silkframework.runtime.serialization.ReadContext
-import org.silkframework.runtime.serialization.XmlSerialization.fromXml
+import org.silkframework.runtime.serialization.XmlSerialization._
 import org.silkframework.util.Identifier
 import org.silkframework.util.XMLUtils._
+import org.silkframework.workspace.LoadedTask
 import org.silkframework.workspace.activity.workflow.Workflow
-import org.silkframework.runtime.serialization.XmlSerialization._
-import org.silkframework.workspace.TaskLoadingError
 
-import scala.util.Try
 import scala.xml.{Attribute, Null, Text, XML}
 
 private class WorkflowXmlSerializer extends XmlSerializer[Workflow] {
@@ -20,7 +18,7 @@ private class WorkflowXmlSerializer extends XmlSerializer[Workflow] {
   /**
    * Loads all tasks of this module.
    */
-  override def loadTasksSafe(resources: ResourceLoader, projectResources: ResourceManager): Seq[Either[Task[Workflow], TaskLoadingError]] = {
+  override def loadTasks(resources: ResourceLoader, projectResources: ResourceManager): Seq[LoadedTask[Workflow]] = {
     implicit val readContext = ReadContext(projectResources)
     val names = resources.list.filter(_.endsWith(".xml"))
     val tasks =

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/xml/XmlWorkspaceProvider.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/xml/XmlWorkspaceProvider.scala
@@ -97,14 +97,9 @@ class XmlWorkspaceProvider(val resources: ResourceManager) extends WorkspaceProv
     resources.child(name)
   }
 
-  override def readTasks[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)
-                                                  (implicit userContext: UserContext): Seq[Task[T]] = {
-    plugin[T].loadTasks(resources.child(project).child(plugin[T].prefix), projectResources).map(_.task)
-  }
-
-  override def readTasksSafe[T <: TaskSpec : ClassTag](project: Identifier,
-                                                       projectResources: ResourceManager)
-                                                      (implicit user: UserContext): Seq[LoadedTask[T]] = {
+  override def readTasks[T <: TaskSpec : ClassTag](project: Identifier,
+                                                   projectResources: ResourceManager)
+                                                  (implicit user: UserContext): Seq[LoadedTask[T]] = {
     plugin[T].loadTasks(resources.child(project).child(plugin[T].prefix), projectResources)
   }
 

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/xml/XmlWorkspaceProvider.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/xml/XmlWorkspaceProvider.scala
@@ -8,7 +8,7 @@ import org.silkframework.runtime.serialization.{ReadContext, XmlSerialization}
 import org.silkframework.util.Identifier
 import org.silkframework.util.XMLUtils._
 import org.silkframework.workspace.io.WorkspaceIO
-import org.silkframework.workspace.{ProjectConfig, TaskLoadingError, WorkspaceProvider}
+import org.silkframework.workspace.{LoadedTask, ProjectConfig, WorkspaceProvider}
 
 import java.util.logging.{Level, Logger}
 import scala.reflect.ClassTag
@@ -23,7 +23,7 @@ class XmlWorkspaceProvider(val resources: ResourceManager) extends WorkspaceProv
   private val log = Logger.getLogger(classOf[XmlWorkspaceProvider].getName)
 
   @volatile
-  private var plugins = Map[Class[_], XmlSerializer[_]]()
+  private var plugins = Map[Class[_], XmlSerializer[_ <: TaskSpec]]()
 
   // Register all module types
   registerModule(new DatasetXmlSerializer())
@@ -99,7 +99,18 @@ class XmlWorkspaceProvider(val resources: ResourceManager) extends WorkspaceProv
 
   override def readTasks[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)
                                                   (implicit userContext: UserContext): Seq[Task[T]] = {
+    plugin[T].loadTasks(resources.child(project).child(plugin[T].prefix), projectResources).map(_.task)
+  }
+
+  override def readTasksSafe[T <: TaskSpec : ClassTag](project: Identifier,
+                                                       projectResources: ResourceManager)
+                                                      (implicit user: UserContext): Seq[LoadedTask[T]] = {
     plugin[T].loadTasks(resources.child(project).child(plugin[T].prefix), projectResources)
+  }
+
+  override def readAllTasks(project: Identifier, projectResources: ResourceManager)
+                           (implicit user: UserContext): Seq[LoadedTask[_]] = {
+    plugins.values.toSeq.flatMap(plugin => plugin.loadTasks(resources.child(project).child(plugin.prefix), projectResources).asInstanceOf[Seq[LoadedTask[_ <: TaskSpec]]])
   }
 
   override def putTask[T <: TaskSpec : ClassTag](project: Identifier, task: Task[T])
@@ -125,12 +136,6 @@ class XmlWorkspaceProvider(val resources: ResourceManager) extends WorkspaceProv
   override def refresh()(implicit userContext: UserContext): Unit = {
     // No refresh needed, all tasks are read from the file system on every read. Nothing is cached
     // This is implemented to avoid warnings on project imports.
-  }
-
-  override def readTasksSafe[T <: TaskSpec : ClassTag](project: Identifier,
-                                                       projectResources: ResourceManager)
-                                                      (implicit user: UserContext): Seq[Either[Task[T], TaskLoadingError]] = {
-    plugin[T].loadTasksSafe(resources.child(project).child(plugin[T].prefix), projectResources)
   }
 
   /**

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceProviderTestTrait.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceProviderTestTrait.scala
@@ -275,7 +275,7 @@ trait WorkspaceProviderTestTrait extends FlatSpec with Matchers with MockitoSuga
     implicit val us: UserContext = emptyUserContext
     workspaceProvider.putTask(PROJECT_NAME, datasetUpdated)
     refreshTest {
-      val ds = workspaceProvider.readTasks[GenericDatasetSpec](PROJECT_NAME, projectResources).find(_.task.id.toString == DATASET_ID).get
+      val ds = workspaceProvider.readTasks[GenericDatasetSpec](PROJECT_NAME, projectResources).find(_.task.id.toString == DATASET_ID).get.task
       ds shouldBe datasetUpdated
     }
   }
@@ -308,7 +308,7 @@ trait WorkspaceProviderTestTrait extends FlatSpec with Matchers with MockitoSuga
     implicit val us: UserContext = emptyUserContext
     workspaceProvider.putTask(PROJECT_NAME, transformTask)
     refreshTest {
-      workspaceProvider.readTasks[TransformSpec](PROJECT_NAME, projectResources).headOption shouldBe Some(transformTask)
+      workspaceProvider.readTasks[TransformSpec](PROJECT_NAME, projectResources).headOption.map(_.task) shouldBe Some(transformTask)
     }
   }
 
@@ -316,7 +316,7 @@ trait WorkspaceProviderTestTrait extends FlatSpec with Matchers with MockitoSuga
     implicit val us: UserContext = emptyUserContext
     workspaceProvider.putTask(PROJECT_NAME, transformTaskUpdated)
     refreshTest {
-      workspaceProvider.readTasks[TransformSpec](PROJECT_NAME, projectResources).headOption shouldBe Some(transformTaskUpdated)
+      workspaceProvider.readTasks[TransformSpec](PROJECT_NAME, projectResources).headOption.map(_.task) shouldBe Some(transformTaskUpdated)
     }
   }
 
@@ -337,7 +337,7 @@ trait WorkspaceProviderTestTrait extends FlatSpec with Matchers with MockitoSuga
     implicit val us: UserContext = emptyUserContext
     workspaceProvider.putTask(PROJECT_NAME, transformTaskHierarchical)
     refreshTest {
-      workspaceProvider.readTasks[TransformSpec](PROJECT_NAME, projectResources).headOption shouldBe Some(transformTaskHierarchical)
+      workspaceProvider.readTasks[TransformSpec](PROJECT_NAME, projectResources).headOption.map(_.task) shouldBe Some(transformTaskHierarchical)
     }
   }
 
@@ -346,7 +346,7 @@ trait WorkspaceProviderTestTrait extends FlatSpec with Matchers with MockitoSuga
     implicit val us: UserContext = emptyUserContext
     workspaceProvider.putTask(PROJECT_NAME, miniWorkflow)
     refreshTest {
-      workspaceProvider.readTasks[Workflow](PROJECT_NAME, projectResources).headOption shouldBe Some(miniWorkflow)
+      workspaceProvider.readTasks[Workflow](PROJECT_NAME, projectResources).headOption.map(_.task) shouldBe Some(miniWorkflow)
     }
   }
 
@@ -354,7 +354,7 @@ trait WorkspaceProviderTestTrait extends FlatSpec with Matchers with MockitoSuga
     implicit val us: UserContext = emptyUserContext
     workspaceProvider.putTask(PROJECT_NAME, miniWorkflowUpdated)
     refreshTest {
-      workspaceProvider.readTasks[Workflow](PROJECT_NAME, projectResources).headOption shouldBe Some(miniWorkflowUpdated)
+      workspaceProvider.readTasks[Workflow](PROJECT_NAME, projectResources).headOption.map(_.task) shouldBe Some(miniWorkflowUpdated)
     }
   }
 
@@ -362,7 +362,7 @@ trait WorkspaceProviderTestTrait extends FlatSpec with Matchers with MockitoSuga
     implicit val us: UserContext = emptyUserContext
     workspaceProvider.putTask(PROJECT_NAME, customTask)
     refreshTest {
-      workspaceProvider.readTasks[CustomTask](PROJECT_NAME, projectResources).headOption shouldBe Some(customTask)
+      workspaceProvider.readTasks[CustomTask](PROJECT_NAME, projectResources).headOption.map(_.task) shouldBe Some(customTask)
     }
   }
 

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceProviderTestTrait.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceProviderTestTrait.scala
@@ -265,7 +265,7 @@ trait WorkspaceProviderTestTrait extends FlatSpec with Matchers with MockitoSuga
     project.addTask[GenericDatasetSpec](DUMMY_DATASET, DatasetSpec(dummyDataset))
     workspaceProvider.putTask(PROJECT_NAME, dataset)
     refreshTest {
-      val tasks = workspaceProvider.readTasks[GenericDatasetSpec](PROJECT_NAME, projectResources)
+      val tasks = workspaceProvider.readTasks[GenericDatasetSpec](PROJECT_NAME, projectResources).map(_.task)
       val ds = tasks.find(_.id.toString == DATASET_ID).get
       ds shouldBe dataset
     }
@@ -275,7 +275,7 @@ trait WorkspaceProviderTestTrait extends FlatSpec with Matchers with MockitoSuga
     implicit val us: UserContext = emptyUserContext
     workspaceProvider.putTask(PROJECT_NAME, datasetUpdated)
     refreshTest {
-      val ds = workspaceProvider.readTasks[GenericDatasetSpec](PROJECT_NAME, projectResources).find(_.id.toString == DATASET_ID).get
+      val ds = workspaceProvider.readTasks[GenericDatasetSpec](PROJECT_NAME, projectResources).find(_.task.id.toString == DATASET_ID).get
       ds shouldBe datasetUpdated
     }
   }
@@ -286,8 +286,8 @@ trait WorkspaceProviderTestTrait extends FlatSpec with Matchers with MockitoSuga
     refreshTest {
       val linkingTask = workspaceProvider.readTasks[LinkSpec](PROJECT_NAME, projectResources).headOption
       linkingTask shouldBe defined
-      linkingTask.get.data shouldBe linkTask.data
-      checkCreationMetaData(linkingTask.get.metaData, linkTask.metaData, specificUserContext)
+      linkingTask.get.task.data shouldBe linkTask.data
+      checkCreationMetaData(linkingTask.get.task.metaData, linkTask.metaData, specificUserContext)
     }
   }
 
@@ -299,8 +299,8 @@ trait WorkspaceProviderTestTrait extends FlatSpec with Matchers with MockitoSuga
     refreshTest {
       val linkingTask = workspaceProvider.readTasks[LinkSpec](PROJECT_NAME, projectResources).headOption
       linkingTask shouldBe defined
-      linkingTask.get.data shouldBe linkTaskUpdated.data
-      checkUpdateMetaData(linkingTask.get.metaData, originalTask.metaData, specificUserContext, specificUserContext2)
+      linkingTask.get.task.data shouldBe linkTaskUpdated.data
+      checkUpdateMetaData(linkingTask.get.task.metaData, originalTask.metaData, specificUserContext, specificUserContext2)
     }
   }
 
@@ -427,7 +427,7 @@ trait WorkspaceProviderTestTrait extends FlatSpec with Matchers with MockitoSuga
     workspaceProvider.readTasks[GenericDatasetSpec](PROJECT_NAME, projectResources).headOption shouldBe defined
     workspaceProvider.deleteTask[GenericDatasetSpec](PROJECT_NAME, DATASET_ID)
     refreshTest {
-      workspaceProvider.readTasks[GenericDatasetSpec](PROJECT_NAME, projectResources).map(_.id.toString) shouldBe Seq(DUMMY_DATASET)
+      workspaceProvider.readTasks[GenericDatasetSpec](PROJECT_NAME, projectResources).map(_.task.id.toString) shouldBe Seq(DUMMY_DATASET)
     }
   }
 

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceProviderTestTrait.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceProviderTestTrait.scala
@@ -241,7 +241,7 @@ trait WorkspaceProviderTestTrait extends FlatSpec with Matchers with MockitoSuga
     val projectDescription = Some("project description")
     val newMetaData = MetaData(projectLabel, description = projectDescription)
     val originalMetaData = project.config.metaData
-    workspace.updateProjectMetaData(PROJECT_NAME, newMetaData)
+    project.updateMetaData(newMetaData)
     refreshTest {
       checkUpdateMetaData(project.config.metaData, originalMetaData.copy(label = projectLabel, description = projectDescription), specificUserContext, specificUserContext2)
     }

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceTest.scala
@@ -137,16 +137,8 @@ object WorkspaceTest {
     }
 
     override def readTasks[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)
-                                                    (implicit user: UserContext): Seq[Task[T]] = {
+                                                    (implicit user: UserContext): Seq[LoadedTask[T]] = {
       val tasks = super.readTasks(project, projectResources)
-      Thread.sleep(loadTimePause)
-      taskReadTimes += ((project, Instant.now))
-      tasks
-    }
-
-    override def readTasksSafe[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)
-                                                        (implicit user: UserContext): Seq[LoadedTask[T]] = {
-      val tasks = super.readTasksSafe(project, projectResources)
       Thread.sleep(loadTimePause)
       taskReadTimes += ((project, Instant.now))
       tasks

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceTest.scala
@@ -143,9 +143,18 @@ object WorkspaceTest {
       taskReadTimes += ((project, Instant.now))
       tasks
     }
+
     override def readTasksSafe[T <: TaskSpec : ClassTag](project: Identifier, projectResources: ResourceManager)
-                                                        (implicit user: UserContext): Seq[Either[Task[T], TaskLoadingError]] = {
+                                                        (implicit user: UserContext): Seq[LoadedTask[T]] = {
       val tasks = super.readTasksSafe(project, projectResources)
+      Thread.sleep(loadTimePause)
+      taskReadTimes += ((project, Instant.now))
+      tasks
+    }
+
+    override def readAllTasks(project: Identifier, projectResources: ResourceManager)
+                             (implicit user: UserContext): Seq[LoadedTask[_]] = {
+      val tasks = super.readAllTasks(project, projectResources)
       Thread.sleep(loadTimePause)
       taskReadTimes += ((project, Instant.now))
       tasks

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/xml/XmlZipProjectMarshalingTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/xml/XmlZipProjectMarshalingTest.scala
@@ -68,7 +68,7 @@ class XmlZipProjectMarshalingTest extends FlatSpec with Matchers {
     }
     val datasets = workspace.readTasks[GenericDatasetSpec](projectName, resources)
     val linkingTask = workspace.readTasks[LinkSpec](projectName, resources)
-    datasets.map(_.id.toString) should contain allOf("DBpedia", "linkedmdb")
-    linkingTask.map(_.id.toString) should contain("movies")
+    datasets.map(_.task.id.toString) should contain allOf("DBpedia", "linkedmdb")
+    linkingTask.map(_.task.id.toString) should contain("movies")
   }
 }


### PR DESCRIPTION
- Added readAllTasks() to load all tasks of all types at once
- Task loading methods return an instance of LoadedTask
- Correctly use Either (the right value is supposed to hold the correct result and not vice versa)
- Use readAllTasks in Workspace to improve performance for RDF Workspaces