### PR TITLE
Bugfix: If more triples than the configured graph store request size are written, a triple is dropped per request 

### DIFF
--- a/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/access/GraphStoreSink.scala
+++ b/silk-plugins/silk-plugins-rdf/src/main/scala/org/silkframework/plugins/dataset/rdf/access/GraphStoreSink.scala
@@ -9,7 +9,7 @@ import org.silkframework.runtime.activity.UserContext
 import org.silkframework.util.Uri
 
 import java.io.{BufferedOutputStream, File, FileOutputStream, OutputStream}
-import java.nio.file.{Files, StandardCopyOption}
+import java.nio.file.Files
 import java.util.logging.Logger
 import scala.util.Try
 
@@ -157,7 +157,6 @@ case class GraphStoreSink(graphStore: GraphStoreTrait,
             case fileUploadGraphStore: GraphStoreFileUploadTrait =>
               tempFile match {
                 case Some(fileToUpload) =>
-                  Files.copy(fileToUpload.toPath, new File("./upload" + nrGraphStoreRequests + ".nt").toPath, StandardCopyOption.REPLACE_EXISTING)
                   fileUploadGraphStore.uploadFileToGraph(graphUri, fileToUpload, "application/n-triples", comment)
                   nrGraphStoreRequests += 1
                 case None =>

--- a/silk-plugins/silk-plugins-rdf/src/test/scala/org/silkframework/plugins/dataset/rdf/access/GraphStoreSinkTest.scala
+++ b/silk-plugins/silk-plugins-rdf/src/test/scala/org/silkframework/plugins/dataset/rdf/access/GraphStoreSinkTest.scala
@@ -1,0 +1,43 @@
+package org.silkframework.plugins.dataset.rdf.access
+
+import org.apache.jena.query.DatasetFactory
+import org.apache.jena.rdf.model.ModelFactory
+import org.scalatest.{FlatSpec, MustMatchers}
+import org.silkframework.config.Prefixes
+import org.silkframework.entity.ValueType
+import org.silkframework.plugins.dataset.rdf.endpoint.JenaDatasetEndpoint
+import org.silkframework.runtime.activity.UserContext
+import org.silkframework.util.ConfigTestTrait
+
+class GraphStoreSinkTest extends FlatSpec with MustMatchers with ConfigTestTrait {
+  behavior of "Graph store sink"
+
+  implicit private val userContext: UserContext = UserContext.Empty
+  implicit private val prefixes: Prefixes = Prefixes.empty
+  private val STATEMENT_SIZE = 37
+
+  it should "chunk the triples according to the config" in {
+    val graph = "urn:graph:default"
+    val dataset = DatasetFactory.createTxnMem()
+    val sink = GraphStoreSink(new JenaDatasetEndpoint(dataset), graph, None, None, dropGraphOnClear = false)
+    sink.init()
+    for(i <- 10 to 19) {
+      // Every statement takes 37 bytes in the upload file
+      sink.writeStatement(s"urn:subj:$i", "urn:prop:p", "value", ValueType.UNTYPED)
+    }
+    dataset.getNamedModel(graph).size() mustBe 0
+    sink.writeStatement("s", "p", "v", ValueType.UNTYPED)
+    // The first 10 statements, the last statement is part of the next transaction
+    dataset.getNamedModel(graph).size() mustBe 10
+    sink.close()
+    dataset.getNamedModel(graph).size() mustBe 11
+  }
+
+  /** The properties that should be changed.
+    * If the value is [[None]] then the property value is removed,
+    * else it is set to the new value.
+    */
+  override def propertyMap: Map[String, Option[String]] = Map(
+    "graphstore.default.max.request.size" -> Some((STATEMENT_SIZE * 10).toString)
+  )
+}


### PR DESCRIPTION
Bugfix: If more triples than the configured graph store request size are written, a triple is dropped per request 