### PR TITLE
Expose metrics for Prometheus using Micrometer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.iml
 *.ipr
 *.iws
+.bsp
 #eclipse
 bin/
 target/

--- a/build.sbt
+++ b/build.sbt
@@ -357,7 +357,8 @@ lazy val workbenchCore = (project in file("silk-workbench/silk-workbench-core"))
     name := "Silk Workbench Core",
     // Play filters (CORS filter etc.)
     libraryDependencies += filters,
-    libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.1" % "test"
+    libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.1" % "test",
+    libraryDependencies += "io.micrometer" % "micrometer-registry-prometheus" % "1.12.3"
   )
 
 lazy val workbenchWorkspace = (project in file("silk-workbench/silk-workbench-workspace"))

--- a/build.sbt
+++ b/build.sbt
@@ -117,7 +117,8 @@ lazy val core = (project in file("silk-core"))
     libraryDependencies += "org.lz4" % "lz4-java" % "1.8.0",
     libraryDependencies += "javax.xml.bind" % "jaxb-api" % "2.3.1",
     libraryDependencies += "xalan" % "xalan" % "2.7.3",
-    libraryDependencies += "xalan" % "serializer" % "2.7.3"
+    libraryDependencies += "xalan" % "serializer" % "2.7.3",
+    libraryDependencies += "io.micrometer" % "micrometer-registry-prometheus" % "1.12.3"
   )
 
 lazy val rules = (project in file("silk-rules"))

--- a/silk-core/src/main/resources/reference.conf
+++ b/silk-core/src/main/resources/reference.conf
@@ -140,5 +140,8 @@ config.production.safeMode = false
 # Enable exposing Micrometer metrics. The specific monitoring system (such as Prometheus) is an implementation detail.
 metrics.enabled = true
 
-# Tags for the Micrometer metrics. This is useful for setting e.g. the app's name.
-metrics.tags = ["app", "cmem"]
+# Prefix for the Micrometer metrics.
+metrics.prefix = "cmem"
+
+# Application name for the Micrometer metrics.
+metrics.app = "silk"

--- a/silk-core/src/main/resources/reference.conf
+++ b/silk-core/src/main/resources/reference.conf
@@ -139,3 +139,6 @@ config.production.safeMode = false
 ###############################################
 # Enable exposing Micrometer metrics. The specific monitoring system (such as Prometheus) is an implementation detail.
 metrics.enabled = true
+
+# Tags for the Micrometer metrics. This is useful for setting e.g. the app's name.
+metrics.tags = ["app", "cmem"]

