### PR TITLE
Fix: sync. variable workflow executions accumulate activity instances

### DIFF
--- a/silk-core/src/main/scala/org/silkframework/runtime/activity/Status.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/activity/Status.scala
@@ -66,6 +66,9 @@ sealed trait Status {
    */
   override def toString: String = message
 
+  /** If this activity has finished running. */
+  def finished(): Boolean = this.isInstanceOf[Status.Finished]
+
   /** The concrete status string. In order to distinguish different states of Finished. */
   def concreteStatus: String = {
     this match {

--- a/silk-core/src/test/scala/org/silkframework/util/StatusCodeTestTrait.scala
+++ b/silk-core/src/test/scala/org/silkframework/util/StatusCodeTestTrait.scala
@@ -19,4 +19,5 @@ trait StatusCodeTestTrait {
 
   // Server error
   final val INTERNAL_ERROR: Int = 500
+  final val SERVICE_UNAVAILABLE: Int = 503
 }

--- a/silk-workbench/silk-workbench-workflow/app/controllers/workflow/WorkflowApi.scala
+++ b/silk-workbench/silk-workbench-workflow/app/controllers/workflow/WorkflowApi.scala
@@ -169,9 +169,9 @@ class WorkflowApi @Inject() () extends InjectedController with UserContextAction
     implicit val (project, workflowTask) = getProjectAndTask[Workflow](projectName, workflowTaskName)
 
     val activity = workflowTask.activity[WorkflowWithPayloadExecutor]
-    val id = activity.startBlocking(workflowConfiguration)
+    val resultValue = activity.startBlockingAndGetValue(workflowConfiguration)
 
-    SerializationUtils.serializeCompileTime(activity.instance(id).value(), Some(project))
+    SerializationUtils.serializeCompileTime(resultValue, Some(project))
   }
 
   /**

--- a/silk-workbench/silk-workbench-workflow/app/controllers/workflow/WorkflowApi.scala
+++ b/silk-workbench/silk-workbench-workflow/app/controllers/workflow/WorkflowApi.scala
@@ -132,6 +132,10 @@ class WorkflowApi @Inject() () extends InjectedController with UserContextAction
       new ApiResponse(
         responseCode = "404",
         description = "If the specified project or workflow has not been found."
+      ),
+      new ApiResponse(
+        responseCode = "503",
+        description = "Workflow execution could not be started because concurrent execution limit is reached."
       )
   ))
   @RequestBody(
@@ -201,6 +205,10 @@ class WorkflowApi @Inject() () extends InjectedController with UserContextAction
       new ApiResponse(
         responseCode = "404",
         description = "If the specified project or workflow has not been found."
+      ),
+      new ApiResponse(
+        responseCode = "503",
+        description = "Workflow execution could not be started because concurrent execution limit is reached."
       )
     ))
   @RequestBody(

--- a/silk-workbench/silk-workbench-workflow/app/controllers/workflowApi/WorkflowApi.scala
+++ b/silk-workbench/silk-workbench-workflow/app/controllers/workflowApi/WorkflowApi.scala
@@ -152,6 +152,10 @@ class WorkflowApi @Inject()() extends InjectedController with ControllerUtilsTra
       new ApiResponse(
         responseCode = "500",
         description = "The workflow execution has failed."
+      ),
+      new ApiResponse(
+        responseCode = "503",
+        description = "Workflow execution could not be started because concurrent execution limit is reached."
       )
   ))
   @RequestBody(
@@ -283,6 +287,10 @@ class WorkflowApi @Inject()() extends InjectedController with ControllerUtilsTra
       new ApiResponse(
         responseCode = "500",
         description = "The workflow execution has failed."
+      ),
+      new ApiResponse(
+        responseCode = "503",
+        description = "Workflow execution could not be started because concurrent execution limit is reached."
       )
     ))
   @RequestBody(

--- a/silk-workbench/silk-workbench-workflow/app/controllers/workflowApi/WorkflowApi.scala
+++ b/silk-workbench/silk-workbench-workflow/app/controllers/workflowApi/WorkflowApi.scala
@@ -232,10 +232,10 @@ class WorkflowApi @Inject()() extends InjectedController with ControllerUtilsTra
 
     val (workflowConfig, mimeTypeOpt) = VariableWorkflowRequestUtils.queryStringToWorkflowConfig(project, workflowTask)
     val activity = workflowTask.activity[WorkflowWithPayloadExecutor]
-    val id = activity.startBlocking(workflowConfig)
+    val resultValue = activity.startBlockingAndGetValue(workflowConfig)
     mimeTypeOpt match {
       case Some(mimeType) =>
-        val outputResource = activity.instance(id).value().resourceManager.get(VariableWorkflowRequestUtils.OUTPUT_FILE_RESOURCE_NAME, mustExist = true)
+        val outputResource = resultValue.resourceManager.get(VariableWorkflowRequestUtils.OUTPUT_FILE_RESOURCE_NAME, mustExist = true)
         Result(
           header = ResponseHeader(OK, Map.empty),
           body = HttpEntity.Strict(ByteString(outputResource.loadAsBytes), Some(mimeType))

--- a/silk-workbench/silk-workbench-workflow/test/controllers/workflowApi/WorkflowApiTest.scala
+++ b/silk-workbench/silk-workbench-workflow/test/controllers/workflowApi/WorkflowApiTest.scala
@@ -2,17 +2,21 @@ package controllers.workflowApi
 
 import controllers.workflowApi.workflow.{WorkflowNodePortConfig, WorkflowNodesPortConfig}
 import helper.IntegrationTestTrait
+import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.{FlatSpec, MustMatchers}
-import org.silkframework.config.CustomTask
+import org.silkframework.config.{CustomTask, Prefixes, Task}
 import org.silkframework.entity.EntitySchema
-import org.silkframework.runtime.plugin.PluginRegistry
-import org.silkframework.serialization.json.JsonHelpers
-import org.silkframework.util.Uri
-import org.silkframework.workspace.SingleProjectWorkspaceProviderTestTrait
-import play.api.routing.Router
+import org.silkframework.execution.{ExecutionReport, ExecutionType, Executor, ExecutorOutput}
+import org.silkframework.runtime.activity.{ActivityContext, UserContext}
 import org.silkframework.runtime.plugin._
+import org.silkframework.serialization.json.JsonHelpers
+import org.silkframework.util.{ConfigTestTrait, Uri}
+import org.silkframework.workspace.SingleProjectWorkspaceProviderTestTrait
+import org.silkframework.workspace.activity.WorkspaceActivity
+import org.silkframework.workspace.activity.workflow.{Workflow, WorkflowOperator, WorkflowOperatorsParameter}
+import play.api.routing.Router
 
-class WorkflowApiTest extends FlatSpec with SingleProjectWorkspaceProviderTestTrait with IntegrationTestTrait with MustMatchers {
+class WorkflowApiTest extends FlatSpec with SingleProjectWorkspaceProviderTestTrait with ConfigTestTrait with IntegrationTestTrait with MustMatchers {
   behavior of "Workflow API"
 
   override def projectPathInClasspath: String = "2dc191ef-d583-4eb8-a8ed-f2a3fb94bd8f_WorkflowAPItestproject.zip"
@@ -39,6 +43,50 @@ class WorkflowApiTest extends FlatSpec with SingleProjectWorkspaceProviderTestTr
     portConfig.byTaskId.get("onePort") mustBe Some(WorkflowNodePortConfig(1, Some(1)))
     portConfig.byTaskId.get("fourPort") mustBe Some(WorkflowNodePortConfig(4, Some(4)))
   }
+
+  it should "return a 503 when too many concurrent variable workflows are started" in {
+    PluginRegistry.registerPlugin(classOf[BlockingTask])
+    PluginRegistry.registerPlugin(classOf[BlockingTaskExecutor])
+    val blockingTaskId = "blockingTask"
+    project.addTask(blockingTaskId, BlockingTask())
+    val workflowId = "concurrentWorkflow"
+    project.addTask(workflowId, Workflow(
+      operators = WorkflowOperatorsParameter(Seq(WorkflowOperator(
+        inputs = Seq.empty,
+        task = blockingTaskId,
+        outputs = Seq.empty,
+        errorOutputs = Seq(),
+        position = (100, 100),
+        blockingTaskId,
+        None,
+        Seq.empty
+      )))
+    ))
+    def executeWorkflowAsync(expectedResponseCode: Int): Unit = {
+      val url = controllers.workflowApi.routes.WorkflowApi.executeVariableWorkflowAsync(projectId, workflowId).url
+      val response = client.url(s"$baseUrl$url")
+        .withHttpHeaders(CONTENT_TYPE -> "text/csv")
+        .post("")
+      checkResponseExactStatusCode(response, expectedResponseCode)
+    }
+    for(_ <- 1 to WorkspaceActivity.maxConcurrentExecutionsPerActivity()) {
+      executeWorkflowAsync(CREATED)
+    }
+    executeWorkflowAsync(SERVICE_UNAVAILABLE)
+    BlockingTask.block = false
+    eventually {
+      BlockingTask.finishCounter must not be 0
+    }
+    executeWorkflowAsync(CREATED)
+  }
+
+  /** The properties that should be changed.
+    * If the value is [[None]] then the property value is removed,
+    * else it is set to the new value.
+    */
+  override def propertyMap: Map[String, Option[String]] = Map(
+    WorkspaceActivity.MAX_CONCURRENT_EXECUTIONS_CONFIG_KEY -> Some("2")
+  )
 }
 
 case class TestCustomTask(nrPorts: IntOptionParameter) extends CustomTask {
@@ -49,4 +97,32 @@ case class TestCustomTask(nrPorts: IntOptionParameter) extends CustomTask {
   }
 
   override def outputSchemaOpt: Option[EntitySchema] = None
+}
+
+object BlockingTask {
+  @volatile
+  var block = true
+  @volatile
+  var finishCounter = 0
+}
+
+/** Task that blocks until externally released. */
+case class BlockingTask() extends CustomTask {
+  override def inputSchemataOpt: Option[Seq[EntitySchema]] = None
+  override def outputSchemaOpt: Option[EntitySchema] = None
+}
+
+case class BlockingTaskExecutor() extends Executor[BlockingTask, ExecutionType] {
+  override def execute(task: Task[BlockingTask],
+                       inputs: Seq[ExecutionType#DataType],
+                       output: ExecutorOutput,
+                       execution: ExecutionType,
+                       context: ActivityContext[ExecutionReport])
+                      (implicit userContext: UserContext, prefixes: Prefixes): Option[ExecutionType#DataType] = {
+    while(BlockingTask.block) {
+      Thread.sleep(1)
+    }
+    BlockingTask.finishCounter += 1
+    None
+  }
 }

--- a/silk-workbench/silk-workbench-workspace/app/controllers/workspace/ActivityApi.scala
+++ b/silk-workbench/silk-workbench-workspace/app/controllers/workspace/ActivityApi.scala
@@ -103,6 +103,10 @@ class ActivityApi @Inject() (implicit system: ActorSystem, mat: Materializer) ex
           mediaType = "application/json",
           schema = new Schema(implementation = classOf[StartActivityResponse])
         ))
