### PR TITLE
Consistent transform errors

### DIFF
--- a/silk-plugins/silk-serialization-json/src/main/scala/org/silkframework/serialization/json/JsonSerializers.scala
+++ b/silk-plugins/silk-serialization-json/src/main/scala/org/silkframework/serialization/json/JsonSerializers.scala
@@ -227,7 +227,7 @@ object JsonSerializers {
       try {
         val transformerPluginId = stringValue(value, FUNCTION)
         val transformer = Transformer(PluginBackwardCompatibility.transformerIdMapping.getOrElse(transformerPluginId, transformerPluginId), ParameterValuesJsonFormat.read(value))
-        TransformInput(id, transformer, inputs.toList)
+        TransformInput(id, transformer, inputs.toIndexedSeq)
       } catch {
         case ex: Exception => throw new ValidationException(ex.getMessage, id, "Transformation")
       }

--- a/silk-rules/src/main/scala/org/silkframework/rule/evaluation/DetailedEvaluator.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/evaluation/DetailedEvaluator.scala
@@ -69,7 +69,7 @@ object DetailedEvaluator {
   def apply(rules: Seq[TransformRule], entity: Entity): DetailedEntity = {
     val subjectRule = rules.find(_.target.isEmpty)
     val uris = subjectRule match {
-      case Some(rule) => rule(entity)
+      case Some(rule) => rule(entity).values
       case None => Seq(entity.uri.toString)
     }
 
@@ -126,9 +126,10 @@ object DetailedEvaluator {
       try {
         TransformedValue(ti, ti.transformer(children.map(_.values)), children)
       } catch {
-        case NonFatal(ex) => TransformedValue(ti, Seq.empty, children, Some(ex))
+        case NonFatal(ex) =>
+          TransformedValue(ti, Seq.empty, children, Some(ex))
       }
 
-    case pi: PathInput => InputValue(pi, input(entity))
+    case pi: PathInput => InputValue(pi, input(entity).values)
   }
 }

--- a/silk-rules/src/main/scala/org/silkframework/rule/evaluation/DetailedIndexer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/evaluation/DetailedIndexer.scala
@@ -41,6 +41,6 @@ object DetailedIndexer {
     val values = if(sourceOrTarget) cmp.inputs.source(entity) else cmp.inputs.target(entity)
     val distanceLimit = cmp.threshold * (1.0 - limit)
 
-    ComparisonIndex(cmp.metric.index(values, distanceLimit, sourceOrTarget), values, cmp)
+    ComparisonIndex(cmp.metric.index(values.values, distanceLimit, sourceOrTarget), values.values, cmp)
   }
 }

--- a/silk-rules/src/main/scala/org/silkframework/rule/execution/TransformReport.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/execution/TransformReport.scala
@@ -86,10 +86,12 @@ object TransformReport {
     * @param value The erroneous value
     * @param message The error description
     */
-  case class RuleError(entity: String, value: Seq[Seq[String]], message: String)
+  case class RuleError(entity: String, value: Seq[Seq[String]], message: String, operatorId: Option[Identifier] = None)
 
   object RuleError {
-    def apply(entity: String, value: Seq[Seq[String]], exception: Throwable): RuleError = new RuleError(entity, value, exception.getMessage)
+    def fromException(entity: String, value: Seq[Seq[String]], exception: Throwable, operatorId: Option[Identifier] = None): RuleError = {
+      new RuleError(entity, value, exception.getMessage, operatorId)
+    }
   }
 
 }

--- a/silk-rules/src/main/scala/org/silkframework/rule/execution/TransformReportBuilder.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/execution/TransformReportBuilder.scala
@@ -26,13 +26,13 @@ private class TransformReportBuilder(task: Task[TransformSpec], rules: Seq[Trans
   // The maximum number of erroneous values to be held for each rule.
   private val maxSampleErrors = 10
 
-  def addRuleError(rule: TransformRule, entity: Entity, ex: Throwable): Unit = {
+  def addRuleError(rule: TransformRule, entity: Entity, ex: Throwable, operatorId: Option[Identifier] = None): Unit = {
     val currentRuleResult = ruleResults(rule.id)
 
     val updatedRuleResult =
       if(currentRuleResult.sampleErrors.size < maxSampleErrors) {
         val values = rule.sourcePaths.map(p => entity.evaluate(UntypedPath(p.operators)))
-        currentRuleResult.withError(RuleError(entity.uri, values, ex))
+        currentRuleResult.withError(RuleError.fromException(entity.uri, values, ex, operatorId))
       } else {
         currentRuleResult.withError()
       }

--- a/silk-rules/src/main/scala/org/silkframework/rule/input/Input.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/input/Input.scala
@@ -31,7 +31,7 @@ trait Input extends Operator {
    * @param entity The entity from which the values should be read.
    * @return The values.
    */
-  def apply(entity: Entity): Seq[String]
+  def apply(entity: Entity): Value
 }
 
 object Input {

--- a/silk-rules/src/main/scala/org/silkframework/rule/input/PathInput.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/input/PathInput.scala
@@ -39,10 +39,11 @@ case class PathInput(id: Identifier = Operator.generateId, path: Path) extends I
     * As a path input does not have any children, an [IllegalArgumentException] will be thrown if the provided children sequence is nonempty.
     */
   override def withChildren(newChildren: Seq[Operator]): PathInput = {
-    if(newChildren.isEmpty)
+    if(newChildren.isEmpty) {
       this
-    else
+    } else {
       throw new IllegalArgumentException("PathInput cannot have any children")
+    }
   }
 
   /**
@@ -51,13 +52,9 @@ case class PathInput(id: Identifier = Operator.generateId, path: Path) extends I
    * @param entity The entity.
    * @return The values.
    */
-  override def apply(entity: Entity): Seq[String] = {
-    eval(entity)
-  }
-
-  private def eval(entity: Entity): Seq[String] = {
+  override def apply(entity: Entity): Value = {
     if(path.operators.isEmpty) {
-      Array(entity.uri.toString)
+      Value(Array(entity.uri.toString))
     } else {
       var index = cachedPathIndex
       if(index < 0 || index >= entity.schema.typedPaths.size || entity.schema.typedPaths(index).normalizedSerialization != path.normalizedSerialization) {
@@ -67,7 +64,7 @@ case class PathInput(id: Identifier = Operator.generateId, path: Path) extends I
         }
         cachedPathIndex = index
       }
-      entity.evaluate(index)
+      Value(entity.evaluate(index))
     }
   }
 }

--- a/silk-rules/src/main/scala/org/silkframework/rule/input/TransformInput.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/input/TransformInput.scala
@@ -15,6 +15,7 @@
 package org.silkframework.rule.input
 
 import org.silkframework.entity.Entity
+import org.silkframework.execution.ExecutionException
 import org.silkframework.rule.Operator
 import org.silkframework.runtime.plugin.PluginBackwardCompatibility
 import org.silkframework.runtime.serialization.{ReadContext, WriteContext, XmlFormat, XmlSerialization}
@@ -50,6 +51,8 @@ case class TransformInput(id: Identifier = Operator.generateId, transformer: Tra
     try {
       Value(transformer(inputValues), errors)
     } catch {
+      case ex: ExecutionException if ex.abortExecution =>
+        throw ex
       case NonFatal(ex) =>
         errors +:= OperatorEvaluationError(id, ex)
         Value(Seq.empty, errors)

--- a/silk-rules/src/main/scala/org/silkframework/rule/input/Value.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/input/Value.scala
@@ -1,0 +1,10 @@
+package org.silkframework.rule.input
+
+import org.silkframework.util.Identifier
+
+/**
+  * Holds the values returned by an input operator.
+  */
+case class Value(values: Seq[String], errors: Iterable[OperatorEvaluationError] = None)
+
+case class OperatorEvaluationError(operatorId: Identifier, error: Throwable)

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/validation/ValidateRegex.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/validation/ValidateRegex.scala
@@ -32,7 +32,7 @@ case class ValidateRegex(
 
   private val compiledRegex = new Regex(regex)
 
-  override def evaluate(value: String) = {
+  override def evaluate(value: String): String = {
     if(!compiledRegex.pattern.matcher(value).matches()) {
       throw new ValidationException(s"Value '$value' did not match regular expression '$regex'.")
     } else {

--- a/silk-rules/src/main/scala/org/silkframework/rule/similarity/Comparison.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/similarity/Comparison.scala
@@ -52,14 +52,14 @@ case class Comparison(id: Identifier = Operator.generateId,
   override def apply(entities: DPair[Entity], limit: Double): Option[Double] = {
     val values1 =
       try {
-        sourceInput.apply(entities.source)
+        sourceInput.apply(entities.source).values
       } catch {
         case NonFatal(_) =>
           Seq.empty
       }
     val values2 =
       try {
-        targetInput.apply(entities.target)
+        targetInput.apply(entities.target).values
       } catch {
         case NonFatal(_) =>
           Seq.empty
@@ -82,7 +82,7 @@ case class Comparison(id: Identifier = Operator.generateId,
     * @return A set of (multidimensional) indexes. Entities within the threshold will always get the same index.
     */
   override def index(entity: Entity, sourceOrTarget: Boolean, limit: Double): Index = {
-    val values = Try(inputs.select(sourceOrTarget)(entity)).getOrElse(Seq.empty)
+    val values = Try(inputs.select(sourceOrTarget)(entity).values).getOrElse(Seq.empty)
 
     val distanceLimit = threshold * (1.0 - limit)
 

--- a/silk-rules/src/test/scala/org/silkframework/rule/TransformRuleTest.scala
+++ b/silk-rules/src/test/scala/org/silkframework/rule/TransformRuleTest.scala
@@ -1,5 +1,6 @@
 package org.silkframework.rule
-
+
+
 import org.silkframework.entity.paths.UntypedPath
 import org.silkframework.rule.input.{PathInput, TransformInput}
 import org.silkframework.rule.plugins.transformer.normalize.LowerCaseTransformer
@@ -79,7 +80,7 @@ class TransformRuleTest extends AnyFlatSpec with Matchers {
         uriRule = None,
         typeRules = Seq.empty,
         propertyRules = Seq(
-          ComplexMapping("invalidRule", TransformInput("duplicateID", LowerCaseTransformer(), Seq(PathInput("duplicateID", UntypedPath.empty))))
+          ComplexMapping("invalidRule", TransformInput("duplicateID", LowerCaseTransformer(), IndexedSeq(PathInput("duplicateID", UntypedPath.empty))))
         )
       )
     )

--- a/silk-rules/src/test/scala/org/silkframework/rule/execution/ExecuteTransformTest.scala
+++ b/silk-rules/src/test/scala/org/silkframework/rule/execution/ExecuteTransformTest.scala
@@ -66,7 +66,7 @@ class ExecuteTransformTest extends AnyFlatSpec with Matchers with MockitoSugar {
   }
 
   private def mapping(id: String, prop: String) = {
-    val transformation = TransformInput(inputs = Seq(PathInput(path = UntypedPath(prop))), transformer = transformerWithExceptions())
+    val transformation = TransformInput(inputs = IndexedSeq(PathInput(path = UntypedPath(prop))), transformer = transformerWithExceptions())
     ComplexMapping(id = Identifier(id), operator = transformation, target = Some(MappingTarget(Uri(prop + "Target"))))
   }
 

--- a/silk-rules/src/test/scala/org/silkframework/rule/similarity/ComparisonTest.scala
+++ b/silk-rules/src/test/scala/org/silkframework/rule/similarity/ComparisonTest.scala
@@ -13,11 +13,12 @@
  */
 
 package org.silkframework.rule.plugins.similarity
-
+
+
 import org.silkframework.config.Prefixes
 import org.silkframework.entity.Entity
 import org.silkframework.rule.Operator
-import org.silkframework.rule.input.Input
+import org.silkframework.rule.input.{Input, Value}
 import org.silkframework.rule.similarity.{Comparison, DistanceMeasure}
 import org.silkframework.testutil.approximatelyEqualTo
 import org.silkframework.util.{DPair, Identifier}
@@ -48,7 +49,7 @@ class ComparisonTest extends AnyFlatSpec with Matchers {
 
   private object DummyInput extends Input {
     val id = Identifier.random
-    def apply(entity: Entity): Seq[String] = Seq("dummy")
+    def apply(entity: Entity): Value = Value(Seq("dummy"))
     def toXML(implicit prefixes: Prefixes): Node = null
     def children = Seq.empty
     def withChildren(newChildren: Seq[Operator]) = ???

--- a/silk-workbench/silk-workbench-rules/app/controllers/transform/PeakTransformApi.scala
+++ b/silk-workbench/silk-workbench-rules/app/controllers/transform/PeakTransformApi.scala
@@ -326,7 +326,8 @@ object PeakTransformApi {
       tryCounter += 1
       val entity = exampleEntities.next()
       try {
-        val transformResult = rule(entity)
+        //TODO forward errors?
+        val transformResult = rule(entity).values
         if (transformResult.nonEmpty) {
           resultBuffer.append(PeakResult(entity.values, transformResult))
           exampleCounter += 1

--- a/silk-workbench/silk-workbench-rules/app/controllers/transform/PeakTransformApi.scala
+++ b/silk-workbench/silk-workbench-rules/app/controllers/transform/PeakTransformApi.scala
@@ -326,10 +326,15 @@ object PeakTransformApi {
       tryCounter += 1
       val entity = exampleEntities.next()
       try {
-        //TODO forward errors?
-        val transformResult = rule(entity).values
-        if (transformResult.nonEmpty) {
-          resultBuffer.append(PeakResult(entity.values, transformResult))
+        val transformResult = rule(entity)
+        for(error <- transformResult.errors) {
+          errorCounter += 1
+          if (errorMessage.isEmpty) {
+            errorMessage = error.error.getClass.getSimpleName + ": " + Option(error.error.getMessage).getOrElse("")
+          }
+        }
+        if (transformResult.values.nonEmpty) {
+          resultBuffer.append(PeakResult(entity.values, transformResult.values))
           exampleCounter += 1
         }
       } catch {

--- a/silk-workbench/silk-workbench-rules/test/controllers/transform/PeakTransformApiTest.scala
+++ b/silk-workbench/silk-workbench-rules/test/controllers/transform/PeakTransformApiTest.scala
@@ -1,6 +1,7 @@
 package controllers.transform
 
-import helper.IntegrationTestTrait
+import helper.IntegrationTestTrait
+
 import org.silkframework.entity.paths.UntypedPath
 import org.silkframework.entity.{Entity, EntitySchema}
 import org.silkframework.rule.input.{PathInput, TransformInput, Transformer}
@@ -52,7 +53,7 @@ class PeakTransformApiTest extends AnyFlatSpec with SingleProjectWorkspaceProvid
 
   private def transformRule(transformer: Transformer): ComplexMapping = {
     val transformation = TransformInput(transformer = transformer,
-      inputs = Seq(PathInput("p", UntypedPath("a")), PathInput("p", UntypedPath("b"))))
+      inputs = IndexedSeq(PathInput("p", UntypedPath("a")), PathInput("p", UntypedPath("b"))))
     ComplexMapping(operator = transformation)
   }
 

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceProviderTestTrait.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceProviderTestTrait.scala
@@ -136,9 +136,9 @@ trait WorkspaceProviderTestTrait extends AnyFlatSpec with Matchers with MockitoS
                   ComplexMapping(
                     id = "complexId",
                     operator = TransformInput("lower", transformer = LowerCaseTransformer(),
-                      inputs = Seq(
+                      inputs = IndexedSeq(
                         TransformInput("concat", transformer = ConcatTransformer(),
-                          inputs = Seq(
+                          inputs = IndexedSeq(
                             PathInput("path", UntypedPath.parse("path"))
                           )
                         )


### PR DESCRIPTION
The handling of errors in transform rules has been aligned with what is already shown in the evaluation (CMEM-5130)
  - If a nested operator throws a validation error (e.g., if the input value is not a number for numeric operators), this no longer leads to a failure of the entire rule.
  - The error will be added to the execution report.
  - Failed operators will return no value.