### PR TITLE
Remove root page

### DIFF
--- a/silk-workbench/app/controllers/Workbench.scala
+++ b/silk-workbench/app/controllers/Workbench.scala
@@ -1,17 +1,16 @@
 package controllers
 
-import config.WorkbenchConfig
 import config.WorkbenchConfig.WorkspaceReact
+import config.baseUrl
 import controllers.core.UserContextActions
-import javax.inject.Inject
 import play.api.mvc.{Action, AnyContent, InjectedController}
-import play.twirl.api.Html
+
+import javax.inject.Inject
 
 class Workbench @Inject() (implicit workspaceReact: WorkspaceReact) extends InjectedController with UserContextActions {
 
   def index: Action[AnyContent] = RequestUserContextAction { implicit request => implicit userContext =>
-    val welcome = Html(WorkbenchConfig.get.welcome.loadAsString())
-    Ok(views.html.start(welcome))
+    Redirect(s"$baseUrl/workbench?itemType=project")
   }
 
   def reactUIRoot(): Action[AnyContent] = Action {

--- a/workspace/src/app/store/ducks/common/initialState.ts
+++ b/workspace/src/app/store/ducks/common/initialState.ts
@@ -23,7 +23,7 @@ export function initialCommonState(): ICommonState {
         searchQuery: "",
         error: {},
         availableDataTypes: {},
-        initialSettings: { emptyWorkspace: true, initialLanguage: "en", hotKeys: {} },
+        initialSettings: { emptyWorkspace: true, initialLanguage: "en", hotKeys: {}},
         exportTypes: [],
         artefactModal: initialArtefactModalState(),
     };

--- a/workspace/src/app/store/ducks/workspace/requests.ts
+++ b/workspace/src/app/store/ducks/workspace/requests.ts
@@ -319,3 +319,11 @@ export const requestProjectTags = async (projectId: string): Promise<FetchRespon
     fetch({
         url: workspaceApi(`/projects/${projectId}/tags`),
     });
+
+/** Import the "movies" example project. */
+export const importExampleProjectRequest = async (): Promise<FetchResponse<void>> => {
+    return fetch({
+        url: legacyApiEndpoint("movies/importExample"),
+        method: "POST"
+    })
+}

--- a/workspace/src/app/views/layout/Header/ExampleProjectImportMenu.tsx
+++ b/workspace/src/app/views/layout/Header/ExampleProjectImportMenu.tsx
@@ -1,0 +1,51 @@
+import {importExampleProjectRequest} from "@ducks/workspace/requests";
+import useErrorHandler from "../../../hooks/useErrorHandler";
+import {useDispatch} from "react-redux";
+import {MenuItem} from "@eccenca/gui-elements";
+import React from "react";
+import {useTranslation} from "react-i18next";
+import {routerOp} from "@ducks/router";
+import {requestProjectMetadata} from "@ducks/shared/requests";
+
+/** Component to load the "movies" example project. */
+export const ExampleProjectImportMenu = () => {
+    const {registerError} = useErrorHandler()
+    const dispatch = useDispatch();
+    const [t] = useTranslation()
+    const [exampleProjectLoaded, setExampleProjectLoaded] = React.useState<boolean | undefined>(undefined);
+    const [loading, setLoading] = React.useState(false)
+    const moviesProjectId = "movies"
+
+    React.useEffect(() => {
+        checkMoviesProjectExists()
+    }, [])
+
+    const checkMoviesProjectExists = async () => {
+        try {
+            await requestProjectMetadata(moviesProjectId)
+            setExampleProjectLoaded(true)
+        } catch(ex) {
+            setExampleProjectLoaded(false)
+        }
+    }
+
+    const importExampleProject = async () => {
+        try {
+            setLoading(true)
+            await importExampleProjectRequest()
+            dispatch(routerOp.goToPage(`projects/${moviesProjectId}`))
+        } catch(ex) {
+            registerError("header.importExampleProject", "Could not import example project.", ex)
+        } finally {
+            setLoading(false)
+        }
+    }
+    return exampleProjectLoaded !== null && !exampleProjectLoaded ?
+        <MenuItem
+            text={t("common.action.loadExampleProject")}
+            icon={"item-add-artefact"}
+            disabled={loading}
+            onClick={importExampleProject}
+        /> :
+        null
+}

--- a/workspace/src/app/views/layout/Header/Header.tsx
+++ b/workspace/src/app/views/layout/Header/Header.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { useTranslation } from "react-i18next";
-import { useLocation } from "react-router-dom";
+import React, {useState} from "react";
+import {useDispatch, useSelector} from "react-redux";
+import {useTranslation} from "react-i18next";
+import {useLocation} from "react-router-dom";
 import {
     ApplicationHeader,
     ApplicationSidebarNavigation,
@@ -24,18 +24,19 @@ import {
     ToolbarSection,
     WorkspaceHeader,
 } from "@eccenca/gui-elements";
-import { commonOp, commonSel } from "@ducks/common";
-import { workspaceSel } from "@ducks/workspace";
-import { routerOp } from "@ducks/router";
+import {commonOp, commonSel} from "@ducks/common";
+import {workspaceSel} from "@ducks/workspace";
+import {routerOp} from "@ducks/router";
 import CreateButton from "../../shared/buttons/CreateButton";
-import { CreateArtefactModal } from "../../shared/modals/CreateArtefactModal/CreateArtefactModal";
-import { NotificationsMenu } from "../../shared/ApplicationNotifications/NotificationsMenu";
-import { triggerHotkeyHandler } from "../../shared/HotKeyHandler/HotKeyHandler";
-import { APPLICATION_CORPORATION_NAME, APPLICATION_NAME, APPLICATION_SUITE_NAME } from "../../../constants/base";
-import { CONTEXT_PATH, SERVE_PATH } from "../../../constants/path";
-import { APP_VIEWHEADER_ID } from "../../shared/PageHeader/PageHeader";
-import { pluginRegistry, SUPPORTED_PLUGINS } from "../../plugins/PluginRegistry";
-import { UserMenuFooterProps } from "../../plugins/plugin.types";
+import {CreateArtefactModal} from "../../shared/modals/CreateArtefactModal/CreateArtefactModal";
+import {NotificationsMenu} from "../../shared/ApplicationNotifications/NotificationsMenu";
+import {triggerHotkeyHandler} from "../../shared/HotKeyHandler/HotKeyHandler";
+import {APPLICATION_CORPORATION_NAME, APPLICATION_NAME, APPLICATION_SUITE_NAME} from "../../../constants/base";
+import {CONTEXT_PATH, SERVE_PATH} from "../../../constants/path";
+import {APP_VIEWHEADER_ID} from "../../shared/PageHeader/PageHeader";
+import {pluginRegistry, SUPPORTED_PLUGINS} from "../../plugins/PluginRegistry";
+import {UserMenuFooterProps} from "../../plugins/plugin.types";
+import {ExampleProjectImportMenu} from "./ExampleProjectImportMenu";
 
 interface IProps {
     onClickApplicationSidebarExpand: any;
@@ -243,6 +244,7 @@ export function Header({ onClickApplicationSidebarExpand, isApplicationSidebarEx
                                             href={CONTEXT_PATH + "/doc/api"}
                                             icon={"application-homepage"}
                                         />
+                                        <ExampleProjectImportMenu />
                                         {!!dmBaseUrl && diUserMenuItems && <diUserMenuItems.Component />}
                                     </Menu>
                                 </ToolbarSection>

--- a/workspace/src/app/views/layout/Header/Header.tsx
+++ b/workspace/src/app/views/layout/Header/Header.tsx
@@ -243,11 +243,6 @@ export function Header({ onClickApplicationSidebarExpand, isApplicationSidebarEx
                                             href={CONTEXT_PATH + "/doc/api"}
                                             icon={"application-homepage"}
                                         />
-                                        <MenuItem
-                                            text={t("common.action.backOld", "Back to old workspace")}
-                                            href={CONTEXT_PATH + "/workspace"}
-                                            icon={"application-legacygui"}
-                                        />
                                         {!!dmBaseUrl && diUserMenuItems && <diUserMenuItems.Component />}
                                     </Menu>
                                 </ToolbarSection>

--- a/workspace/src/locales/manual/en.json
+++ b/workspace/src/locales/manual/en.json
@@ -224,6 +224,7 @@
             "download": "Download",
             "export": "Export to",
             "exportTo": "Export to",
+            "loadExampleProject": "Add \"movies\" example project",
             "logout": "Logout",
             "moreOptions": "Show more options",
             "openInNewTab": "Open link in new tab",

--- a/workspace/src/locales/manual/en.json
+++ b/workspace/src/locales/manual/en.json
@@ -214,7 +214,6 @@
             "CopyProject": "Copy to another project",
             "abort": "Abort",
             "add": "Add",
-            "backOld": "Back to old workspace",
             "cancel": "Cancel",
             "copy": "Copy",
             "clone": "Clone",


### PR DESCRIPTION
- Redirect to workbench project search page
- Remove legacy workspace link from user menu
- Add "load example project" action to user menu