### PR TITLE
Fix: SPARQL restriction expands wrong SPARQL pattern 

### DIFF
--- a/silk-core/src/main/scala/org/silkframework/entity/rdf/SparqlRestriction.scala
+++ b/silk-core/src/main/scala/org/silkframework/entity/rdf/SparqlRestriction.scala
@@ -15,6 +15,7 @@
 package org.silkframework.entity.rdf
 
 import org.silkframework.config.Prefixes
+import org.silkframework.runtime.validation.BadUserInputException
 import org.silkframework.util.Uri
 
 import scala.util.matching.Regex
@@ -57,7 +58,7 @@ object SparqlRestriction {
     val strippedRestrictions = restrictions.trim.stripSuffix(".").trim
     val cleanedRestrictions = if (strippedRestrictions.isEmpty) "" else strippedRestrictions + " ."
 
-    val prefixRegex = new Regex("""([\w-]+):([\w.-]+)""")
+    val prefixRegex = new Regex("""([\w-]+):([\w.-]+(?:\\/[\w.-]+)*)""")
 
     // Replace all prefixes with their full URIs
     val restrictionsFull = prefixRegex.replaceAllIn(cleanedRestrictions, replacePrefix _)
@@ -76,7 +77,7 @@ object SparqlRestriction {
     val name = m.group(2)
     prefixes.get(prefix) match {
       case Some(namespace) => s"<$namespace$name>"
-      case None => m.toString() // Keep the original if the prefix is not found
+      case None => throw new BadUserInputException(s"Unknown prefix '$prefix' in SPARQL restriction.")
     }
   }
 

--- a/silk-core/src/main/scala/org/silkframework/entity/rdf/SparqlRestriction.scala
+++ b/silk-core/src/main/scala/org/silkframework/entity/rdf/SparqlRestriction.scala
@@ -57,7 +57,7 @@ object SparqlRestriction {
     val strippedRestrictions = restrictions.trim.stripSuffix(".").trim
     val cleanedRestrictions = if (strippedRestrictions.isEmpty) "" else strippedRestrictions + " ."
 
-    val prefixRegex = new Regex("""([\w-]+):([\w-]+)""")
+    val prefixRegex = new Regex("""([\w-]+):([\w.-]+)""")
 
     // Replace all prefixes with their full URIs
     val restrictionsFull = prefixRegex.replaceAllIn(cleanedRestrictions, replacePrefix _)

--- a/silk-core/src/main/scala/org/silkframework/entity/rdf/SparqlRestriction.scala
+++ b/silk-core/src/main/scala/org/silkframework/entity/rdf/SparqlRestriction.scala
@@ -58,7 +58,7 @@ object SparqlRestriction {
     val strippedRestrictions = restrictions.trim.stripSuffix(".").trim
     val cleanedRestrictions = if (strippedRestrictions.isEmpty) "" else strippedRestrictions + " ."
 
-    val prefixRegex = new Regex("""([\w-]+):([\w.-]+(?:\\/[\w.-]+)*)""")
+    val prefixRegex = """(?<!<)(?<![\p{L}\d])([a-zA-Z][a-zA-Z0-9]*):([^\s/<>"';]+)(?![^<]*>)(?![^"']*["'](?:[^"']*["'][^"']*["'])*[^"']*$)""".r
 
     // Replace all prefixes with their full URIs
     val restrictionsFull = prefixRegex.replaceAllIn(cleanedRestrictions, replacePrefix _)

--- a/silk-core/src/test/scala/org/silkframework/entity/rdf/SparqlRestrictionTest.scala
+++ b/silk-core/src/test/scala/org/silkframework/entity/rdf/SparqlRestrictionTest.scala
@@ -4,6 +4,7 @@ package org.silkframework.entity.rdf
 import org.silkframework.config.Prefixes
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.silkframework.runtime.validation.BadUserInputException
 
 class SparqlRestrictionTest extends AnyFlatSpec with Matchers {
 
@@ -36,6 +37,11 @@ class SparqlRestrictionTest extends AnyFlatSpec with Matchers {
   it should "resolve prefixes correctly if using property paths with prefixed names" in {
     val restriction = "?a owl:sameAs/rdf:type owl:Thing ."
     resolve(restriction) should be ("?a <http://www.w3.org/2002/07/owl#sameAs>/<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Thing> .")
+  }
+
+  it should "fail if a prefix in a property path is not defined" in {
+    val restriction = "?a rdf:type/schema:additionalType owl:Class ."
+    an[BadUserInputException] should be thrownBy resolve(restriction)
   }
 
   private def resolve(sparql: String) = SparqlRestriction.fromSparql("a", sparql).toSparql

--- a/silk-core/src/test/scala/org/silkframework/entity/rdf/SparqlRestrictionTest.scala
+++ b/silk-core/src/test/scala/org/silkframework/entity/rdf/SparqlRestrictionTest.scala
@@ -44,6 +44,11 @@ class SparqlRestrictionTest extends AnyFlatSpec with Matchers {
     an[BadUserInputException] should be thrownBy resolve(restriction)
   }
 
+  it should "not replace prefixes in full URIs" in {
+    val restriction = "?a <urn:test:prop1> <http://www.example.com/someValue> ."
+    resolve(restriction) should be (restriction)
+  }
+
   private def resolve(sparql: String) = SparqlRestriction.fromSparql("a", sparql).toSparql
 
 }

--- a/silk-core/src/test/scala/org/silkframework/entity/rdf/SparqlRestrictionTest.scala
+++ b/silk-core/src/test/scala/org/silkframework/entity/rdf/SparqlRestrictionTest.scala
@@ -33,6 +33,11 @@ class SparqlRestrictionTest extends AnyFlatSpec with Matchers {
     resolve(restriction) should be (restriction)
   }
 
+  it should "resolve prefixes correctly if using property paths with prefixed names" in {
+    val restriction = "?a owl:sameAs/rdf:type owl:Thing ."
+    resolve(restriction) should be ("?a <http://www.w3.org/2002/07/owl#sameAs>/<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Thing> .")
+  }
+
   private def resolve(sparql: String) = SparqlRestriction.fromSparql("a", sparql).toSparql
 
 }

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/TestWorkspaceProviderTestTrait.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/TestWorkspaceProviderTestTrait.scala
@@ -1,7 +1,7 @@
 package org.silkframework.workspace
 
 import org.scalatest.{BeforeAndAfterAll, TestSuite}
-import org.silkframework.config.MetaData
+import org.silkframework.config.{MetaData, Prefixes}
 import org.silkframework.runtime.activity.UserContext
 import org.silkframework.runtime.plugin.{ParameterValues, PluginContext, PluginRegistry, TestPluginContext}
 import org.silkframework.runtime.resource.InMemoryResourceManager
@@ -78,10 +78,10 @@ trait TestWorkspaceProviderTestTrait extends BeforeAndAfterAll { this: TestSuite
     super.afterAll()
   }
 
-  def retrieveOrCreateProject(projectId: Identifier)(implicit userContext: UserContext): Project = {
+  def retrieveOrCreateProject(projectId: Identifier, prefixes: Prefixes = Prefixes.default)(implicit userContext: UserContext): Project = {
     WorkspaceFactory().workspace(userContext).findProject(projectId) match{
       case Some(p) => p
-      case None => WorkspaceFactory().workspace(userContext).createProject(new ProjectConfig(projectId, metaData = MetaData(Some(projectId))))
+      case None => WorkspaceFactory().workspace(userContext).createProject(new ProjectConfig(projectId, metaData = MetaData(Some(projectId)), projectPrefixes = prefixes))
     }
   }
 }


### PR DESCRIPTION
SPARQL restriction expands wrong SPARQL pattern when using property paths with prefixed names (CMEM-6418).