### PR TITLE
Reload failed tasks after project/workspace reload

### DIFF
--- a/silk-core/src/main/scala/org/silkframework/workspace/WorkspaceProvider.scala
+++ b/silk-core/src/main/scala/org/silkframework/workspace/WorkspaceProvider.scala
@@ -330,12 +330,7 @@ case class TaskLoadingError(projectId: Option[Identifier],
                             label: Option[String] = None,
                             description: Option[String] = None,
                             factoryFunction: Option[(ParameterValues, PluginContext) => LoadedTask[_ <: TaskSpec]],
-                            originalParameterValues: Option[OriginalTaskData]) {
-
-
-
-
-}
+                            originalParameterValues: Option[OriginalTaskData])
 
 /** Data necessary to restore a task that has failed loading. */
 case class OriginalTaskData(pluginId: String,

--- a/silk-core/src/main/scala/org/silkframework/workspace/WorkspaceProvider.scala
+++ b/silk-core/src/main/scala/org/silkframework/workspace/WorkspaceProvider.scala
@@ -330,7 +330,12 @@ case class TaskLoadingError(projectId: Option[Identifier],
                             label: Option[String] = None,
                             description: Option[String] = None,
                             factoryFunction: Option[(ParameterValues, PluginContext) => LoadedTask[_ <: TaskSpec]],
-                            originalParameterValues: Option[OriginalTaskData])
+                            originalParameterValues: Option[OriginalTaskData]) {
+
+
+
+
+}
 
 /** Data necessary to restore a task that has failed loading. */
 case class OriginalTaskData(pluginId: String,

--- a/silk-workbench/silk-workbench-workspace/app/controllers/workspaceApi/project/ProjectLoadingErrors.scala
+++ b/silk-workbench/silk-workbench-workspace/app/controllers/workspaceApi/project/ProjectLoadingErrors.scala
@@ -72,7 +72,7 @@ object ProjectLoadingErrors {
 
     override def errorTitle: String = "Task loading error"
 
-    override def httpErrorCode: Option[Int] = Some(HttpURLConnection.HTTP_INTERNAL_ERROR)
+    override def httpErrorCode: Option[Int] = Some(HttpURLConnection.HTTP_BAD_REQUEST)
 
     override def additionalJson: JsObject = {
       Json.obj(

--- a/silk-workbench/silk-workbench-workspace/app/controllers/workspaceApi/project/ProjectLoadingErrors.scala
+++ b/silk-workbench/silk-workbench-workspace/app/controllers/workspaceApi/project/ProjectLoadingErrors.scala
@@ -1,13 +1,22 @@
 package controllers.workspaceApi.project
 
 import controllers.errorReporting.ErrorReport.{ErrorReportItem, Stacktrace}
-import org.silkframework.workspace.TaskLoadingError
-import play.api.libs.json.{Format, Json}
+import org.silkframework.config.MetaData
+import org.silkframework.runtime.activity.UserContext
+import org.silkframework.runtime.plugin.{ParameterValues, PluginContext}
+import org.silkframework.runtime.validation.{NotFoundException, RequestException}
+import org.silkframework.workbench.utils.JsonRequestException
+import org.silkframework.workspace.{Project, TaskLoadingError}
+import play.api.libs.json.{JsObject, Json}
+
+import java.net.HttpURLConnection
+import scala.util.Try
 
 /**
   * Used for the project task loading error report API.
   */
 object ProjectLoadingErrors {
+
   def fromTaskLoadingError(taskLoadingError: TaskLoadingError): ErrorReportItem = {
     ErrorReportItem(
       projectId = taskLoadingError.projectId.map(_.toString),
@@ -20,4 +29,56 @@ object ProjectLoadingErrors {
       stackTrace = Some(Stacktrace.fromException(taskLoadingError.throwable))
     )
   }
+
+  /**
+    * Tries to reload all tasks that caused loading errors.
+    * Loading errors that are resolved are removed from the project.
+    */
+  def tryReloadTasks(project: Project)(implicit user: UserContext): Unit = {
+    for(loadingError <- project.loadingErrors) {
+      Try(reloadTask(project, loadingError))
+    }
+  }
+
+  /**
+    * Reloads a task from a task loading error.
+    *
+    * @param project The project
+    * @param taskLoadingError The task loading error
+    * @param parameterValues Optionally overwrites parameter values.
+    */
+  def reloadTask(project: Project, taskLoadingError: TaskLoadingError, parameterValues: Option[ParameterValues] = None)
+                (implicit user: UserContext): Unit = {
+    taskLoadingError.factoryFunction match {
+      case Some(reloadFunction) =>
+        reloadFunction(parameterValues.getOrElse(ParameterValues.empty), PluginContext.fromProject(project)).taskOrError match {
+          case Left(error) =>
+            val taskLoadingError = ProjectLoadingErrors.fromTaskLoadingError(error)
+            throw CannotReloadTaskException(taskLoadingError)
+          case Right(task) =>
+            project.updateAnyTask(task.id, task.data, Some(MetaData(label = taskLoadingError.label, description = taskLoadingError.description)))
+            project.removeLoadingError(task.id)
+        }
+      case None =>
+        throw new NotFoundException("The task cannot be reloaded.")
+    }
+  }
+
+  /**
+    * Thrown if a task could not be (re)loaded.
+    */
+  case class CannotReloadTaskException(taskLoadingError: ErrorReportItem)
+    extends RequestException(s"The task could not be loaded. Summary: ${taskLoadingError.errorSummary}", None) with JsonRequestException {
+
+    override def errorTitle: String = "Task loading error"
+
+    override def httpErrorCode: Option[Int] = Some(HttpURLConnection.HTTP_INTERNAL_ERROR)
+
+    override def additionalJson: JsObject = {
+      Json.obj(
+        "taskLoadingError" -> Json.toJson(taskLoadingError)
+      )
+    }
+  }
 }
+


### PR DESCRIPTION
- Fixed: Reloaded failed tasks are missing the original label and description