### PR TITLE
Global variables can be marked sensitive for storing passwords (CMEM-4817)

### DIFF
--- a/silk-core/src/main/scala/org/silkframework/config/InvalidConfigException.scala
+++ b/silk-core/src/main/scala/org/silkframework/config/InvalidConfigException.scala
@@ -1,0 +1,13 @@
+package org.silkframework.config
+
+import com.typesafe.config.{ConfigException, ConfigOrigin}
+
+/**
+ * Thrown if the configuration is invalid.
+ *
+ * @param configKey The configuration key that is invalid, e.g., ''config.variables''.
+ * @param details Error description
+ * @param cause Optional cause
+ */
+class InvalidConfigException(key: String, origin: ConfigOrigin, details: String, cause: Option[Throwable] = None)
+  extends ConfigException(s"The configuration is invalid at key '$key': $details ($origin)", cause.orNull)

--- a/silk-core/src/main/scala/org/silkframework/runtime/plugin/PluginDescription.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/plugin/PluginDescription.scala
@@ -138,7 +138,7 @@ trait PluginDescription[+T] {
       case template: ParameterTemplateValue =>
         // Only password parameters are allowed to resolve sensitive variables
         val templateVariables =
-          if(stringParam == PasswordParameterType) {
+          if(stringParam.name == PasswordParameterType.name) {
             context.templateVariables.all
           } else {
             context.templateVariables.all.withoutSensitiveVariables()

--- a/silk-core/src/main/scala/org/silkframework/runtime/plugin/types/TemplateParameter.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/plugin/types/TemplateParameter.scala
@@ -1,5 +1,11 @@
 package org.silkframework.runtime.plugin.types
 
-import org.silkframework.runtime.templating.TemplateVariablesReader
+import org.silkframework.runtime.templating.{TemplateVariables, TemplateVariablesReader}
 
-case class TemplateParameter(templateStr: String, templateVariables: TemplateVariablesReader)
+case class TemplateParameter(templateStr: String, templateVariables: TemplateVariablesReader) {
+
+  def nonSensitiveVariables: TemplateVariables = {
+    templateVariables.all.withoutSensitiveVariables()
+  }
+
+}

--- a/silk-core/src/main/scala/org/silkframework/runtime/templating/TemplateVariables.scala
+++ b/silk-core/src/main/scala/org/silkframework/runtime/templating/TemplateVariables.scala
@@ -14,7 +14,7 @@ import scala.xml.Node
   */
 case class TemplateVariables(variables: Seq[TemplateVariable]) {
 
-  val map: Map[String, TemplateVariable] = variables.map(v => (v.name, v)).toMap
+  lazy val map: Map[String, TemplateVariable] = variables.map(v => (v.name, v)).toMap
 
   validate()
 
@@ -72,6 +72,13 @@ case class TemplateVariables(variables: Seq[TemplateVariable]) {
     */
   def merge(other: TemplateVariables): TemplateVariables = {
     TemplateVariables(variables ++ other.variables)
+  }
+
+  /**
+   * Returns only non-sensitive variables
+   */
+  def withoutSensitiveVariables(): TemplateVariables = {
+    TemplateVariables(variables.filterNot(_.isSensitive))
   }
 
   private def validate(): Unit = {

--- a/silk-core/src/test/scala/org/silkframework/runtime/templating/GlobalTemplateVariablesTest.scala
+++ b/silk-core/src/test/scala/org/silkframework/runtime/templating/GlobalTemplateVariablesTest.scala
@@ -1,0 +1,56 @@
+package org.silkframework.runtime.templating
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.silkframework.util.ConfigTestTrait
+
+class GlobalTemplateVariablesTest extends AnyFlatSpec with Matchers {
+
+  behavior of "GlobalTemplateVariables"
+
+  it should "load global variables" in {
+    ConfigTestTrait.updateAndBackupParameters(Map(
+      "config.variables.global.simpleVar" -> Some("value 1"),
+      "config.variables.global.complexVar.value" -> Some("value 2"),
+      "config.variables.global.complexVar.description" -> Some("my description"),
+      "config.variables.global.complexVar.isSensitive" -> Some("false"),
+      "config.variables.global.sensitiveVar.value" -> Some("value 3"),
+      "config.variables.global.sensitiveVar.isSensitive" -> Some("true")
+    ))
+
+    val variables = GlobalTemplateVariables.all
+
+    variables.map.get("simpleVar") shouldBe
+      Some(TemplateVariable(
+        name = "simpleVar",
+        value = "value 1",
+        template = None,
+        description = None,
+        isSensitive = false,
+        scope = GlobalTemplateVariablesConfig.globalScope
+      ))
+
+    variables.map.get("complexVar") shouldBe
+      Some(TemplateVariable(
+        name = "complexVar",
+        value = "value 2",
+        template = None,
+        description = Some("my description"),
+        isSensitive = false,
+        scope = GlobalTemplateVariablesConfig.globalScope
+      ))
+
+    variables.map.get("sensitiveVar") shouldBe
+      Some(TemplateVariable(
+        name = "sensitiveVar",
+        value = "value 3",
+        template = None,
+        description = None,
+        isSensitive = true,
+        scope = GlobalTemplateVariablesConfig.globalScope
+      ))
+  }
+
+  //TODO add test for invalid config
+
+}

--- a/silk-core/src/test/scala/org/silkframework/runtime/templating/GlobalTemplateVariablesTest.scala
+++ b/silk-core/src/test/scala/org/silkframework/runtime/templating/GlobalTemplateVariablesTest.scala
@@ -51,6 +51,4 @@ class GlobalTemplateVariablesTest extends AnyFlatSpec with Matchers {
       ))
   }
 
-  //TODO add test for invalid config
-
 }

--- a/silk-plugins/silk-serialization-json/src/main/scala/org/silkframework/serialization/json/PluginSerializers.scala
+++ b/silk-plugins/silk-serialization-json/src/main/scala/org/silkframework/serialization/json/PluginSerializers.scala
@@ -2,6 +2,7 @@ package org.silkframework.serialization.json
 
 import org.silkframework.runtime.plugin._
 import org.silkframework.runtime.serialization.{ReadContext, Serialization, WriteContext}
+import org.silkframework.runtime.templating.exceptions.TemplateEvaluationException
 import org.silkframework.serialization.json.JsonSerializers.{PARAMETERS, TEMPLATES, TYPE}
 import play.api.libs.json._
 
@@ -21,7 +22,18 @@ object PluginSerializers {
     }
 
     override def write(value: ParameterValues)(implicit writeContext: WriteContext[JsValue]): JsObject = {
-      val parameters = writeParameters(value)
+      write(value, failOnInvalidTemplates = true)
+    }
+
+    /**
+     * Serializes parameter values a JSON.
+     *
+     * @param value The parameter values to be serialized.
+     * @param failOnInvalidTemplates If true, [[TemplateEvaluationException]] will be thrown if a template is invalid, e.g., if a reference variable is not bound.
+     *                               If false, invalid templates will resolve to an empty value.
+     */
+    def write(value: ParameterValues, failOnInvalidTemplates: Boolean)(implicit writeContext: WriteContext[JsValue]): JsObject = {
+      val parameters = writeParameters(value, failOnInvalidTemplates)
       val templates = writeTemplates(value)
       if(templates.value.isEmpty) {
         Json.obj(
@@ -55,19 +67,24 @@ object PluginSerializers {
       }
     }
 
-    private def writeParameters(params: ParameterValues)
+    private def writeParameters(params: ParameterValues, failOnInvalidTemplates: Boolean)
                                (implicit writeContext: WriteContext[JsValue]): JsObject = {
       JsObject(
         params.values.collect {
           case (key, ParameterStringValue(strValue)) =>
             (key, JsString(strValue))
           case (key, template: ParameterTemplateValue) =>
-            (key, JsString(template.evaluate(writeContext.templateVariables.all)))
+            try {
+              (key, JsString(template.evaluate(writeContext.templateVariables.all)))
+            } catch {
+              case _: TemplateEvaluationException if !failOnInvalidTemplates =>
+                (key, JsString(""))
+            }
           case (key, parameterObjectValue: ParameterObjectValue) =>
             val value = parameterObjectValue.value(writeContext)
             (key, Serialization.formatForDynamicType[JsValue](value.getClass).write(value))
           case (key, values: ParameterValues) =>
-            (key, writeParameters(values))
+            (key, writeParameters(values, failOnInvalidTemplates))
         }
       )
     }

--- a/silk-workbench/silk-workbench-core/app/controllers/workspaceApi/coreApi/VariableTemplateApi.scala
+++ b/silk-workbench/silk-workbench-core/app/controllers/workspaceApi/coreApi/VariableTemplateApi.scala
@@ -345,7 +345,7 @@ class VariableTemplateApi @Inject()() extends InjectedController with UserContex
           new Content(
             mediaType = "application/json",
             schema = new Schema(`type` = "object"),
-            examples = Array(new ExampleObject(VariableTemplateApiDoc.validateVariableTemplateResponse)) // TODO
+            examples = Array(new ExampleObject(VariableTemplateApiDoc.validateVariableTemplateResponse))
           )
         )
       )

--- a/silk-workbench/silk-workbench-core/app/controllers/workspaceApi/coreApi/variableTemplate/VariableTemplateRequests.scala
+++ b/silk-workbench/silk-workbench-core/app/controllers/workspaceApi/coreApi/variableTemplate/VariableTemplateRequests.scala
@@ -43,11 +43,14 @@ trait VariableTemplateRequest {
 
 }
 
-case class ValidateVariableTemplateRequest(templateString: String, project: Option[String] = None, variableName: Option[String] = None) extends VariableTemplateRequest {
+case class ValidateVariableTemplateRequest(templateString: String,
+                                           project: Option[String] = None,
+                                           variableName: Option[String] = None,
+                                           includeSensitiveVariables: Boolean = false) extends VariableTemplateRequest {
 
   def execute()(implicit user: UserContext): VariableTemplateValidationResponse = {
     val resultOrError: Either[String, String] = try {
-      Left(collectVariables().resolveTemplateValue(templateString))
+      Left(collectVariables(includeSensitiveVariables = includeSensitiveVariables).resolveTemplateValue(templateString))
     } catch {
       case ex: UnboundVariablesException if variableName.isDefined && ex.missingVars.size == 1 =>
         // Check if the variable is unbound because it is defined after the current one

--- a/silk-workbench/silk-workbench-core/app/controllers/workspaceApi/coreApi/variableTemplate/VariableTemplateRequests.scala
+++ b/silk-workbench/silk-workbench-core/app/controllers/workspaceApi/coreApi/variableTemplate/VariableTemplateRequests.scala
@@ -46,11 +46,11 @@ trait VariableTemplateRequest {
 case class ValidateVariableTemplateRequest(templateString: String,
                                            project: Option[String] = None,
                                            variableName: Option[String] = None,
-                                           includeSensitiveVariables: Boolean = false) extends VariableTemplateRequest {
+                                           includeSensitiveVariables: Option[Boolean] = None) extends VariableTemplateRequest {
 
   def execute()(implicit user: UserContext): VariableTemplateValidationResponse = {
     val resultOrError: Either[String, String] = try {
-      Left(collectVariables(includeSensitiveVariables = includeSensitiveVariables).resolveTemplateValue(templateString))
+      Left(collectVariables(includeSensitiveVariables = includeSensitiveVariables.getOrElse(false)).resolveTemplateValue(templateString))
     } catch {
       case ex: UnboundVariablesException if variableName.isDefined && ex.missingVars.size == 1 =>
         // Check if the variable is unbound because it is defined after the current one

--- a/silk-workbench/silk-workbench-core/app/org/silkframework/runtime/templating/operations/UpdateVariableModification.scala
+++ b/silk-workbench/silk-workbench-core/app/org/silkframework/runtime/templating/operations/UpdateVariableModification.scala
@@ -17,7 +17,7 @@ case class UpdateVariableModification(project: Project, variable: TemplateVariab
       case index: Int =>
         TemplateVariables(variables.updated(index, variable))
     }
-    updatedVariables.resolved(GlobalTemplateVariables.all)
+    updatedVariables.resolved(GlobalTemplateVariables.all.withoutSensitiveVariables())
   }
 
   override protected def generateException(task: Task[_ <: TaskSpec], cause: Throwable): CannotModifyVariablesUsedByTaskException = {

--- a/silk-workbench/silk-workbench-core/app/org/silkframework/runtime/templating/operations/UpdateVariablesModification.scala
+++ b/silk-workbench/silk-workbench-core/app/org/silkframework/runtime/templating/operations/UpdateVariablesModification.scala
@@ -10,7 +10,7 @@ case class UpdateVariablesModification(project: Project, updatedVariables: Templ
   override def operation: String = s"Updated the following variables ${updatedVariables.variables.map(_.name).mkString("'", "', '", "'")}"
 
   override protected def updateVariables(currentVariables: TemplateVariables): TemplateVariables = {
-    updatedVariables.resolved(GlobalTemplateVariables.all)
+    updatedVariables.resolved(GlobalTemplateVariables.all.withoutSensitiveVariables())
   }
 
   override protected def generateException(task: Task[_ <: TaskSpec], cause: Throwable): CannotModifyVariablesUsedByTaskException = {

--- a/silk-workbench/silk-workbench-workspace/app/controllers/projectApi/requests/ReloadFailedTaskRequest.scala
+++ b/silk-workbench/silk-workbench-workspace/app/controllers/projectApi/requests/ReloadFailedTaskRequest.scala
@@ -49,7 +49,8 @@ object OriginalTaskDataResponse {
     override def write(value: OriginalTaskData)(implicit writeContext: WriteContext[JsValue]): JsValue = {
       Json.obj(
         PLUGIN_ID -> value.pluginId,
-        PARAMETER_VALUES -> ParameterValuesJsonFormat.write(value.parameterValues)
+        // Invalid templates should not fail the evaluation to give the user a chance to fix the template.
+        PARAMETER_VALUES -> ParameterValuesJsonFormat.write(value.parameterValues, failOnInvalidTemplates = false)
       )
     }
   }

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceProviderTestTrait.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/WorkspaceProviderTestTrait.scala
@@ -621,7 +621,7 @@ trait WorkspaceProviderTestTrait extends AnyFlatSpec with Matchers with MockitoS
     val templateVariables1 = TemplateVariables(Seq(
       TemplateVariable("myVar1", "myValue1", None, None, isSensitive = false, "project"),
       TemplateVariable("myVar2", "myValue2", None, Some("test description"), isSensitive = true, "project"),
-      TemplateVariable("myVar3", "myValue3", None, None, isSensitive = true, "project")
+      TemplateVariable("myVar3", "myValue2b", Some("{{project.myVar2}}b"), None, isSensitive = true, "project")
     ))
     variables.putVariables(templateVariables1)
     refreshTest {
@@ -631,7 +631,7 @@ trait WorkspaceProviderTestTrait extends AnyFlatSpec with Matchers with MockitoS
     // Modify variables and read again
     val templateVariables2 = TemplateVariables(Seq(
       TemplateVariable("myVar2", "myValue2", None, Some("test description 2"), isSensitive = true, "project"),
-      TemplateVariable("myVar4", "myValue4", None, None, isSensitive = true, "project"),
+      TemplateVariable("myVar4", "myValue2b", Some("{{project.myVar2}}b"), None, isSensitive = true, "project"),
       TemplateVariable("myVar1", "myValue1", None, None, isSensitive = false, "project")
     ))
     variables.putVariables(templateVariables2)

--- a/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/ArtefactFormParameter.tsx
+++ b/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/ArtefactFormParameter.tsx
@@ -229,6 +229,7 @@ export const ArtefactFormParameter = ({
                             evaluatedValueMessage={
                                 supportVariableTemplateElement.showTemplatePreview ? setTemplateInfoMessage : undefined
                             }
+                            allowSensitiveVariables={isPasswordInput}
                         />
                     ) : (
                         inputElementFactory(valueState.current.inputValueBeforeSwitch, onElementValueChange)
@@ -281,6 +282,7 @@ interface TemplateInputComponentProps {
     variableName?: string;
     handleTemplateErrors?: (error?: string) => any;
     multiline?: boolean;
+    allowSensitiveVariables?: boolean;
 }
 
 /** The input component for the template value. */
@@ -295,6 +297,7 @@ export const TemplateInputComponent = memo(
         variableName,
         handleTemplateErrors,
         multiline,
+        allowSensitiveVariables,
     }: TemplateInputComponentProps) => {
         const modalContext = React.useContext(CreateArtefactModalContext);
         const { registerError: globalErrorHandler } = useErrorHandler();
@@ -325,8 +328,15 @@ export const TemplateInputComponent = memo(
 
         const autoComplete = React.useCallback(async (inputString: string, cursorPosition: number) => {
             try {
-                return (await requestAutoCompleteTemplateString(inputString, cursorPosition, projectId, variableName))
-                    .data;
+                return (
+                    await requestAutoCompleteTemplateString(
+                        inputString,
+                        cursorPosition,
+                        projectId,
+                        variableName,
+                        allowSensitiveVariables
+                    )
+                ).data;
             } catch (error) {
                 handleTemplateErrors
                     ? handleTemplateErrors(error)

--- a/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/ArtefactFormParameter.tsx
+++ b/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/ArtefactFormParameter.tsx
@@ -352,7 +352,12 @@ export const TemplateInputComponent = memo(
             async (inputString: string): Promise<ValidateTemplateResponse | undefined> => {
                 try {
                     const validationResponse = (
-                        await requestValidateTemplateString(inputString, projectId, variableName)
+                        await requestValidateTemplateString(
+                            inputString,
+                            projectId,
+                            variableName,
+                            allowSensitiveVariables
+                        )
                     ).data;
                     evaluatedValueMessage?.(
                         validationResponse.evaluatedTemplate

--- a/workspace/src/app/views/shared/modals/CreateArtefactModal/CreateArtefactModal.requests.ts
+++ b/workspace/src/app/views/shared/modals/CreateArtefactModal/CreateArtefactModal.requests.ts
@@ -47,13 +47,15 @@ export const requestValidateTemplateString = async (
  * @param cursorPosition
  * @param project
  * @param variableName optional parameter to make correct suggestions for when an existing variable is edited
+ * @param includeSensitiveVariables include sensitive variables in the autocompletion.
  * @returns
  */
 export const requestAutoCompleteTemplateString = async (
     inputString: string,
     cursorPosition: number,
     project?: string,
-    variableName?: string
+    variableName?: string,
+    includeSensitiveVariables?: boolean
 ): Promise<FetchResponse<IPartialAutoCompleteResult>> => {
     return fetch({
         url: coreApi("/variableTemplate/completion"),
@@ -63,6 +65,7 @@ export const requestAutoCompleteTemplateString = async (
             cursorPosition,
             project,
             variableName,
+            includeSensitiveVariables,
         },
     });
 };

--- a/workspace/src/app/views/shared/modals/CreateArtefactModal/CreateArtefactModal.requests.ts
+++ b/workspace/src/app/views/shared/modals/CreateArtefactModal/CreateArtefactModal.requests.ts
@@ -28,7 +28,8 @@ export interface ValidateTemplateResponse extends IValidationResult {
 export const requestValidateTemplateString = async (
     templateString: string,
     project?: string,
-    variableName?: string
+    variableName?: string,
+    includeSensitiveVariables?: boolean
 ): Promise<FetchResponse<ValidateTemplateResponse>> => {
     return fetch({
         url: coreApi("/variableTemplate/validation"),
@@ -37,6 +38,7 @@ export const requestValidateTemplateString = async (
             templateString,
             project,
             variableName,
+            includeSensitiveVariables,
         },
     });
 };


### PR DESCRIPTION
* Sensitive variables can only be used in password fields.
* Using sensitive variables in other fields or in variable templates fails and does not expose the value.
* Example:
```
config.variables = {
  global = {
    sensitiveVar = {
      value = "value 2"
      isSensitive = true
    }
  }
```