--- a/silk-core/src/main/resources/reference.conf
+++ b/silk-core/src/main/resources/reference.conf
@@ -133,3 +133,9 @@ org.silkframework.runtime.resource.Resource = {
 
 # Mode that prevents accessing external services outside of workflows. Default false
 config.production.safeMode = false
+
+###############################################
+### Metrics config
+###############################################
+# Enable exposing Micrometer metrics. The specific monitoring system (such as Prometheus) is an implementation detail.
+metrics.enabled = true

--- a/silk-core/src/main/scala/org/silkframework/config/TaskSpec.scala
+++ b/silk-core/src/main/scala/org/silkframework/config/TaskSpec.scala
@@ -1,6 +1,5 @@
 package org.silkframework.config
 
-import org.silkframework.entity.EntitySchema
 import org.silkframework.runtime.plugin.annotations.PluginType
 import org.silkframework.runtime.plugin.{ParameterValues, PluginContext}
 import org.silkframework.runtime.resource.Resource

--- a/silk-core/src/main/scala/org/silkframework/dataset/DataSource.scala
+++ b/silk-core/src/main/scala/org/silkframework/dataset/DataSource.scala
@@ -30,7 +30,7 @@ import scala.util.Random
 trait DataSource {
 
   /**
-    * The dataset task underlying the Datset this source belongs to
+    * The dataset task underlying the Dataset this source belongs to
     * @return
     */
   def underlyingTask: Task[DatasetSpec[Dataset]]

--- a/silk-core/src/main/scala/org/silkframework/runtime/activity/ActivityExecution.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/activity/ActivityExecution.scala
@@ -5,11 +5,13 @@ import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics
 import org.silkframework.config.DefaultConfig
 import org.silkframework.runtime.activity.Status.{Canceling, Finished, Waiting}
 import org.silkframework.runtime.execution.Execution
+import org.silkframework.runtime.metrics.PrometheusRegistryProvider
 
 import java.time.Instant
 import java.util.concurrent.ForkJoinPool.ManagedBlocker
 import java.util.concurrent._
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 import scala.util.control.NonFatal
 
@@ -338,11 +340,8 @@ object ActivityExecution {
    * @return
    */
   private def registerMetrics[E <: ExecutorService](executor: E, name: String, tags: List[Tag]): E = {
-    import org.silkframework.runtime.metrics.MeterRegistryProvider.meterRegistry
-
-    import scala.jdk.CollectionConverters._
     val metrics = new ExecutorServiceMetrics(executor, name, tags.asJava)
-    metrics.bindTo(meterRegistry)
+    metrics.bindTo(PrometheusRegistryProvider.meterRegistry)
     executor
   }
 }

--- a/silk-core/src/main/scala/org/silkframework/runtime/activity/ActivityExecution.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/activity/ActivityExecution.scala
@@ -1,8 +1,7 @@
 package org.silkframework.runtime.activity
 
-import io.micrometer.core.instrument.{MeterRegistry, Tag}
+import io.micrometer.core.instrument.Tag
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics
-import io.micrometer.prometheus.{PrometheusConfig, PrometheusMeterRegistry}
 import org.silkframework.config.DefaultConfig
 import org.silkframework.runtime.activity.Status.{Canceling, Finished, Waiting}
 import org.silkframework.runtime.execution.Execution
@@ -298,9 +297,6 @@ object ActivityExecution {
     keepAliveInMs = KEEP_ALIVE_MS
   ))
 
-  // Registry of Micrometer-based metrics, with Prometheus as a specific implementation.
-  private val meterRegistry: MeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
-
   /**
     * The size of the fork join thread pool
     */
@@ -342,6 +338,8 @@ object ActivityExecution {
    * @return
    */
   private def registerMetrics[E <: ExecutorService](executor: E, name: String, tags: List[Tag]): E = {
+    import org.silkframework.runtime.metrics.MeterRegistryProvider.meterRegistry
+
     import scala.jdk.CollectionConverters._
     val metrics = new ExecutorServiceMetrics(executor, name, tags.asJava)
     metrics.bindTo(meterRegistry)

--- a/silk-core/src/main/scala/org/silkframework/runtime/activity/ActivityExecution.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/activity/ActivityExecution.scala
@@ -5,7 +5,7 @@ import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics
 import org.silkframework.config.DefaultConfig
 import org.silkframework.runtime.activity.Status.{Canceling, Finished, Waiting}
 import org.silkframework.runtime.execution.Execution
-import org.silkframework.runtime.metrics.PrometheusRegistryProvider
+import org.silkframework.runtime.metrics.MeterRegistryProvider
 
 import java.time.Instant
 import java.util.concurrent.ForkJoinPool.ManagedBlocker
@@ -341,7 +341,7 @@ object ActivityExecution {
    */
   private def registerMetrics[E <: ExecutorService](executor: E, name: String, tags: List[Tag]): E = {
     val metrics = new ExecutorServiceMetrics(executor, name, tags.asJava)
-    metrics.bindTo(PrometheusRegistryProvider.meterRegistry)
+    metrics.bindTo(MeterRegistryProvider().meterRegistry)
     executor
   }
 }

--- a/silk-core/src/main/scala/org/silkframework/runtime/activity/ActivityExecution.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/activity/ActivityExecution.scala
@@ -341,7 +341,7 @@ object ActivityExecution {
    */
   private def registerMetrics[E <: ExecutorService](executor: E, name: String, tags: List[Tag]): E = {
     val metrics = new ExecutorServiceMetrics(executor, name, tags.asJava)
-    metrics.bindTo(MeterRegistryProvider().meterRegistry)
+    metrics.bindTo(MeterRegistryProvider.meterRegistry)
     executor
   }
 }

--- a/silk-core/src/main/scala/org/silkframework/runtime/metrics/MeterRegistryProvider.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/metrics/MeterRegistryProvider.scala
@@ -1,6 +1,7 @@
 package org.silkframework.runtime.metrics
 
-import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.{Meter, MeterRegistry}
+import io.micrometer.core.instrument.config.NamingConvention
 import io.micrometer.prometheus.{PrometheusConfig, PrometheusMeterRegistry}
 
 /**
@@ -18,5 +19,13 @@ sealed trait MeterRegistryProvider {
  * Provider of a Micrometer-based meter registry for Prometheus as a monitoring system.
  */
 object PrometheusRegistryProvider extends MeterRegistryProvider {
-  override val meterRegistry: MeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+  private val prefix: String = "cmem.di"
+
+  override val meterRegistry: MeterRegistry = {
+    val registry: PrometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+    val prefixedNamingConvention: NamingConvention = (name: String, `type`: Meter.Type, baseUnit: String) =>
+      registry.config().namingConvention.name(s"$prefix.$name", `type`, baseUnit)
+    registry.config().namingConvention(prefixedNamingConvention)
+    registry
+  }
 }

--- a/silk-core/src/main/scala/org/silkframework/runtime/metrics/MeterRegistryProvider.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/metrics/MeterRegistryProvider.scala
@@ -1,5 +1,6 @@
 package org.silkframework.runtime.metrics
 
+import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.prometheus.{PrometheusConfig, PrometheusMeterRegistry}
 
 /**
@@ -7,9 +8,15 @@ import io.micrometer.prometheus.{PrometheusConfig, PrometheusMeterRegistry}
  *
  * The `MeterRegistry` of Micrometer is used for creating and holding meters.
  *
- * For each monitoring system, there should be a single registry. Here, we only provide a single Prometheus registry.
+ * For each monitoring system, there should be a single registry.
  */
-object MeterRegistryProvider {
-  // Registry of Micrometer-based metrics, with Prometheus as a specific implementation.
-  val meterRegistry: PrometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+sealed trait MeterRegistryProvider {
+  def meterRegistry: MeterRegistry
+}
+
+/**
+ * Provider of a Micrometer-based meter registry for Prometheus as a monitoring system.
+ */
+object PrometheusRegistryProvider extends MeterRegistryProvider {
+  override val meterRegistry: MeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
 }

--- a/silk-core/src/main/scala/org/silkframework/runtime/metrics/MeterRegistryProvider.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/metrics/MeterRegistryProvider.scala
@@ -1,7 +1,6 @@
 package org.silkframework.runtime.metrics
 
-import io.micrometer.core.instrument.{Meter, MeterRegistry}
-import io.micrometer.core.instrument.config.NamingConvention
+import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.prometheus.{PrometheusConfig, PrometheusMeterRegistry}
 import org.silkframework.config.DefaultConfig
 
@@ -36,26 +35,8 @@ private object PrometheusRegistryProvider {
       case _ => "silk"
     }
 
-    def prefix: String = Try {
-      DefaultConfig.instance.apply().getString("metrics.prefix")
-    } match {
-      case Success(prefix) if prefix.nonEmpty => prefix
-      case _ => "cmem"
-    }
-
-    def prefixed(namingConvention: NamingConvention, prefix: String): NamingConvention =
-      (name: String, `type`: Meter.Type, baseUnit: String) => namingConvention.name(s"$prefix.$name", `type`, baseUnit)
-
     val registry: PrometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
-
-    // Tag with app name
     registry.config().commonTags("app", app)
-
-    // Prefix with platform name
-    registry.config().namingConvention(
-      prefixed(registry.config().namingConvention(), prefix)
-    )
-
     registry
   }
 }

--- a/silk-core/src/main/scala/org/silkframework/runtime/metrics/MeterRegistryProvider.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/metrics/MeterRegistryProvider.scala
@@ -1,6 +1,5 @@
 package org.silkframework.runtime.metrics
 
-import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.prometheus.{PrometheusConfig, PrometheusMeterRegistry}
 
 /**
@@ -12,5 +11,5 @@ import io.micrometer.prometheus.{PrometheusConfig, PrometheusMeterRegistry}
  */
 object MeterRegistryProvider {
   // Registry of Micrometer-based metrics, with Prometheus as a specific implementation.
-  val meterRegistry: MeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+  val meterRegistry: PrometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
 }

--- a/silk-core/src/main/scala/org/silkframework/runtime/metrics/MeterRegistryProvider.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/metrics/MeterRegistryProvider.scala
@@ -1,0 +1,16 @@
+package org.silkframework.runtime.metrics
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.prometheus.{PrometheusConfig, PrometheusMeterRegistry}
+
+/**
+ * Provider of a Registry of Micrometer-based metrics.
+ *
+ * The `MeterRegistry` of Micrometer is used for creating and holding meters.
+ *
+ * For each monitoring system, there should be a single registry. Here, we only provide a single Prometheus registry.
+ */
+object MeterRegistryProvider {
+  // Registry of Micrometer-based metrics, with Prometheus as a specific implementation.
+  val meterRegistry: MeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+}

--- a/silk-core/src/main/scala/org/silkframework/runtime/metrics/MeterRegistryProvider.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/metrics/MeterRegistryProvider.scala
@@ -22,10 +22,11 @@ object PrometheusRegistryProvider extends MeterRegistryProvider {
   private val prefix: String = "cmem.di"
 
   override val meterRegistry: MeterRegistry = {
+    def prefixed(namingConvention: NamingConvention): NamingConvention =
+      (name: String, `type`: Meter.Type, baseUnit: String) => namingConvention.name(s"$prefix.$name", `type`, baseUnit)
     val registry: PrometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
-    val prefixedNamingConvention: NamingConvention = (name: String, `type`: Meter.Type, baseUnit: String) =>
-      registry.config().namingConvention.name(s"$prefix.$name", `type`, baseUnit)
-    registry.config().namingConvention(prefixedNamingConvention)
+    val namingConvention = registry.config().namingConvention()
+    registry.config().namingConvention(prefixed(namingConvention))
     registry
   }
 }

--- a/silk-core/src/main/scala/org/silkframework/runtime/metrics/MeterRegistryProvider.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/metrics/MeterRegistryProvider.scala
@@ -25,7 +25,8 @@ class MeterRegistryProvider {
 }
 
 object MeterRegistryProvider {
-  def apply(): MeterRegistryProvider = new MeterRegistryProvider()
+  private val INSTANCE: MeterRegistryProvider = new MeterRegistryProvider()
+  def apply(): MeterRegistryProvider = INSTANCE
 }
 
 /**

--- a/silk-core/src/main/scala/org/silkframework/runtime/metrics/MetricsConfig.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/metrics/MetricsConfig.scala
@@ -1,0 +1,14 @@
+package org.silkframework.runtime.metrics
+
+import org.silkframework.config.DefaultConfig
+
+import scala.util.{Success, Try}
+
+object MetricsConfig {
+  lazy val prefix: String = Try {
+    DefaultConfig.instance.apply().getString("metrics.prefix")
+  } match {
+    case Success(prefix) if prefix.nonEmpty => prefix
+    case _ => "cmem"
+  }
+}

--- a/silk-core/src/main/scala/org/silkframework/runtime/metrics/NoopMeterRegistry.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/metrics/NoopMeterRegistry.scala
@@ -1,0 +1,53 @@
+package org.silkframework.runtime.metrics
+
+import io.micrometer.core.instrument.Meter.Type
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig
+import io.micrometer.core.instrument.distribution.pause.PauseDetector
+import io.micrometer.core.instrument.noop._
+import io.micrometer.core.instrument._
+
+import java.lang
+import java.util.concurrent.TimeUnit
+import java.util.function.{ToDoubleFunction, ToLongFunction}
+import scala.util.Random
+
+class NoopMeterRegistry(clock: Clock = new MockClock()) extends MeterRegistry(clock) {
+  private def meterId(typ: Type): Meter.Id = {
+    def randomString: String = Random.alphanumeric.filter(_.isDigit).take(5).mkString
+    new Meter.Id(randomString, Tags.empty(), randomString, randomString, typ)
+  }
+
+  override def newGauge[T](id: Meter.Id, obj: T, valueFunction: ToDoubleFunction[T]): Gauge =
+    new NoopGauge(meterId(Type.GAUGE))
+
+  override def newCounter(id: Meter.Id): Counter = new NoopCounter(meterId(Type.COUNTER))
+
+  override def newTimer(id: Meter.Id,
+                        distributionStatisticConfig: DistributionStatisticConfig,
+                        pauseDetector: PauseDetector): Timer = new NoopTimer(meterId(Type.TIMER))
+
+  override def newDistributionSummary(id: Meter.Id,
+                                      distributionStatisticConfig: DistributionStatisticConfig,
+                                      scale: Double): DistributionSummary =
+    new NoopDistributionSummary(meterId(Type.DISTRIBUTION_SUMMARY))
+
+  override def newMeter(id: Meter.Id,
+                        `type`: Meter.Type,
+                        measurements: lang.Iterable[Measurement]): Meter = new NoopMeter(meterId(`type`))
+
+  override def newFunctionTimer[T](id: Meter.Id,
+                                   obj: T,
+                                   countFunction: ToLongFunction[T],
+                                   totalTimeFunction: ToDoubleFunction[T],
+                                   totalTimeFunctionUnit: TimeUnit): FunctionTimer =
+    new NoopFunctionTimer(meterId(Type.TIMER))
+
+  override def newFunctionCounter[T](id: Meter.Id,
+                                     obj: T,
+                                     countFunction: ToDoubleFunction[T]): FunctionCounter =
+    new NoopFunctionCounter(meterId(Type.COUNTER))
+
+  override def getBaseTimeUnit: TimeUnit = TimeUnit.SECONDS
+
+  override def defaultHistogramConfig(): DistributionStatisticConfig = DistributionStatisticConfig.NONE
+}

--- a/silk-core/src/main/scala/org/silkframework/runtime/plugin/PluginRegistry.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/plugin/PluginRegistry.scala
@@ -76,7 +76,6 @@ object PluginRegistry {
    *
    * @param id The id of the plugin.
    * @param params The instantiation parameters.
-   * @param resources The resource loader for retrieving referenced resources.
    * @tparam T The base type of the plugin.
    * @return A new instance of the plugin type with the given parameters.
    */

--- a/silk-workbench/silk-workbench-core/app/config/WorkbenchConfig.scala
+++ b/silk-workbench/silk-workbench-core/app/config/WorkbenchConfig.scala
@@ -181,7 +181,7 @@ object WorkbenchConfig {
         // Register the version string in a Micrometer counter.
         // The counter is not increased further. What's important, is the version string set in the value of the tag.
         // This is arguably a somewhat improper or quirky usage of Micrometer and metrics in general.
-        MeterRegistryProvider().meterRegistry.counter("workbench.config", "version", versionString).increment()
+        MeterRegistryProvider.meterRegistry.counter("workbench.config", "version", versionString).increment()
         versionString
       case Failure(_) =>
         throw new RuntimeException("No version string ist set!")

--- a/silk-workbench/silk-workbench-core/app/config/WorkbenchConfig.scala
+++ b/silk-workbench/silk-workbench-core/app/config/WorkbenchConfig.scala
@@ -1,16 +1,16 @@
 package config
 
-import java.io.{File, InputStream}
 import com.typesafe.config.{Config => TypesafeConfig}
 import config.WorkbenchConfig.Tabs
-
-import javax.inject.Inject
 import org.silkframework.config.DefaultConfig
+import org.silkframework.runtime.metrics.PrometheusRegistryProvider
 import org.silkframework.runtime.resource._
 import play.api.mvc.RequestHeader
 import play.api.{Configuration, Environment, Mode}
 import play.twirl.api.Html
 
+import java.io.{File, InputStream}
+import javax.inject.Inject
 import scala.io.{Codec, Source}
 import scala.util.{Failure, Success, Try}
 
@@ -178,6 +178,10 @@ object WorkbenchConfig {
       DefaultConfig.instance.apply().getString("workbench.version")
     ) match {
       case Success(versionString) =>
+        // Register the version string in a Micrometer counter.
+        // The counter is not increased further. What's important, is the version string set in the value of the tag.
+        // This is arguably a somewhat improper or quirky usage of Micrometer and metrics in general.
+        PrometheusRegistryProvider.meterRegistry.counter("workbench.config", "version", versionString).increment()
         versionString
       case Failure(_) =>
         throw new RuntimeException("No version string ist set!")

--- a/silk-workbench/silk-workbench-core/app/config/WorkbenchConfig.scala
+++ b/silk-workbench/silk-workbench-core/app/config/WorkbenchConfig.scala
@@ -4,6 +4,7 @@ import com.typesafe.config.{Config => TypesafeConfig}
 import config.WorkbenchConfig.Tabs
 import org.silkframework.config.DefaultConfig
 import org.silkframework.runtime.metrics.MeterRegistryProvider
+import org.silkframework.runtime.metrics.MetricsConfig.prefix
 import org.silkframework.runtime.resource._
 import play.api.mvc.RequestHeader
 import play.api.{Configuration, Environment, Mode}
@@ -181,12 +182,13 @@ object WorkbenchConfig {
         // Register the version string in a Micrometer counter.
         // The counter is not increased further. What's important, is the version string set in the value of the tag.
         // This is arguably a somewhat improper or quirky usage of Micrometer and metrics in general.
-        MeterRegistryProvider.meterRegistry.counter("workbench.config", "version", versionString).increment()
+        MeterRegistryProvider.meterRegistry.counter(s"$prefix.workbench.config", "version", versionString).increment()
         versionString
       case Failure(_) =>
         throw new RuntimeException("No version string ist set!")
     }
   }
+
   /**
    * Retrieves the Workbench configuration.
    */

--- a/silk-workbench/silk-workbench-core/app/config/WorkbenchConfig.scala
+++ b/silk-workbench/silk-workbench-core/app/config/WorkbenchConfig.scala
@@ -3,7 +3,7 @@ package config
 import com.typesafe.config.{Config => TypesafeConfig}
 import config.WorkbenchConfig.Tabs
 import org.silkframework.config.DefaultConfig
-import org.silkframework.runtime.metrics.PrometheusRegistryProvider
+import org.silkframework.runtime.metrics.MeterRegistryProvider
 import org.silkframework.runtime.resource._
 import play.api.mvc.RequestHeader
 import play.api.{Configuration, Environment, Mode}
@@ -181,7 +181,7 @@ object WorkbenchConfig {
         // Register the version string in a Micrometer counter.
         // The counter is not increased further. What's important, is the version string set in the value of the tag.
         // This is arguably a somewhat improper or quirky usage of Micrometer and metrics in general.
-        PrometheusRegistryProvider.meterRegistry.counter("workbench.config", "version", versionString).increment()
+        MeterRegistryProvider().meterRegistry.counter("workbench.config", "version", versionString).increment()
         versionString
       case Failure(_) =>
         throw new RuntimeException("No version string ist set!")

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/Project.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/Project.scala
@@ -133,7 +133,7 @@ class Project(initialConfig: ProjectConfig, provider: WorkspaceProvider, val res
     * @throws NotFoundException
     */
   def activity(activityName: String): ProjectActivity[_ <: HasValue] = {
-    projectActivities.find(_.name == activityName)
+    projectActivities.find(_.name.toString == activityName)
       .getOrElse(throw NotFoundException(s"Project '$id' does not contain an activity named '$activityName'. " +
         s"Available activities: ${activities.map(_.name).mkString(", ")}"))
   }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
@@ -46,7 +46,7 @@ class Workspace(val provider: WorkspaceProvider,
                (implicit userContext: UserContext)
   extends WorkspaceReadTrait {
   // Register workspace metrics.
-  new WorkspaceMetrics(this).bindTo(meterRegistryProvider.meterRegistry)
+  new WorkspaceMetrics(() => projects, () => projects.flatMap(_.allTasks)).bindTo(meterRegistryProvider.meterRegistry)
 
   private val log = Logger.getLogger(classOf[Workspace].getName)
 

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
@@ -41,8 +41,7 @@ import scala.util.control.NonFatal
   * @param repository  the resource repository
   */
 class Workspace(val provider: WorkspaceProvider,
-                val repository: ResourceRepository,
-                val meterRegistryProvider: MeterRegistryProvider = MeterRegistryProvider())
+                val repository: ResourceRepository)
   extends WorkspaceReadTrait {
   private val log = Logger.getLogger(classOf[Workspace].getName)
 
@@ -322,7 +321,7 @@ class Workspace(val provider: WorkspaceProvider,
   }
 
   private def registerWorkspaceMetrics(implicit userContext: UserContext): Unit =
-    new WorkspaceMetrics(() => projects, () => projects.flatMap(_.allTasks)).bindTo(meterRegistryProvider.meterRegistry)
+    new WorkspaceMetrics(() => projects, () => projects.flatMap(_.allTasks)).bindTo(MeterRegistryProvider.meterRegistry)
 }
 
 object Workspace {

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
@@ -17,6 +17,7 @@ package org.silkframework.workspace
 import org.silkframework.config.{DefaultConfig, Prefixes}
 import org.silkframework.runtime.activity.{HasValue, UserContext}
 import org.silkframework.runtime.metrics.MeterRegistryProvider
+import org.silkframework.runtime.metrics.MetricsConfig.prefix
 import org.silkframework.runtime.plugin.{PluginContext, PluginRegistry}
 import org.silkframework.runtime.validation.{NotFoundException, ServiceUnavailableException}
 import org.silkframework.util.Identifier
@@ -321,7 +322,7 @@ class Workspace(val provider: WorkspaceProvider,
   }
 
   private def registerWorkspaceMetrics(implicit userContext: UserContext): Unit =
-    new WorkspaceMetrics(Workspace.prefix, () => projects, () => projects.flatMap(_.allTasks))
+    new WorkspaceMetrics(prefix, () => projects, () => projects.flatMap(_.allTasks))
       .bindTo(MeterRegistryProvider.meterRegistry)
 }
 
@@ -330,13 +331,5 @@ object Workspace {
   def autoRunCachedActivities: Boolean = {
     val cfg = DefaultConfig.instance()
     cfg.getBoolean("caches.config.enableAutoRun")
-  }
-
-  // Metrics prefix
-  def prefix: String = Try {
-    DefaultConfig.instance.apply().getString("metrics.prefix")
-  } match {
-    case Success(prefix) if prefix.nonEmpty => prefix
-    case _ => "cmem"
   }
 }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
@@ -16,7 +16,7 @@ package org.silkframework.workspace
 
 import org.silkframework.config.{DefaultConfig, Prefixes}
 import org.silkframework.runtime.activity.{HasValue, UserContext}
-import org.silkframework.runtime.metrics.{MeterRegistryProvider, PrometheusRegistryProvider}
+import org.silkframework.runtime.metrics.MeterRegistryProvider
 import org.silkframework.runtime.plugin.{PluginContext, PluginRegistry}
 import org.silkframework.runtime.validation.{NotFoundException, ServiceUnavailableException}
 import org.silkframework.util.Identifier
@@ -42,7 +42,7 @@ import scala.util.control.NonFatal
   */
 class Workspace(val provider: WorkspaceProvider,
                 val repository: ResourceRepository,
-                val meterRegistryProvider: MeterRegistryProvider = PrometheusRegistryProvider)
+                val meterRegistryProvider: MeterRegistryProvider = MeterRegistryProvider())
   extends WorkspaceReadTrait {
   private val log = Logger.getLogger(classOf[Workspace].getName)
 

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
@@ -283,7 +283,7 @@ class Workspace(val provider: WorkspaceProvider, val repository: ResourceReposit
     }
   }
 
-  private def addProjectToCache(project: Project) = {
+  private def addProjectToCache(project: Project): Unit = {
     cachedProjects :+= project
   }
 

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/Workspace.scala
@@ -16,12 +16,14 @@ package org.silkframework.workspace
 
 import org.silkframework.config.{DefaultConfig, Prefixes}
 import org.silkframework.runtime.activity.{HasValue, UserContext}
+import org.silkframework.runtime.metrics.{MeterRegistryProvider, PrometheusRegistryProvider}
 import org.silkframework.runtime.plugin.{PluginContext, PluginRegistry}
 import org.silkframework.runtime.validation.{NotFoundException, ServiceUnavailableException}
 import org.silkframework.util.Identifier
 import org.silkframework.workspace.TaskCleanupPlugin.CleanUpAfterTaskDeletionFunction
 import org.silkframework.workspace.activity.{GlobalWorkspaceActivity, GlobalWorkspaceActivityFactory}
 import org.silkframework.workspace.exceptions.{IdentifierAlreadyExistsException, ProjectNotFoundException}
+import org.silkframework.workspace.metrics.WorkspaceMetrics
 import org.silkframework.workspace.resources.ResourceRepository
 
 import java.io._
@@ -38,7 +40,13 @@ import scala.util.control.NonFatal
   * @param provider    the workspace provider
   * @param repository  the resource repository
   */
-class Workspace(val provider: WorkspaceProvider, val repository: ResourceRepository) extends WorkspaceReadTrait {
+class Workspace(val provider: WorkspaceProvider,
+                val repository: ResourceRepository,
+                val meterRegistryProvider: MeterRegistryProvider = PrometheusRegistryProvider)
+               (implicit userContext: UserContext)
+  extends WorkspaceReadTrait {
+  // Register workspace metrics.
+  new WorkspaceMetrics(this).bindTo(meterRegistryProvider.meterRegistry)
 
   private val log = Logger.getLogger(classOf[Workspace].getName)
 

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/activity/TaskActivity.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/activity/TaskActivity.scala
@@ -10,7 +10,7 @@ import scala.reflect.ClassTag
 import scala.runtime.BoxedUnit
 
 /**
-  * Holds an activity that is part of an task.
+  * Holds an activity that is part of a task.
   *
   * @param task           The task this activity belongs to.
   * @param defaultFactory The initial activity factory for generating the activity.

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/activity/workflow/LocalWorkflowExecutor.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/activity/workflow/LocalWorkflowExecutor.scala
@@ -53,7 +53,7 @@ case class LocalWorkflowExecutor(workflowTask: ProjectTask[Workflow],
       val registry = PrometheusRegistryProvider.meterRegistry
       val stopwatch: Timer.Sample = Timer.start()
       runWorkflow(context, updateUserContext(userContext))
-      stopwatch.stop(registry.timer("timer.workflow.execution", "workflow", workflowTask.toString))
+      stopwatch.stop(registry.timer("timer.workflow.execution", "workflow", workflowTask.id.toString))
     } catch {
       case cancelledWorkflowException: StopWorkflowExecutionException if !cancelledWorkflowException.failWorkflow =>
         // In case of an cancelled workflow from an operator, the workflow should still be successful

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/activity/workflow/LocalWorkflowExecutor.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/activity/workflow/LocalWorkflowExecutor.scala
@@ -304,7 +304,7 @@ case class LocalWorkflowExecutor(workflowTask: ProjectTask[Workflow],
     try {
       val registry = PrometheusRegistryProvider.meterRegistry
       val stopwatch: Timer.Sample = Timer.start()
-      val entitiesCounter: Counter = registry.counter("workflow.dataset", "entities", "count")
+      val entitiesCounter: Counter = registry.counter("workflow.dataset.count", "entities", workflowTask.id.toString)
       executeAndClose("Writing", workflowDataset.nodeId, resolvedDataset, Seq(entityTable), ExecutorOutput.empty) { _ =>
         // ignore result
       }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/activity/workflow/LocalWorkflowExecutor.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/activity/workflow/LocalWorkflowExecutor.scala
@@ -304,7 +304,7 @@ case class LocalWorkflowExecutor(workflowTask: ProjectTask[Workflow],
     try {
       val registry = PrometheusRegistryProvider.meterRegistry
       val stopwatch: Timer.Sample = Timer.start()
-      val entitiesCounter: Counter = registry.counter("timer.workflow.dataset.execution", "entities", "count")
+      val entitiesCounter: Counter = registry.counter("timer.workflow.dataset", "entities", "count")
       executeAndClose("Writing", workflowDataset.nodeId, resolvedDataset, Seq(entityTable), ExecutorOutput.empty) { _ =>
         // ignore result
       }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/activity/workflow/LocalWorkflowExecutor.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/activity/workflow/LocalWorkflowExecutor.scala
@@ -54,7 +54,7 @@ case class LocalWorkflowExecutor(workflowTask: ProjectTask[Workflow],
       val registry = PrometheusRegistryProvider.meterRegistry
       val stopwatch: Timer.Sample = Timer.start()
       runWorkflow(context, updateUserContext(userContext))
-      stopwatch.stop(registry.timer("timer.workflow.execution", "workflow", workflowTask.id.toString))
+      stopwatch.stop(registry.timer("workflow.execution", "workflow", workflowTask.id.toString))
     } catch {
       case cancelledWorkflowException: StopWorkflowExecutionException if !cancelledWorkflowException.failWorkflow =>
         // In case of an cancelled workflow from an operator, the workflow should still be successful
@@ -186,7 +186,7 @@ case class LocalWorkflowExecutor(workflowTask: ProjectTask[Workflow],
             writeErrorOutput(operatorNode, executorOutput)
             process(result)
           }
-          stopwatch.stop(registry.timer("timer.workflow.operator.execution", "operator", operator.nodeId))
+          stopwatch.stop(registry.timer("workflow.operator.execution", "operator", operator.nodeId))
           result
         } catch {
           case ex: WorkflowExecutionException =>
@@ -304,11 +304,11 @@ case class LocalWorkflowExecutor(workflowTask: ProjectTask[Workflow],
     try {
       val registry = PrometheusRegistryProvider.meterRegistry
       val stopwatch: Timer.Sample = Timer.start()
-      val entitiesCounter: Counter = registry.counter("timer.workflow.dataset", "entities", "count")
+      val entitiesCounter: Counter = registry.counter("workflow.dataset", "entities", "count")
       executeAndClose("Writing", workflowDataset.nodeId, resolvedDataset, Seq(entityTable), ExecutorOutput.empty) { _ =>
         // ignore result
       }
-      stopwatch.stop(registry.timer("timer.workflow.dataset.execution", "dataset", workflowTask.id.toString))
+      stopwatch.stop(registry.timer("workflow.dataset.execution", "dataset", workflowTask.id.toString))
       Try(entityTable.use(_.size)).foreach(entitiesCounter.increment(_))
       ()
     } catch {

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/activity/workflow/LocalWorkflowExecutor.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/activity/workflow/LocalWorkflowExecutor.scala
@@ -338,12 +338,19 @@ case class LocalWorkflowExecutor(workflowTask: ProjectTask[Workflow],
       executeAndClose("Writing", workflowDataset.nodeId, resolvedDataset, entityTables, ExecutorOutput.empty) { _ =>
         // ignore result
       }
-      stopwatch.stop(registry.timer(s"$prefix.workflow.dataset.execution", "dataset", workflowTask.id.toString))
+      stopwatch.stop(
+        registry.timer(
+          s"$prefix.workflow.dataset.execution",
+          "workflow", workflowTask.id.toString,
+          "dataset", workflowDataset.nodeId
+        )
+      )
       entityTables.foreach { entityTable =>
         Try {entityTable.use(_.size)}.foreach(
-          registry.counter(s"$prefix.workflow.dataset.count",
-          "entities", workflowTask.id.toString,
-          "node", workflowDataset.nodeId
+          registry.counter(
+            s"$prefix.workflow.dataset.count",
+            "workflow", workflowTask.id.toString,
+            "dataset", workflowDataset.nodeId
           ).increment(_)
         )
       }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/activity/workflow/LocalWorkflowExecutor.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/activity/workflow/LocalWorkflowExecutor.scala
@@ -10,7 +10,7 @@ import org.silkframework.execution.{EntityHolder, ExecutorOutput}
 import org.silkframework.plugins.dataset.InternalDataset
 import org.silkframework.rule.TransformSpec
 import org.silkframework.runtime.activity.{ActivityContext, UserContext}
-import org.silkframework.runtime.metrics.PrometheusRegistryProvider
+import org.silkframework.runtime.metrics.MeterRegistryProvider
 import org.silkframework.workspace.ProjectTask
 import org.silkframework.workspace.activity.transform.TransformTaskUtils._
 import org.silkframework.workspace.activity.workflow.ReconfigureTasks.ReconfigurableTask
@@ -51,7 +51,7 @@ case class LocalWorkflowExecutor(workflowTask: ProjectTask[Workflow],
                   (implicit userContext: UserContext): Unit = {
     cancelled = false
     try {
-      val registry = PrometheusRegistryProvider.meterRegistry
+      val registry = MeterRegistryProvider().meterRegistry
       val stopwatch: Timer.Sample = Timer.start()
       runWorkflow(context, updateUserContext(userContext))
       stopwatch.stop(registry.timer("workflow.execution", "workflow", workflowTask.id.toString))
@@ -173,7 +173,7 @@ case class LocalWorkflowExecutor(workflowTask: ProjectTask[Workflow],
 
       if (!cancelled && !isExecutedWorkflow) {
         try {
-          val registry = PrometheusRegistryProvider.meterRegistry
+          val registry = MeterRegistryProvider().meterRegistry
           val stopwatch: Timer.Sample = Timer.start()
           val result = executeAndClose("Executing", operatorNode.nodeId, operatorTask, inputResults.flatten, executorOutput) { result =>
             // Throw exception if result was promised, but not returned
@@ -302,7 +302,7 @@ case class LocalWorkflowExecutor(workflowTask: ProjectTask[Workflow],
                                        (implicit workflowRunContext: WorkflowRunContext): Unit = {
     val resolvedDataset = resolveDataset(datasetTask(workflowDataset), replaceSinks)
     try {
-      val registry = PrometheusRegistryProvider.meterRegistry
+      val registry = MeterRegistryProvider().meterRegistry
       val stopwatch: Timer.Sample = Timer.start()
       executeAndClose("Writing", workflowDataset.nodeId, resolvedDataset, Seq(entityTable), ExecutorOutput.empty) { _ =>
         // ignore result

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/activity/workflow/LocalWorkflowExecutor.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/activity/workflow/LocalWorkflowExecutor.scala
@@ -51,7 +51,7 @@ case class LocalWorkflowExecutor(workflowTask: ProjectTask[Workflow],
                   (implicit userContext: UserContext): Unit = {
     cancelled = false
     try {
-      val registry = MeterRegistryProvider().meterRegistry
+      val registry = MeterRegistryProvider.meterRegistry
       val stopwatch: Timer.Sample = Timer.start()
       runWorkflow(context, updateUserContext(userContext))
       stopwatch.stop(registry.timer("workflow.execution", "workflow", workflowTask.id.toString))
@@ -173,7 +173,7 @@ case class LocalWorkflowExecutor(workflowTask: ProjectTask[Workflow],
 
       if (!cancelled && !isExecutedWorkflow) {
         try {
-          val registry = MeterRegistryProvider().meterRegistry
+          val registry = MeterRegistryProvider.meterRegistry
           val stopwatch: Timer.Sample = Timer.start()
           val result = executeAndClose("Executing", operatorNode.nodeId, operatorTask, inputResults.flatten, executorOutput) { result =>
             // Throw exception if result was promised, but not returned
@@ -302,7 +302,7 @@ case class LocalWorkflowExecutor(workflowTask: ProjectTask[Workflow],
                                        (implicit workflowRunContext: WorkflowRunContext): Unit = {
     val resolvedDataset = resolveDataset(datasetTask(workflowDataset), replaceSinks)
     try {
-      val registry = MeterRegistryProvider().meterRegistry
+      val registry = MeterRegistryProvider.meterRegistry
       val stopwatch: Timer.Sample = Timer.start()
       executeAndClose("Writing", workflowDataset.nodeId, resolvedDataset, Seq(entityTable), ExecutorOutput.empty) { _ =>
         // ignore result

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
@@ -45,17 +45,17 @@ class WorkspaceMetrics(projectProvider: () => Seq[Project],
     def customTasks: Seq[ProjectTask[CustomTask]] = projects.flatMap(_.tasks[CustomTask])
     def workflowTasks: Seq[ProjectTask[Workflow]] = projects.flatMap(_.tasks[Workflow])
 
-    def gauge[TaskType <: TaskSpec](tasks: Seq[ProjectTask[TaskType]], specification: String): Unit = {
-      Gauge.builder("task.size", () => tasks.size)
+    def gauge[TaskType <: TaskSpec](taskProvider: () => Seq[ProjectTask[TaskType]], specification: String): Unit = {
+      Gauge.builder("task.size", () => taskProvider().size)
         .description("Workspace task size, per task specification")
         .tags("spec", specification)
         .register(registry)
     }
 
-    gauge(transformTasks, "Transform")
-    gauge(datasetTasks, "Dataset")
-    gauge(linkTasks, "Linking")
-    gauge(customTasks, "Task")
-    gauge(workflowTasks, "Workflow")
+    gauge(() => transformTasks, "Transform")
+    gauge(() => datasetTasks, "Dataset")
+    gauge(() => linkTasks, "Linking")
+    gauge(() => customTasks, "Task")
+    gauge(() => workflowTasks, "Workflow")
   }
 }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
@@ -1,0 +1,23 @@
+package org.silkframework.workspace.metrics
+
+import io.micrometer.core.instrument.binder.MeterBinder
+import io.micrometer.core.instrument.{Gauge, MeterRegistry}
+import org.silkframework.runtime.activity.UserContext
+import org.silkframework.workspace.Workspace
+
+import scala.util.Try
+
+/**
+ * Metrics for a Workspace instance.
+ *
+ * @param workspace Workspace to monitor.
+ * @param userContext User context needed to retrieve the projects, etc.
+ */
+class WorkspaceMetrics(workspace: Workspace)(implicit userContext: UserContext) extends MeterBinder {
+  override def bindTo(registry: MeterRegistry): Unit = {
+    Gauge.builder("workspace.metrics", workspace, (w: Workspace) => Try(w.projects.size.toDouble).getOrElse(0.0))
+      .tags("project", "size")
+      .description("Workspace metrics: project size")
+      .register(registry)
+  }
+}

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
@@ -37,13 +37,13 @@ class WorkspaceMetrics(projectProvider: () => Seq[Project],
   }
 
   private def workspaceTaskSizesPerCategory(registry: MeterRegistry): Unit = Try {
-    val projects: Seq[Project] = projectProvider()
+    def projects: Seq[Project] = projectProvider()
 
-    val transformTasks: Seq[ProjectTask[TransformSpec]] = projects.flatMap(_.tasks[TransformSpec])
-    val datasetTasks: Seq[ProjectTask[DatasetSpec[_]]] = projects.flatMap(_.tasks[DatasetSpec[_]])
-    val linkTasks: Seq[ProjectTask[LinkSpec]] = projects.flatMap(_.tasks[LinkSpec])
-    val customTasks: Seq[ProjectTask[CustomTask]] = projects.flatMap(_.tasks[CustomTask])
-    val workflowTasks: Seq[ProjectTask[Workflow]] = projects.flatMap(_.tasks[Workflow])
+    def transformTasks: Seq[ProjectTask[TransformSpec]] = projects.flatMap(_.tasks[TransformSpec])
+    def datasetTasks: Seq[ProjectTask[DatasetSpec[_]]] = projects.flatMap(_.tasks[DatasetSpec[_]])
+    def linkTasks: Seq[ProjectTask[LinkSpec]] = projects.flatMap(_.tasks[LinkSpec])
+    def customTasks: Seq[ProjectTask[CustomTask]] = projects.flatMap(_.tasks[CustomTask])
+    def workflowTasks: Seq[ProjectTask[Workflow]] = projects.flatMap(_.tasks[Workflow])
 
     def gauge[TaskType <: TaskSpec](tasks: Seq[ProjectTask[TaskType]], specification: String): Unit = {
       Gauge.builder("task.size", () => tasks.size)

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
@@ -46,7 +46,7 @@ class WorkspaceMetrics(projectProvider: () => Seq[Project],
     def workflowTasks: Seq[ProjectTask[Workflow]] = projects.flatMap(_.tasks[Workflow])
 
     def gauge[TaskType <: TaskSpec](taskProvider: () => Seq[ProjectTask[TaskType]], specification: String): Unit = {
-      Gauge.builder("task.size", () => taskProvider().size)
+      Gauge.builder("workspace.task.size", () => taskProvider().size)
         .description("Workspace task size, per task specification")
         .tags("spec", specification)
         .register(registry)

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
@@ -15,12 +15,27 @@ import scala.util.Try
  */
 class WorkspaceMetrics(workspace: Workspace)(implicit userContext: UserContext) extends MeterBinder {
   override def bindTo(registry: MeterRegistry): Unit = {
+    workspaceProjectSize(registry)
+    workspaceTaskSize(registry)
+  }
+
+  private def workspaceProjectSize(registry: MeterRegistry): Unit = {
     Gauge.builder(
         "workspace.project.size",
         workspace,
         (w: Workspace) => Try(w.projects.size.toDouble).getOrElse(0.0)
       )
       .description("Workspace project size")
+      .register(registry)
+  }
+
+  private def workspaceTaskSize(registry: MeterRegistry): Unit = {
+    Gauge.builder(
+        "workspace.task.size",
+        workspace,
+        (w: Workspace) => Try(w.projects.flatMap(_.allTasks).size.toDouble).getOrElse(0.0)
+      )
+      .description("Workspace task size")
       .register(registry)
   }
 }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
@@ -46,7 +46,7 @@ class WorkspaceMetrics(projectProvider: () => Seq[Project],
     def workflowTasks: Seq[ProjectTask[Workflow]] = projects.flatMap(_.tasks[Workflow])
 
     def gauge[TaskType <: TaskSpec](taskProvider: () => Seq[ProjectTask[TaskType]], specification: String): Unit = {
-      Gauge.builder("workspace.task.size", () => taskProvider().size)
+      Gauge.builder("workspace.task.spec.size", () => taskProvider().size)
         .description("Workspace task size, per task specification")
         .tags("spec", specification)
         .register(registry)

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
@@ -2,18 +2,16 @@ package org.silkframework.workspace.metrics
 
 import io.micrometer.core.instrument.binder.MeterBinder
 import io.micrometer.core.instrument.{Gauge, MeterRegistry}
-import org.silkframework.runtime.activity.UserContext
-import org.silkframework.workspace.Workspace
+import org.silkframework.config.TaskSpec
+import org.silkframework.workspace.{Project, ProjectTask}
 
 import scala.util.Try
 
 /**
  * Metrics for a Workspace instance.
- *
- * @param workspace Workspace to monitor.
- * @param userContext User context needed to retrieve the projects, etc.
  */
-class WorkspaceMetrics(workspace: Workspace)(implicit userContext: UserContext) extends MeterBinder {
+class WorkspaceMetrics(projectProvider: () => Seq[Project],
+                       tasksProvider: () => Seq[ProjectTask[_ <: TaskSpec]]) extends MeterBinder {
   override def bindTo(registry: MeterRegistry): Unit = {
     workspaceProjectSize(registry)
     workspaceTaskSize(registry)
@@ -23,8 +21,7 @@ class WorkspaceMetrics(workspace: Workspace)(implicit userContext: UserContext) 
   private def workspaceProjectSize(registry: MeterRegistry): Unit = {
     Gauge.builder(
         "workspace.project.size",
-        workspace,
-        (w: Workspace) => Try(w.projects.size.toDouble).getOrElse(0.0)
+        () => Try(projectProvider().size.toDouble).getOrElse(0.0)
       )
       .description("Workspace project size")
       .register(registry)
@@ -33,8 +30,7 @@ class WorkspaceMetrics(workspace: Workspace)(implicit userContext: UserContext) 
   private def workspaceTaskSize(registry: MeterRegistry): Unit = {
     Gauge.builder(
         "workspace.task.size",
-        workspace,
-        (w: Workspace) => Try(w.projects.flatMap(_.allTasks).size.toDouble).getOrElse(0.0)
+        () => Try(tasksProvider().size.toDouble).getOrElse(0.0)
       )
       .description("Workspace task size")
       .register(registry)
@@ -42,12 +38,12 @@ class WorkspaceMetrics(workspace: Workspace)(implicit userContext: UserContext) 
 
   private def workspaceTaskSizesPerCategory(registry: MeterRegistry): Unit = {
     Try {
-      val allTasks = workspace.projects.flatMap(_.allTasks)
-      val allTasksBySpec = allTasks.groupBy(_.data.getClass)
+      val allTasks: Seq[ProjectTask[_ <: TaskSpec]] = tasksProvider()
+      val allTasksBySpec: Map[Class[_], Seq[ProjectTask[_ <: TaskSpec]]] = allTasks.groupBy(_.data.getClass)
 
       allTasksBySpec.foreach { specAndTasks =>
-        val clazz = specAndTasks._1
-        val tasks = specAndTasks._2
+        val clazz: Class[_] = specAndTasks._1
+        val tasks: Seq[ProjectTask[_ <: TaskSpec]] = specAndTasks._2
         Gauge.builder("task.size", () => tasks.size)
           .description("Workspace task size, per task specification")
           .tags("spec", clazz.getSimpleName)

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
@@ -2,9 +2,8 @@ package org.silkframework.workspace.metrics
 
 import io.micrometer.core.instrument.binder.MeterBinder
 import io.micrometer.core.instrument.{Gauge, MeterRegistry}
-import org.silkframework.config.TaskSpec
 import org.silkframework.runtime.activity.UserContext
-import org.silkframework.workspace.{ProjectTask, Workspace}
+import org.silkframework.workspace.Workspace
 
 import scala.util.Try
 

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
@@ -15,8 +15,11 @@ import scala.util.Try
  */
 class WorkspaceMetrics(workspace: Workspace)(implicit userContext: UserContext) extends MeterBinder {
   override def bindTo(registry: MeterRegistry): Unit = {
-    Gauge.builder("workspace.metrics", workspace, (w: Workspace) => Try(w.projects.size.toDouble).getOrElse(0.0))
-      .tags("project", "size")
+    Gauge.builder(
+        "workspace.metrics.project.size",
+        workspace,
+        (w: Workspace) => Try(w.projects.size.toDouble).getOrElse(0.0)
+      )
       .description("Workspace metrics: project size")
       .register(registry)
   }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
@@ -14,7 +14,8 @@ import scala.util.Try
 /**
  * Metrics for a Workspace instance.
  */
-class WorkspaceMetrics(projectProvider: () => Seq[Project],
+class WorkspaceMetrics(prefix: String,
+                       projectProvider: () => Seq[Project],
                        tasksProvider: () => Seq[ProjectTask[_ <: TaskSpec]])
                       (implicit userContext: UserContext)
   extends MeterBinder {
@@ -25,13 +26,13 @@ class WorkspaceMetrics(projectProvider: () => Seq[Project],
   }
 
   private def workspaceProjectSize(registry: MeterRegistry): Unit = {
-    Gauge.builder("workspace.project.size", () => Try(projectProvider().size).getOrElse(0).toDouble)
+    Gauge.builder(s"$prefix.workspace.project.size", () => Try(projectProvider().size).getOrElse(0).toDouble)
       .description("Workspace project size")
       .register(registry)
   }
 
   private def workspaceTaskSize(registry: MeterRegistry): Unit = {
-    Gauge.builder("workspace.task.size", () => Try(tasksProvider().size).getOrElse(0).toDouble)
+    Gauge.builder(s"$prefix.workspace.task.size", () => Try(tasksProvider().size).getOrElse(0).toDouble)
       .description("Workspace task size")
       .register(registry)
   }
@@ -46,7 +47,7 @@ class WorkspaceMetrics(projectProvider: () => Seq[Project],
     def workflowTasks: Seq[ProjectTask[Workflow]] = projects.flatMap(_.tasks[Workflow])
 
     def gauge[TaskType <: TaskSpec](taskProvider: () => Seq[ProjectTask[TaskType]], specification: String): Unit = {
-      Gauge.builder("workspace.task.spec.size", () => taskProvider().size)
+      Gauge.builder(s"$prefix.workspace.task.spec.size", () => taskProvider().size)
         .description("Workspace task size, per task specification")
         .tags("spec", specification)
         .register(registry)

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
@@ -33,7 +33,7 @@ class WorkspaceMetrics(projectProvider: () => Seq[Project],
   private def workspaceTaskSizesPerCategory(registry: MeterRegistry): Unit = {
     Try {
       val allTasks: Seq[ProjectTask[_ <: TaskSpec]] = tasksProvider()
-      val allTasksBySpec: Map[Class[_], Seq[ProjectTask[_ <: TaskSpec]]] = allTasks.groupBy(_.data.getClass)
+      val allTasksBySpec: Map[Class[_], Seq[ProjectTask[_ <: TaskSpec]]] = allTasks.groupBy(_.taskType)
 
       allTasksBySpec.foreach { specAndTasks =>
         val clazz: Class[_] = specAndTasks._1

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
@@ -16,11 +16,11 @@ import scala.util.Try
 class WorkspaceMetrics(workspace: Workspace)(implicit userContext: UserContext) extends MeterBinder {
   override def bindTo(registry: MeterRegistry): Unit = {
     Gauge.builder(
-        "workspace.metrics.project.size",
+        "workspace.project.size",
         workspace,
         (w: Workspace) => Try(w.projects.size.toDouble).getOrElse(0.0)
       )
-      .description("Workspace metrics: project size")
+      .description("Workspace project size")
       .register(registry)
   }
 }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
@@ -43,15 +43,12 @@ class WorkspaceMetrics(workspace: Workspace)(implicit userContext: UserContext) 
 
   private def workspaceTaskSizesPerCategory(registry: MeterRegistry): Unit = {
     Try {
-      val allTasks: Seq[ProjectTask[_ <: TaskSpec]] = workspace.projects.flatMap(_.allTasks)
-
-      val allTasksBySpec: Map[Class[ProjectTask[_ <: TaskSpec]], Seq[ProjectTask[_ <: TaskSpec]]] =
-        allTasks.groupBy(_.data.getClass)
+      val allTasks = workspace.projects.flatMap(_.allTasks)
+      val allTasksBySpec = allTasks.groupBy(_.data.getClass)
 
       allTasksBySpec.foreach { specAndTasks =>
-        val clazz: Class[ProjectTask[_ <: TaskSpec]] = specAndTasks._1
-        val tasks: Seq[ProjectTask[_ <: TaskSpec]] = specAndTasks._2
-
+        val clazz = specAndTasks._1
+        val tasks = specAndTasks._2
         Gauge.builder("task.size", () => tasks.size)
           .description("Workspace task size, per task specification")
           .tags("spec", clazz.getSimpleName)

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/metrics/WorkspaceMetrics.scala
@@ -19,19 +19,13 @@ class WorkspaceMetrics(projectProvider: () => Seq[Project],
   }
 
   private def workspaceProjectSize(registry: MeterRegistry): Unit = {
-    Gauge.builder(
-        "workspace.project.size",
-        () => Try(projectProvider().size.toDouble).getOrElse(0.0)
-      )
+    Gauge.builder("workspace.project.size", () => Try(projectProvider().size).getOrElse(0).toDouble)
       .description("Workspace project size")
       .register(registry)
   }
 
   private def workspaceTaskSize(registry: MeterRegistry): Unit = {
-    Gauge.builder(
-        "workspace.task.size",
-        () => Try(tasksProvider().size.toDouble).getOrElse(0.0)
-      )
+    Gauge.builder("workspace.task.size", () => Try(tasksProvider().size).getOrElse(0).toDouble)
       .description("Workspace task size")
       .register(registry)
   }
@@ -44,6 +38,7 @@ class WorkspaceMetrics(projectProvider: () => Seq[Project],
       allTasksBySpec.foreach { specAndTasks =>
         val clazz: Class[_] = specAndTasks._1
         val tasks: Seq[ProjectTask[_ <: TaskSpec]] = specAndTasks._2
+
         Gauge.builder("task.size", () => tasks.size)
           .description("Workspace task size, per task specification")
           .tags("spec", clazz.getSimpleName)

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/TestWorkspaceProviderTestTrait.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/TestWorkspaceProviderTestTrait.scala
@@ -51,7 +51,6 @@ trait TestWorkspaceProviderTestTrait extends BeforeAndAfterAll { this: TestSuite
   // Workaround for config problem, this should make sure that the workspace is a fresh in-memory RDF workspace
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    implicit val testUserContext: UserContext.Empty.type = UserContext.Empty
     val replacementWorkspace = new Workspace(workspaceProvider, createResourceRepository(tmpDir))
     val rdfWorkspaceFactory = new WorkspaceFactory {
       /**
@@ -62,6 +61,7 @@ trait TestWorkspaceProviderTestTrait extends BeforeAndAfterAll { this: TestSuite
     }
     oldWorkspaceFactory = WorkspaceFactory.factory
     WorkspaceFactory.factory = rdfWorkspaceFactory
+    implicit val testUserContext: UserContext.Empty.type = UserContext.Empty
     if(initWorkspaceBeforeAll) {
       WorkspaceFactory().workspace.projects // Initialize workspace before starting tests
     }

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/TestWorkspaceProviderTestTrait.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/TestWorkspaceProviderTestTrait.scala
@@ -51,6 +51,7 @@ trait TestWorkspaceProviderTestTrait extends BeforeAndAfterAll { this: TestSuite
   // Workaround for config problem, this should make sure that the workspace is a fresh in-memory RDF workspace
   override protected def beforeAll(): Unit = {
     super.beforeAll()
+    implicit val testUserContext: UserContext.Empty.type = UserContext.Empty
     val replacementWorkspace = new Workspace(workspaceProvider, createResourceRepository(tmpDir))
     val rdfWorkspaceFactory = new WorkspaceFactory {
       /**
@@ -61,7 +62,6 @@ trait TestWorkspaceProviderTestTrait extends BeforeAndAfterAll { this: TestSuite
     }
     oldWorkspaceFactory = WorkspaceFactory.factory
     WorkspaceFactory.factory = rdfWorkspaceFactory
-    implicit val testUserContext: UserContext.Empty.type = UserContext.Empty
     if(initWorkspaceBeforeAll) {
       WorkspaceFactory().workspace.projects // Initialize workspace before starting tests
     }

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceProviderTestTrait.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceProviderTestTrait.scala
@@ -55,13 +55,13 @@ trait WorkspaceProviderTestTrait extends AnyFlatSpec with Matchers with MockitoS
 
   def createWorkspaceProvider(): WorkspaceProvider
 
-  private def refreshTest(ex: => Unit)(implicit userContext: UserContext) = withRefresh(PROJECT_NAME)(ex)
+  private def refreshTest(ex: => Unit)(implicit userContext: UserContext): Unit = withRefresh(PROJECT_NAME)(ex)
 
   val workspaceProvider: WorkspaceProvider = createWorkspaceProvider()
 
   private val repository = InMemoryResourceRepository()
 
-  private val workspace = new Workspace(workspaceProvider, repository)
+  private def workspace(implicit userContext: UserContext) = new Workspace(workspaceProvider, repository)
 
   private val projectResources = repository.get(PROJECT_NAME)
 

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceProviderTestTrait.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceProviderTestTrait.scala
@@ -61,7 +61,7 @@ trait WorkspaceProviderTestTrait extends AnyFlatSpec with Matchers with MockitoS
 
   private val repository = InMemoryResourceRepository()
 
-  private def workspace(implicit userContext: UserContext) = new Workspace(workspaceProvider, repository)
+  private val workspace = new Workspace(workspaceProvider, repository)
 
   private val projectResources = repository.get(PROJECT_NAME)
 


### PR DESCRIPTION
# Expose metrics for Prometheus using Micrometer

This PR adds support for exposing metrics using Micrometer, with the specific use-case of Prometheus in mind.

The main changes in this PR are:
1. Integrating the **functionality of Micrometer-based metrics** and configuring the Micrometer-based metrics to work with Prometheus as the monitoring and alerting software system
2. Exposing the **thread pool metrics** of the `Activity`
3. Exposing the **total number** of **projects** and **tasks** in a **workspace**
4. Exposing the number of **tasks** by their **specification** (Transform, Dataset, Linking, Task, Workflow).
5. Exposing the **runtime** of a **workflow**, **operator** and **dataset**, as well as the **number of entities** of a dataset.
6. Exposing the **version** (Workbench Core).
7. Add the **app name** as a metrics tag, via the property `metrics.tags`.
8. Add **descriptions** to the metrics.
9. Enable enabling/disabling the metrics functionality, via the property `metrics.enabled`.