### PR TITLE
Fix issues when updating a plugin spec at runtime

### DIFF
--- a/workspace/src/app/views/shared/TaskConfig/TaskConfigPreview.tsx
+++ b/workspace/src/app/views/shared/TaskConfig/TaskConfigPreview.tsx
@@ -56,8 +56,13 @@ export function TaskConfigPreview({ taskData, taskDescription }: IProps) {
                 Object.entries(obj)
                     .filter(([key]) => {
                         const pd = paramDescriptions[key];
-                        const passwordParameter = pd.parameterType === INPUT_TYPES.PASSWORD;
-                        return pd && pd.visibleInDialog && !pd.advanced && !passwordParameter;
+                        // It is possible that a new version of the task plugin has changed or removed parameters. Ignore parameters without parameter spec.
+                        if(!pd) {
+                            return false
+                        } else {
+                            const passwordParameter = pd.parameterType === INPUT_TYPES.PASSWORD;
+                            return pd && pd.visibleInDialog && !pd.advanced && !passwordParameter;
+                        }
                     })
                     .forEach(([paramName, paramValue]) => {
                         const value = paramDisplayValue(paramValue);

--- a/workspace/src/app/views/taskViews/shared/rules/rule.utils.tsx
+++ b/workspace/src/app/views/taskViews/shared/rules/rule.utils.tsx
@@ -68,6 +68,13 @@ const extractOperatorNodeFromTransformInput = (
         extractOperatorNodeFromValueInput(input, result, isTarget, ruleOperator)
     );
     const op = ruleOperator(transformInput.function, "TransformOperator");
+    const parameters = transformInput.parameters
+    Object.entries(op.parameterSpecification).forEach(([parameterId, paramSpec]) => {
+        if(parameters[parameterId] == null) {
+            // Rule parameters are missing that are available in the plugin spec,
+            parameters[parameterId] = paramSpec.defaultValue
+        }
+    })
     result.push({
         nodeId: transformInput.id,
         inputs: inputs,

--- a/workspace/src/app/views/taskViews/shared/rules/rule.utils.tsx
+++ b/workspace/src/app/views/taskViews/shared/rules/rule.utils.tsx
@@ -69,12 +69,14 @@ const extractOperatorNodeFromTransformInput = (
     );
     const op = ruleOperator(transformInput.function, "TransformOperator");
     const parameters = transformInput.parameters
-    Object.entries(op.parameterSpecification).forEach(([parameterId, paramSpec]) => {
-        if(parameters[parameterId] == null) {
-            // Rule parameters are missing that are available in the plugin spec,
-            parameters[parameterId] = paramSpec.defaultValue
-        }
-    })
+    if(op) {
+        Object.entries(op.parameterSpecification).forEach(([parameterId, paramSpec]) => {
+            if(parameters[parameterId] == null) {
+                // Rule parameters are missing that are available in the plugin spec,
+                parameters[parameterId] = paramSpec.defaultValue
+            }
+        })
+    }
     result.push({
         nodeId: transformInput.id,
         inputs: inputs,


### PR DESCRIPTION
- This can happen when e.g. a Python plugin has been updated at runtime and added a new parameter. In this case the new parameter is currently missing in existing instances of that plugin.