### PR TITLE
Bugfix: Some characters are stripped from CSV output

### DIFF
--- a/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CsvWriter.scala
+++ b/silk-plugins/silk-plugins-csv/src/main/scala/org/silkframework/plugins/dataset/csv/CsvWriter.scala
@@ -46,6 +46,10 @@ class CsvWriter(resource: WritableResource, properties: Seq[TypedProperty], sett
     */
   private def createCsvWriter() = {
     val writerSettings = new CsvWriterSettings
+
+    // Allow the processing of non-printable characters.
+    writerSettings.trimValues(false)
+
     writerSettings.getFormat.setLineSeparator("\n")
     if(properties.nonEmpty) {
       writerSettings.setHeaders(properties.map(_.propertyUri.uri): _*)


### PR DESCRIPTION
# Bugfix: Some characters are stripped from CSV output

Task: https://jira.eccenca.com/browse/CMEM-6524

Allow the processing of non-printable characters in the CsvWriter of uniVocity-parsers, as documented in https://stackoverflow.com/questions/39318083/how-to-use-univocity-parsers-to-process-non-printable-character.