+      ),
+      new ApiResponse(
+        responseCode = "503",
+        description = "Activity execution could not be started because concurrent execution limit is reached."
       )
   ))
   @RequestBody(
@@ -155,6 +159,10 @@ class ActivityApi @Inject() (implicit system: ActorSystem, mat: Materializer) ex
           mediaType = "application/json",
           schema = new Schema(implementation = classOf[StartActivityResponse])
         ))
+      ),
+      new ApiResponse(
+        responseCode = "503",
+        description = "Activity execution could not be started because concurrent execution limit is reached."
       )
     ))
   @RequestBody(

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/activity/WorkspaceActivity.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/activity/WorkspaceActivity.scala
@@ -2,7 +2,7 @@ package org.silkframework.workspace.activity
 
 import java.time.Instant
 import java.util.logging.Logger
-import org.silkframework.config.{Prefixes, TaskSpec}
+import org.silkframework.config.{DefaultConfig, Prefixes, TaskSpec}
 import org.silkframework.runtime.activity.{ObservableMirror, _}
 import org.silkframework.runtime.plugin.ClassPluginDescription
 import org.silkframework.util.{Identifier, IdentifierGenerator}
@@ -10,6 +10,7 @@ import org.silkframework.workspace.{Project, ProjectTask}
 
 import scala.collection.immutable.ListMap
 import scala.reflect.ClassTag
+import scala.util.Try
 
 /**
   * An activity that is either attached to a project (ProjectActivity) or a task (TaskActivity) or is a GlobalWorkspaceActivity.
@@ -21,6 +22,7 @@ abstract class WorkspaceActivity[ActivityType <: HasValue : ClassTag]() {
     */
   private val identifierGenerator = new IdentifierGenerator(name)
   private val log: Logger = Logger.getLogger(this.getClass.getName)
+  lazy private val maxConcurrentExecutionsPerActivity = WorkspaceActivity.maxConcurrentExecutionsPerActivity()
 
   /**
     * Each workspace activity does have a current instance that's always defined.
@@ -36,7 +38,7 @@ abstract class WorkspaceActivity[ActivityType <: HasValue : ClassTag]() {
 
   /**
     * For non-singleton activities, this holds all instances.
-    * If there are more instances than [[WorkspaceActivity.MAX_CONTROLS_PER_ACTIVITY]], the oldest ones are removed.
+    * If there are more instances than [[maxConcurrentExecutionsPerActivity]], the oldest finished ones are removed.
     */
   @volatile
   private var instances: ListMap[Identifier, ActivityControl[ActivityType#ValueType]] = ListMap()
@@ -156,6 +158,23 @@ abstract class WorkspaceActivity[ActivityType <: HasValue : ClassTag]() {
   }
 
   /**
+    * Starts an activity in blocking mode and returns the result of the activity execution.
+    * The activity instance is removed automatically after the activity has finished.
+    * Optionally applies a supplied configuration to the started activity.
+    *
+    * @param config The activity parameters
+    * @param user The user context
+    * @return The identifier of the started activity
+    */
+  final def startBlockingAndGetValue(config: Map[String, String] = Map.empty)(implicit user: UserContext): ActivityType#ValueType = {
+    val (id, control) = addInstance(config)
+    control.startBlocking()
+    val value = control.value()
+    removeActivityInstance(id)
+    value
+  }
+
+  /**
     * The default configuration of this activity type.
     */
   final def defaultConfig: Map[String, String] = ClassPluginDescription(factory.getClass).parameterValues(factory)(Prefixes.empty)
@@ -181,10 +200,11 @@ abstract class WorkspaceActivity[ActivityType <: HasValue : ClassTag]() {
       }
     } else {
       val newControl = createControl(config)
-      if(instances.size >= WorkspaceActivity.MAX_CONTROLS_PER_ACTIVITY) {
+      if(instances.size >= maxConcurrentExecutionsPerActivity) {
         val activityDescription = projectOpt.map(p => s"In project ${p.id} activity '$name'").getOrElse(s"In workspace activity '$name'")
         log.warning(s"$activityDescription: Dropping an activity control instance because the control " +
-            s"instance queue is full (max. ${WorkspaceActivity.MAX_CONTROLS_PER_ACTIVITY}. Dropped instance ID: ${instances.head._1}")
+            s"instance queue is full (max. $maxConcurrentExecutionsPerActivity. Dropped instance ID: ${instances.head._1}." +
+        s" Make sure to remove consumed results by the client. This limit can be increased via config key '${WorkspaceActivity.MAX_CONCURRENT_EXECUTIONS_CONFIG_KEY}'.")
         instances = instances.drop(1)
       }
       instances += ((identifier, newControl))
@@ -210,10 +230,19 @@ abstract class WorkspaceActivity[ActivityType <: HasValue : ClassTag]() {
 
 object WorkspaceActivity {
 
+  val MAX_CONCURRENT_EXECUTIONS_CONFIG_KEY = "org.silkframework.runtime.activity.concurrentExecutions"
+
   /**
     * The maximum number of instances that are held in memory for each activity type.
     * If more instances are created, the oldest ones are removed.
     */
-  val MAX_CONTROLS_PER_ACTIVITY: Int = 20
-
+  def maxConcurrentExecutionsPerActivity(): Int = {
+    val cfg = DefaultConfig.instance()
+    val defaultValue = 20
+    if(cfg.hasPath(MAX_CONCURRENT_EXECUTIONS_CONFIG_KEY)) {
+      Try(cfg.getInt(MAX_CONCURRENT_EXECUTIONS_CONFIG_KEY)).getOrElse(defaultValue)
+    } else {
+      defaultValue
+    }
+  }
 }


### PR DESCRIPTION
- Make number of concurrent activity instances configurable via 'org.silkframework.runtime.activity.concurrentExecutions'