### PR TITLE
Fix bugs in mapping editor and workflow re-configuration

### DIFF
--- a/workspace/src/app/views/pages/MappingEditor/HierarchicalMapping/containers/MappingRule/DraggableItem.jsx
+++ b/workspace/src/app/views/pages/MappingEditor/HierarchicalMapping/containers/MappingRule/DraggableItem.jsx
@@ -83,7 +83,7 @@ class DraggableItem extends React.Component {
                 isDragDisabled={this.state.expanded}
                 style={{ width: "15" }}
                 key={this.props.id}
-                draggableId={this.props.id}
+                draggableId={`draggable-${this.props.id}`}
                 index={this.props.pos}
             >
                 {(provided, snapshot) => (


### PR DESCRIPTION
- In mapping rules, using a target property ending on /valueOf, breaks the editor, because the drag and drop library (react-beautiful-dnd), tries to overwrite read-only object prototype members.
- Re-configuration of the 'file' dataset parameter in a workflow of a dataset used as source leads to the file being deleted.