### PR TITLE
Fix project file handling in the UI for files containing "special" characters

### DIFF
--- a/workspace/src/app/store/ducks/workspace/requests.ts
+++ b/workspace/src/app/store/ducks/workspace/requests.ts
@@ -200,7 +200,7 @@ export const requestRemoveProjectPrefix = async (prefixName: string, projectId: 
 export const requestIfResourceExists = async (projectId: string, resourceName: string): Promise<boolean> => {
     try {
         const { data } = await fetch({
-            url: legacyApiEndpoint(`/projects/${projectId}/resources/${resourceName}/metadata`),
+            url: legacyApiEndpoint(`/projects/${projectId}/resources/${encodeURIComponent(resourceName)}/metadata`),
         });
         return "size" in data;
     } catch (e) {
@@ -215,7 +215,7 @@ export const requestIfResourceExists = async (projectId: string, resourceName: s
 export const requestRemoveProjectResource = async (projectId: string, resourceName: string): Promise<void> => {
     try {
         await fetch({
-            url: legacyApiEndpoint(`/projects/${projectId}/resources/${resourceName}`),
+            url: legacyApiEndpoint(`/projects/${projectId}/resources/${encodeURIComponent(resourceName)}`),
             method: "DELETE",
         });
     } catch (e) {
@@ -229,7 +229,7 @@ export const projectFileResourceDependents = async (
     resourceName: string
 ): Promise<FetchResponse<ITaskLink[]>> => {
     return fetch({
-        url: legacyApiEndpoint(`/projects/${projectId}/resources/${resourceName}/usage`),
+        url: legacyApiEndpoint(`/projects/${projectId}/resources/${encodeURIComponent(resourceName)}/usage`),
     });
 };
 

--- a/workspace/src/app/views/pages/Project/FileWidget/FileWidget.tsx
+++ b/workspace/src/app/views/pages/Project/FileWidget/FileWidget.tsx
@@ -159,10 +159,11 @@ export const FileWidget = () => {
                                                                     name="item-download"
                                                                     text={t("common.action.download")}
                                                                     small
-                                                                    href={`${CONTEXT_PATH}/workspace/projects/${projectId}/resources/${file.name}`}
+                                                                    href={`${CONTEXT_PATH}/workspace/projects/${projectId}/resources/${encodeURIComponent(file.name)}`}
                                                                 />
                                                                 <IconButton
                                                                     name="item-remove"
+                                                                    data-test-id={"resource-delete-btn"}
                                                                     text={t("common.action.DeleteSmth", {
                                                                         smth: t("widget.FileWidget.file"),
                                                                     })}


### PR DESCRIPTION
Fixes:

- project resource with special characters in their name could not be deleted nor downloaded