### PR TITLE
Improvements to expected exceptions in operator examples:

### DIFF
--- a/silk-rules/src/main/scala/org/silkframework/rule/OperatorExampleValues.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/OperatorExampleValues.scala
@@ -50,6 +50,11 @@ trait OperatorExampleValue {
   def parameters: Map[String, String]
 
   /**
+   * The class of the exception that is expected to be thrown by this example, if any.
+   */
+  def throwsException: Option[Class[_]]
+
+  /**
     * Format this example as markdown.
     */
   def markdownFormatted(sb: StringBuilder): Unit

--- a/silk-rules/src/main/scala/org/silkframework/rule/annotations/AggregatorExample.java
+++ b/silk-rules/src/main/scala/org/silkframework/rule/annotations/AggregatorExample.java
@@ -23,7 +23,7 @@ public @interface AggregatorExample {
     // Expected output score. NaN to represent an empty score (None).
     double output();
 
-    // The full class path or empty string
-    String throwsException() default "";
+    // Thrown exception if evaluation should fail. Defaults to Object class if no exception is thrown.
+    Class<?> throwsException() default Object.class;
 
 }

--- a/silk-rules/src/main/scala/org/silkframework/rule/annotations/TransformExample.java
+++ b/silk-rules/src/main/scala/org/silkframework/rule/annotations/TransformExample.java
@@ -25,8 +25,7 @@ public @interface TransformExample {
 
     String[] output() default {};
 
-    // The full class path or empty string
-    String throwsException() default "";
-
+    // Thrown exception if evaluation should fail. Defaults to Object class if no exception is thrown.
+    Class<?> throwsException() default Object.class;
 }
 

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/aggegrator/ScalingAggregator.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/aggegrator/ScalingAggregator.scala
@@ -27,7 +27,7 @@ import org.silkframework.runtime.plugin.annotations.{Param, Plugin}
     description = "Throws a validation error if more than one input is provided.",
     inputs = Array(0.1, 0.2),
     output = Double.NaN,
-    throwsException = "java.lang.IllegalArgumentException"
+    throwsException = classOf[java.lang.IllegalArgumentException]
   )
 ))
 case class ScalingAggregator(

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/conditional/ContainsAllOf.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/conditional/ContainsAllOf.scala
@@ -34,17 +34,17 @@ import org.silkframework.runtime.plugin.annotations.Plugin
   new TransformExample(
     input1 = Array("A", "B", "C"),
     input2 = Array(),
-    throwsException = "java.lang.IllegalArgumentException"
+    throwsException = classOf[java.lang.IllegalArgumentException]
   ),
   new TransformExample(
     input1 = Array("A"),
     input2 = Array("A"),
     input3 = Array("A"),
-    throwsException = "java.lang.IllegalArgumentException"
+    throwsException = classOf[java.lang.IllegalArgumentException]
   ),
   new TransformExample(
     input1 = Array("A"),
-    throwsException = "java.lang.IllegalArgumentException"
+    throwsException = classOf[java.lang.IllegalArgumentException]
   )
 ))
 case class ContainsAllOf() extends Transformer {

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/conditional/ContainsAnyOf.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/conditional/ContainsAnyOf.scala
@@ -34,17 +34,17 @@ import org.silkframework.runtime.plugin.annotations.Plugin
   new TransformExample(
     input1 = Array("A", "B", "C"),
     input2 = Array(),
-    throwsException = "java.lang.IllegalArgumentException"
+    throwsException = classOf[java.lang.IllegalArgumentException]
   ),
   new TransformExample(
     input1 = Array("A"),
     input2 = Array("A"),
     input3 = Array("A"),
-    throwsException = "java.lang.IllegalArgumentException"
+    throwsException = classOf[java.lang.IllegalArgumentException]
   ),
   new TransformExample(
     input1 = Array("A"),
-    throwsException = "java.lang.IllegalArgumentException"
+    throwsException = classOf[java.lang.IllegalArgumentException]
   )
 ))
 case class ContainsAnyOf() extends Transformer {

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/conditional/Negate.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/conditional/Negate.scala
@@ -17,11 +17,11 @@ import org.silkframework.runtime.plugin.annotations.Plugin
   ),
   new TransformExample(
     input1 = Array("falsee", "true"),
-    throwsException = "java.lang.IllegalArgumentException"
+    throwsException = classOf[java.lang.IllegalArgumentException]
   ),
   new TransformExample(
     input1 = Array(),
-    throwsException = "java.lang.IllegalArgumentException"
+    throwsException = classOf[java.lang.IllegalArgumentException]
   )
 ))
 case class Negate() extends Transformer {

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/date/ParseDateTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/date/ParseDateTransformer.scala
@@ -64,12 +64,12 @@ import java.util.Locale;
   new TransformExample(
     parameters = Array("format", "MMM yyyy", "locale", "de"),
     input1 = Array("May 2024"),
-    throwsException = "org.silkframework.runtime.validation.ValidationException"
+    throwsException = classOf[org.silkframework.runtime.validation.ValidationException]
   ),
   new TransformExample(
     parameters = Array("format", "yyyyMMdd", "lenient", "false"),
     input1 = Array("20150000"),
-    throwsException = "org.silkframework.runtime.validation.ValidationException"
+    throwsException = classOf[org.silkframework.runtime.validation.ValidationException]
   )
 ))
 case class ParseDateTransformer(

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/substring/SubstringTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/substring/SubstringTransformer.scala
@@ -48,7 +48,7 @@ If 'endIndex' is negative, -endIndex characters are removed from the end."""
     parameters = Array("beginIndex", "2", "endIndex", "4"),
     input1 = Array("abc"),
     output = Array("c"),
-    throwsException = "org.silkframework.runtime.validation.ValidationException"
+    throwsException = classOf[org.silkframework.runtime.validation.ValidationException]
   ),
   new TransformExample(
     parameters = Array("beginIndex", "2", "endIndex", "4", "stringMustBeInRange", "false"),

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/validation/ValidateDateAfter.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/validation/ValidateDateAfter.scala
@@ -31,7 +31,7 @@ import org.silkframework.runtime.validation.ValidationException
   new TransformExample(
     input1 = Array("2015-04-02"),
     input2 = Array("2015-04-03"),
-    throwsException = "org.silkframework.runtime.validation.ValidationException"
+    throwsException = classOf[org.silkframework.runtime.validation.ValidationException]
   ),
   new TransformExample(
     input1 = Array("2015-04-04"),
@@ -48,7 +48,7 @@ import org.silkframework.runtime.validation.ValidationException
     parameters = Array("allowEqual", "false"),
     input1 = Array("2015-04-03"),
     input2 = Array("2015-04-03"),
-    throwsException = "org.silkframework.runtime.validation.ValidationException"
+    throwsException = classOf[org.silkframework.runtime.validation.ValidationException]
   )
 ))
 case class ValidateDateAfter(

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/validation/ValidateNumberOValues.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/validation/ValidateNumberOValues.scala
@@ -35,7 +35,7 @@ import org.silkframework.runtime.validation.ValidationException
     parameters = Array("min", "0", "max", "1"),
     input1 = Array("value1", "value2"),
     output = Array(),
-    throwsException = "org.silkframework.runtime.validation.ValidationException"
+    throwsException = classOf[org.silkframework.runtime.validation.ValidationException]
   )
 ))
 case class ValidateNumberOValues(

--- a/silk-rules/src/main/scala/org/silkframework/rule/similarity/DistanceMeasureExampleValue.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/similarity/DistanceMeasureExampleValue.scala
@@ -21,6 +21,9 @@ case class DistanceMeasureExampleValue(description: Option[String],
     sb ++= s"  - Target: `${format(inputs.target)}`\n"
     sb ++= "\n"
     sb ++= s"* Returns: → `${output}`\n"
+    for(exceptionClass <- throwsException) {
+      sb ++= s"* **Throws error:** `${exceptionClass.getSimpleName}`\n"
+    }
   }
 
   private def format(traversable: Iterable[_]): String = {

--- a/silk-rules/src/test/scala/org/silkframework/rule/test/AggregatorTest.scala
+++ b/silk-rules/src/test/scala/org/silkframework/rule/test/AggregatorTest.scala
@@ -56,34 +56,34 @@ abstract class AggregatorTest[T <: Aggregator : ClassTag] extends PluginTest {
       val description = if (example.description.isEmpty) "" else s" (${example.description})"
 
       it should "fulfill: " + example.formatted + description in {
-        if (example.throwsException != "") {
-          val expectedException = Class.forName(example.throwsException)
-          var expectedExceptionThrown = false
-          try {
-            aggregator(operators(example.inputs, weights), DPair.fill(Entity.empty("dummy")), 0.0)
-          } catch {
-            case NonFatal(ex) =>
-              if (!expectedException.isAssignableFrom(ex.getClass)) {
-                fail("Another exception was thrown: " + ex.getClass.getName + ". Expected: " + example.throwsException)
-              } else {
-                expectedExceptionThrown = true
-              }
-          }
-          if(!expectedExceptionThrown) {
-            fail("Exception " + example.throwsException + " has not been thrown!")
-          }
-        } else {
-          val result = aggregator(operators(example.inputs, weights), DPair.fill(Entity.empty("dummy")), 0.0)
-          (result.score, example.output) match {
-            case (Some(resultScore), Some(expectedScore)) =>
-              resultScore shouldBe expectedScore +- epsilon
-            case (Some(resultScore), None) =>
-              fail(s"Aggregation did return a similarity score ($resultScore), although it was expected to return none.")
-            case (None, Some(expectedScore)) =>
-              fail(s"Aggregation did not return a similarity score, although it was expected to return $expectedScore.")
-            case (None, None) =>
-            // success
-          }
+        example.throwsException match {
+          case Some(expectedException) =>
+            var expectedExceptionThrown = false
+            try {
+              aggregator(operators(example.inputs, weights), DPair.fill(Entity.empty("dummy")), 0.0)
+            } catch {
+              case NonFatal(ex) =>
+                if (!expectedException.isAssignableFrom(ex.getClass)) {
+                  fail("Another exception was thrown: " + ex.getClass.getName + ". Expected: " + example.throwsException)
+                } else {
+                  expectedExceptionThrown = true
+                }
+            }
+            if(!expectedExceptionThrown) {
+              fail("Exception " + example.throwsException + " has not been thrown!")
+            }
+          case None =>
+            val result = aggregator(operators(example.inputs, weights), DPair.fill(Entity.empty("dummy")), 0.0)
+            (result.score, example.output) match {
+              case (Some(resultScore), Some(expectedScore)) =>
+                resultScore shouldBe expectedScore +- epsilon
+              case (Some(resultScore), None) =>
+                fail(s"Aggregation did return a similarity score ($resultScore), although it was expected to return none.")
+              case (None, Some(expectedScore)) =>
+                fail(s"Aggregation did not return a similarity score, although it was expected to return $expectedScore.")
+              case (None, None) =>
+              // success
+            }
         }
       }
     }

--- a/silk-rules/src/test/scala/org/silkframework/rule/test/TransformerTest.scala
+++ b/silk-rules/src/test/scala/org/silkframework/rule/test/TransformerTest.scala
@@ -54,31 +54,30 @@ abstract class TransformerTest[T <: Transformer : ClassTag] extends PluginTest {
       }
 
     def addTest(): Unit = {
-      if(example.throwsException != "") {
-        it should s"throw ${example.throwsException} for parameters ${format(example.parameters)} and input values ${format(example.input.map(format))}" in {
-          generatedOutput should have size 0
-          val expectedException = Class.forName(example.throwsException)
-          throwableOpt match {
-            case Some(ex) =>
-              if(!expectedException.isAssignableFrom(ex.getClass)) {
-                throw new RuntimeException("Another exception was thrown: " + ex.getClass.getName + ". Expected: " + example.throwsException)
-              }
-            case None =>
-              throw new RuntimeException("Exception " + example.throwsException + " has not been thrown!")
+      example.throwsException match {
+        case Some(expectedException) =>
+          it should s"throw ${example.throwsException} for parameters ${format(example.parameters)} and input values ${format(example.input.map(format))}" in {
+            generatedOutput should have size 0
+            throwableOpt match {
+              case Some(ex) =>
+                if(!expectedException.isAssignableFrom(ex.getClass)) {
+                  throw new RuntimeException("Another exception was thrown: " + ex.getClass.getName + ". Expected: " + example.throwsException)
+                }
+              case None =>
+                throw new RuntimeException("Exception " + example.throwsException + " has not been thrown!")
+            }
           }
-
-        }
-      } else {
-        it should s"return ${format(example.output)} for parameters ${format(example.parameters)} and input values ${format(example.input.map(format))}" in {
-          throwableOpt foreach { ex =>
-            log.warning("Exception was thrown: " + ex.getMessage)
-            ex.printStackTrace()
+        case None =>
+          it should s"return ${format(example.output)} for parameters ${format(example.parameters)} and input values ${format(example.input.map(format))}" in {
+            throwableOpt foreach { ex =>
+              log.warning("Exception was thrown: " + ex.getMessage)
+              ex.printStackTrace()
+            }
+            generatedOutput should have size example.output.size
+            for ((value, expected) <- generatedOutput zip example.output) {
+              value shouldEqual expected
+            }
           }
-          generatedOutput should have size example.output.size
-          for ((value, expected) <- generatedOutput zip example.output) {
-            value shouldEqual expected
-          }
-        }
       }
     }
 


### PR DESCRIPTION
- Use Class type instead of Classname strings in all annotations.
- Display expected exceptions in markdown.