### PR TITLE
Show URI validation error of complex URI rules in various places

### DIFF
--- a/silk-rules/src/main/scala/org/silkframework/rule/evaluation/DetailedEvaluator.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/evaluation/DetailedEvaluator.scala
@@ -18,7 +18,8 @@ import org.silkframework.entity.Entity
 import org.silkframework.rule.input.{Input, PathInput, TransformInput}
 import org.silkframework.rule.similarity.{Aggregation, Comparison, SimilarityOperator}
 import org.silkframework.rule.{LinkageRule, TransformRule}
-import org.silkframework.util.DPair
+import org.silkframework.runtime.validation.ValidationException
+import org.silkframework.util.{DPair, Uri}
 
 import scala.util.control.NonFatal
 
@@ -72,7 +73,13 @@ object DetailedEvaluator {
       case Some(rule) => rule(entity).values
       case None => Seq(entity.uri.toString)
     }
-
+    if(subjectRule.isDefined) {
+      val invalidUri = uris.find(uri  => !Uri(uri).isValidUri)
+      if(invalidUri.isDefined) {
+        // The URI rule has generated an invalid URI
+        throw new ValidationException(s"URI rule of object mapping has generated an invalid URI: '${invalidUri.get}'!")
+      }
+    }
     val values = for(rule <- rules) yield apply(rule, entity)
     DetailedEntity(uris, values, rules)
   }

--- a/silk-rules/src/main/scala/org/silkframework/rule/execution/local/TransformedEntities.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/execution/local/TransformedEntities.scala
@@ -10,7 +10,7 @@ import org.silkframework.rule.execution.TransformReportBuilder
 import org.silkframework.rule.{RootMappingRule, TransformRule, TransformSpec}
 import org.silkframework.runtime.iterator.CloseableIterator
 import org.silkframework.runtime.validation.ValidationException
-import org.silkframework.util.Identifier
+import org.silkframework.util.{Identifier, Uri}
 
 import java.util.logging.Logger
 import scala.collection.mutable
@@ -98,6 +98,10 @@ class TransformedEntities(task: Task[TransformSpec],
       for (uri <- uris) yield {
         if(count > 0 && outputSchema.singleEntity && rule.isInstanceOf[RootMappingRule]) {
           throw new MultipleValuesException(s"Tried to generate multiple entities, but the '$ruleLabel' mapping is configured to output a single entity.")
+        }
+        if(subjectRule.isDefined && !Uri(uri).isValidUri) {
+          // The URI rule has generated an invalid URI
+          throw new ValidationException(s"URI rule of object mapping '$ruleLabel' has generated an invalid URI: '$uri'!")
         }
 
         lazy val objectEntity = { // Constructs an entity that only contains object source paths for object mappings

--- a/workspace/src/app/views/pages/MappingEditor/HierarchicalMapping/containers/MappingRule/ExampleView.tsx
+++ b/workspace/src/app/views/pages/MappingEditor/HierarchicalMapping/containers/MappingRule/ExampleView.tsx
@@ -39,7 +39,7 @@ interface RuleExamples {
     sourcePaths: string[][];
     results: RuleExample[];
     status: {
-        id: "success" | "not supported" | "empty with exceptions" | "empty" | string;
+        id: "success" | "with exceptions" | "not supported" | "empty with exceptions" | "empty" | string;
         msg?: string;
     };
 }
@@ -181,6 +181,19 @@ export const ExampleView = ({ id, rawRule, ruleType, objectSourcePathContext, up
                             </TableHeader>
                         </TableRow>
                     </TableHead>
+                    {resultsCount > 0 && examples.status.id === "with exceptions" && examples.status.msg ?
+                        <TableBody>
+                            <TableRow key={"errorRow"}>
+                                <TableCell colSpan={3}>
+                                    <ProblemNotification
+                                        message={t("HierarchicalMapping.ExampleView.errors.withExceptions", {error: examples.status.msg})}
+                                        details={examples.status.msg}
+                                    />
+                                </TableCell>
+                            </TableRow>
+                        </TableBody> :
+                        null
+                    }
                     {_.map(examples.results, (result, index) => (
                         <TableBody key={`tbody_${index}`}>
                             {sourcePaths.map((sourcePath, i) => (

--- a/workspace/src/locales/manual/en.json
+++ b/workspace/src/locales/manual/en.json
@@ -1215,7 +1215,8 @@
             "errors": {
                 "emptyResult": "Preview has returned no results.",
                 "emptyWithExceptions": "Preview has returned no results, possibly because of transform validation errors.",
-                "notSupported": "Input source does not support the transform preview."
+                "notSupported": "Input source does not support the transform preview.",
+                "withExceptions": "At least one problem has been detected: {{error}}"
             }
         }
     },


### PR DESCRIPTION
- Example transform view of object rule shows a warning for the URI rule
- Transform execution fails (in case of URI rule of root mapping) or shows validation errors
- Transform evaluation shows an error for the affected object mapping rule
- Workflow execution shows validation errors