### PR TITLE
Improve handling of dependent value handling in create/update dialog

### DIFF
--- a/workspace/src/app/views/shared/TargetVocabularySelection/DefaultTargetVocabularySelection.tsx
+++ b/workspace/src/app/views/shared/TargetVocabularySelection/DefaultTargetVocabularySelection.tsx
@@ -8,7 +8,7 @@ import { IInputAttributes } from "../modals/CreateArtefactModal/ArtefactForms/In
 
 /** Target vocabulary selection component that has static entries 'all installed vocabularies' and 'none'.
  *  And alternatively allows to multi-select all available vocabularies (from the global vocabulary cache). */
-export function DefaultTargetVocabularySelection({ id, name, intent, defaultValue, onChange }: IInputAttributes) {
+export function DefaultTargetVocabularySelection({ id, name, defaultValue, onChange }: IInputAttributes) {
     const [vocabularies, setVocabularies] = useState<IVocabularyInfo[]>([]);
     const [loading, setLoading] = useState<boolean>(true);
     const [t] = useTranslation();

--- a/workspace/src/app/views/shared/YamlEditor.tsx
+++ b/workspace/src/app/views/shared/YamlEditor.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { CodeAutocompleteField } from "@eccenca/gui-elements";
 import {
     CodeAutocompleteFieldPartialAutoCompleteResult,
+    CodeAutocompleteFieldProps,
     CodeAutocompleteFieldReplacementResult,
     CodeAutocompleteFieldValidationResult,
 } from "@eccenca/gui-elements/src/components/AutoSuggestion/AutoSuggestion";
@@ -34,6 +35,7 @@ interface YamlEditorProps {
     onChange: (currentValue: string) => any;
     /** The auto-completion config. */
     autoCompletion?: IPropertyAutocomplete;
+    intent?: CodeAutocompleteFieldProps["intent"];
 }
 
 export const YamlEditor: React.FC<YamlEditorProps> = ({
@@ -46,6 +48,7 @@ export const YamlEditor: React.FC<YamlEditorProps> = ({
     autoCompletion,
     id,
     onChange,
+    intent,
 }) => {
     const { registerError } = useErrorHandler();
 
@@ -125,6 +128,7 @@ export const YamlEditor: React.FC<YamlEditorProps> = ({
             initialValue={initialValue ?? ""}
             multiline={true}
             onChange={onChange}
+            intent={intent}
             fetchSuggestions={fetchSuggestions}
             autoCompletionRequestDelay={200}
             checkInput={checkYamlString}

--- a/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/ArtefactFormParameter.tsx
+++ b/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/ArtefactFormParameter.tsx
@@ -19,7 +19,10 @@ import {
     OptionallyLabelledParameter,
     optionallyLabelledParameterToValue,
 } from "../../../../taskViews/linking/linking.types";
-import { CodeAutocompleteFieldValidationResult } from "@eccenca/gui-elements/src/components/AutoSuggestion/AutoSuggestion";
+import {
+    CodeAutocompleteFieldProps,
+    CodeAutocompleteFieldValidationResult,
+} from "@eccenca/gui-elements/src/components/AutoSuggestion/AutoSuggestion";
 import { useSelector } from "react-redux";
 import { commonSel } from "@ducks/common";
 import { CreateArtefactModalContext } from "../CreateArtefactModalContext";
@@ -184,6 +187,8 @@ export const ArtefactFormParameter = ({
                     parameterType,
                 ))) ||
         isTemplateInputType;
+    const inputIntent: CodeAutocompleteFieldProps["intent"] =
+        infoMessageDanger || !!validationError ? "danger" : highlightForReview ? "warning" : undefined;
 
     return (
         <FieldItem
@@ -195,7 +200,7 @@ export const ArtefactFormParameter = ({
                 htmlFor: parameterId,
                 tooltip: tooltip,
             }}
-            intent={infoMessageDanger || !!validationError ? "danger" : highlightForReview ? "warning" : undefined}
+            intent={inputIntent}
             messageText={infoMessage || validationError || templateInfoMessage || passwordMsgText}
             disabled={disabled}
             helperText={helperText}
@@ -219,6 +224,7 @@ export const ArtefactFormParameter = ({
                             evaluatedValueMessage={
                                 supportVariableTemplateElement?.showTemplatePreview ? setTemplateInfoMessage : undefined
                             }
+                            intent={inputIntent}
                             allowSensitiveVariables={isPasswordInput}
                             // If the parameter is a template parameter, the validation is not aware in general what variables exist
                             ignoreUnboundVariables={isTemplateInputType && !showVariableTemplateInput}
@@ -274,6 +280,7 @@ interface TemplateInputComponentProps {
     allowSensitiveVariables?: boolean;
     /** If the validation of the template string should ignore unbound variables. */
     ignoreUnboundVariables: boolean;
+    intent?: CodeAutocompleteFieldProps["intent"];
 }
 
 /** The input component for the template value. */
@@ -290,6 +297,7 @@ export const TemplateInputComponent = memo(
         multiline,
         allowSensitiveVariables,
         ignoreUnboundVariables,
+        intent,
     }: TemplateInputComponentProps) => {
         const currentUB = React.useRef<boolean>(ignoreUnboundVariables);
         currentUB.current = ignoreUnboundVariables;
@@ -386,6 +394,7 @@ export const TemplateInputComponent = memo(
                 checkInput={checkTemplate}
                 autoCompletionRequestDelay={200}
                 multiline={multiline}
+                intent={intent}
                 outerDivAttributes={
                     {
                         "data-test-id": "codemirror-wrapper",

--- a/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/ArtefactFormParameter.tsx
+++ b/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/ArtefactFormParameter.tsx
@@ -71,6 +71,7 @@ interface Props {
         defaultValue?: string | number | boolean | OptionallyLabelledParameter<string | number | boolean>;
     };
     parameterType?: string;
+    highlightForReview?: boolean;
 }
 
 /** Wrapper around the input element of a parameter. Supports switching to variable templates. */
@@ -88,6 +89,7 @@ export const ArtefactFormParameter = ({
     disabled = false,
     tooltip,
     supportVariableTemplateElement,
+    highlightForReview = false,
 }: Props) => {
     const [t] = useTranslation();
     const [toggledTemplateSwitchBefore, setToggledTemplateSwitchBefore] = React.useState<boolean>(false);
@@ -186,13 +188,14 @@ export const ArtefactFormParameter = ({
     return (
         <FieldItem
             key={parameterId}
+            data-test-id={`task-form-parameter-${parameterId}`}
             labelProps={{
                 text: label,
                 info: required ? t("common.words.required") : undefined,
                 htmlFor: parameterId,
                 tooltip: tooltip,
             }}
-            intent={infoMessageDanger || !!validationError ? "danger" : undefined}
+            intent={infoMessageDanger || !!validationError ? "danger" : highlightForReview ? "warning" : undefined}
             messageText={infoMessage || validationError || templateInfoMessage || passwordMsgText}
             disabled={disabled}
             helperText={helperText}

--- a/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/InputMapper.tsx
+++ b/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/InputMapper.tsx
@@ -21,7 +21,7 @@ interface IProps {
     projectId: string;
     parameter: ITaskParameter;
     // Blueprint intent
-    intent: Intent;
+    intent?: Intent;
     onChange: (value) => void;
     // Initial values in a flat form, e.g. "nestedParam.param1". This is either set for all parameters or not set for none.
     // The prefixed values can be addressed with help of the 'formParamId' parameter.
@@ -40,7 +40,7 @@ export type RegisterForExternalChangesFn = (
 export interface IInputAttributes {
     id: string;
     name: string;
-    intent: Intent;
+    intent?: Intent;
     onChange: (value) => void;
     value?: any;
     defaultValue?: any;

--- a/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/ParameterAutoCompletion.tsx
+++ b/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/ParameterAutoCompletion.tsx
@@ -42,7 +42,7 @@ export interface ParameterAutoCompletionProps {
     /** If a value is required. If true, a reset won't be possible. */
     required: boolean;
     onChange: (value: IAutocompleteDefaultResponse) => any;
-    intent: Intent;
+    intent?: Intent;
     /** Show errors in the auto-completion list instead of the global error notification widget. */
     showErrorsInline?: boolean;
     /** When set to true the auto-complete input field will be in read-only mode and cannot be edited. */

--- a/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/ParameterWidget.tsx
+++ b/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/ParameterWidget.tsx
@@ -76,6 +76,7 @@ interface IProps {
     // Values that the auto-completion of other parameters depends on
     dependentValues: React.MutableRefObject<Record<string, DependsOnParameterValueAny | undefined>>;
     parameterCallbacks: ExtendedParameterCallbacks;
+    isDependencyReviewHighlighted: (fullParameterId: string) => boolean;
 }
 
 /** Renders the errors message based on the error type. */
@@ -109,6 +110,7 @@ export const ParameterWidget = (props: IProps) => {
         initialValues,
         dependentValues,
         parameterCallbacks,
+        isDependencyReviewHighlighted,
     } = props;
     const parameterExtensions = pluginRegistry.pluginComponent<ParameterExtensions>(
         SUPPORTED_PLUGINS.DI_PARAMETER_EXTENSIONS,
@@ -144,6 +146,10 @@ export const ParameterWidget = (props: IProps) => {
             : undefined;
 
     const detailedDocumentationAvailable = parameterCallbacks.namedAnchors.includes(formParamId);
+    const dependencyReviewHighlighted = isDependencyReviewHighlighted(formParamId);
+    const dependencyReviewMessage = dependencyReviewHighlighted
+        ? (t("form.taskForm.affectedParameterNeedsReview") as string)
+        : undefined;
     let propertyHelperText: JSX.Element | undefined = undefined;
     if ((description && description.length > MAXLENGTH_TOOLTIP) || detailedDocumentationAvailable) {
         let parameterDescription: JSX.Element = <Markdown>{description}</Markdown>;
@@ -198,6 +204,7 @@ export const ParameterWidget = (props: IProps) => {
         return (
             <FieldSet
                 boxed
+                data-test-id={`task-form-parameter-${formParamId}`}
                 title={
                     <Label
                         isLayoutForElement="span"
@@ -207,6 +214,8 @@ export const ParameterWidget = (props: IProps) => {
                     />
                 }
                 helperText={propertyHelperText}
+                intent={!!errorText ? "danger" : dependencyReviewHighlighted ? "warning" : undefined}
+                messageText={errorText ? errorText : dependencyReviewMessage}
             >
                 {Object.entries(propertyDetails.properties as Record<string, IArtefactItemProperty>).map(
                     ([nestedParamId, nestedParam]) => {
@@ -224,6 +233,7 @@ export const ParameterWidget = (props: IProps) => {
                                 initialValues={initialValues}
                                 dependentValues={dependentValues}
                                 parameterCallbacks={parameterCallbacks}
+                                isDependencyReviewHighlighted={isDependencyReviewHighlighted}
                             />
                         );
                     },
@@ -234,6 +244,7 @@ export const ParameterWidget = (props: IProps) => {
         return (
             <FieldSet
                 boxed
+                data-test-id={`task-form-parameter-${formParamId}`}
                 title={
                     <Label
                         isLayoutForElement="span"
@@ -243,13 +254,13 @@ export const ParameterWidget = (props: IProps) => {
                     />
                 }
                 helperText={propertyHelperText}
-                intent={!!errorMessage(title, errors) ? "danger" : undefined}
-                messageText={errorText ? errorText : infoHelperText}
+                intent={!!errorMessage(title, errors) ? "danger" : dependencyReviewHighlighted ? "warning" : undefined}
+                messageText={errorText ? errorText : dependencyReviewMessage ?? infoHelperText}
             >
                 <InputMapper
                     projectId={projectId}
                     parameter={{ paramId: formParamId, param: propertyDetails }}
-                    intent={errors ? Intent.DANGER : Intent.NONE}
+                    intent={errors ? Intent.DANGER : dependencyReviewHighlighted ? Intent.WARNING : Intent.NONE}
                     onChange={changeHandlers[formParamId]}
                     initialParameterValue={initialValues[formParamId]}
                     required={required}
@@ -274,9 +285,10 @@ export const ParameterWidget = (props: IProps) => {
                 required={required && propertyDetails.parameterType !== "boolean"}
                 tooltip={description && description.length <= MAXLENGTH_TOOLTIP ? description : undefined}
                 helperText={propertyHelperText}
-                infoMessage={errorText ? errorText : infoHelperText}
+                infoMessage={errorText ? errorText : dependencyReviewMessage ?? infoHelperText}
                 infoMessageDanger={!!errorText}
                 parameterType={propertyDetails.parameterType}
+                highlightForReview={dependencyReviewHighlighted}
                 supportVariableTemplateElement={{
                     onChange: changeHandlers[formParamId],
                     startWithTemplateView: isTemplateParameter,

--- a/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/ParameterWidget.tsx
+++ b/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/ParameterWidget.tsx
@@ -304,6 +304,7 @@ export const ParameterWidget = (props: IProps) => {
                                 projectId={projectId}
                                 pluginId={pluginId}
                                 autoCompletion={autoCompletion}
+                                intent={errors ? "danger" : dependencyReviewHighlighted ? "warning" : undefined}
                                 id={formParamId}
                                 initialValue={initialValue?.value ?? initialValue}
                                 onChange={(value) => (onChange ? onChange(value) : changeHandlers[formParamId](value))}
@@ -330,7 +331,7 @@ export const ParameterWidget = (props: IProps) => {
                                         : defaultValueAsJs(propertyDetails, true))
                                 }
                                 autoCompletion={autoCompletion}
-                                intent={errors ? Intent.DANGER : Intent.NONE}
+                                intent={errors ? Intent.DANGER : dependencyReviewHighlighted ? Intent.WARNING : undefined}
                                 formParamId={formParamId}
                                 dependentValue={dependentValue}
                                 defaultValue={parameterCallbacks.defaultValue}
@@ -347,7 +348,7 @@ export const ParameterWidget = (props: IProps) => {
                             <InputMapper
                                 projectId={projectId}
                                 parameter={{ paramId: formParamId, param: propertyDetails }}
-                                intent={errors ? Intent.DANGER : Intent.NONE}
+                                intent={errors ? Intent.DANGER : dependencyReviewHighlighted ? Intent.WARNING : undefined}
                                 onChange={onChange ?? changeHandlers[formParamId]}
                                 initialParameterValue={initialParameterValue}
                                 required={required}

--- a/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/TaskForm.tsx
+++ b/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/TaskForm.tsx
@@ -32,6 +32,7 @@ import utils from "@eccenca/gui-elements/src/cmem/markdown/markdown.utils";
 import { commonOp } from "@ducks/common";
 import { DependsOnParameterValueAny } from "./ParameterAutoCompletion";
 import { FieldValues, FormContextValues } from "react-hook-form";
+import { collectPopulatedDependentParameters } from "./TaskForm.utils";
 
 export const READ_ONLY_PARAMETER = "readOnly";
 
@@ -63,8 +64,13 @@ export interface IProps {
     /** If a parameter value is changed in a way that did not use the parameter widget, this must be called in order to update the value in the widget itself. */
     propagateExternallyChangedParameterValue: (fullParamId: string, value: string) => any;
 
-    /** Shows a warning notification with the following message in the dialog popup that can be removed by the user. */
-    showWarningMessage: (message: string) => void;
+    /** Shows or clears a warning notification in the dialog popup. */
+    showWarningMessage: (warning?: TaskFormReviewWarning) => void;
+}
+
+export interface TaskFormReviewWarning {
+    message: React.JSX.Element | string;
+    onClearHighlightedValues?: () => void;
 }
 
 export interface UpdateTaskProps {
@@ -144,8 +150,10 @@ export function TaskForm({
         React.useRef<Record<string, DependsOnParameterValueAny | undefined>>({});
     const dependentParameters = React.useRef<Map<string, Set<string>>>(new Map());
     const [doChange, setDoChange] = useState<boolean>(false);
+    const [staleDependentParameterIds, setStaleDependentParameterIds] = useState<string[]>([]);
     const { registerError } = useErrorHandler();
     const parameterDefaultValues = React.useRef<Map<string, string | null>>(new Map());
+    const staleDependentParameterIdsRef = React.useRef<string[]>([]);
     parameterDefaultValues.current = extractDefaultValues(artefact);
 
     const addDependentParameter = React.useCallback((dependentParameter: string, dependsOn: string) => {
@@ -252,6 +260,34 @@ export function TaskForm({
             setDoChange(false);
         }
     }, [doChange]);
+
+    const scrollParameterIntoView = React.useCallback((fullParameterId: string) => {
+        const parameterElement = window.document.querySelector(
+            `[data-test-id="task-form-parameter-${fullParameterId}"]`,
+        ) as HTMLElement | null;
+        parameterElement?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, []);
+
+    useEffect(() => {
+        staleDependentParameterIdsRef.current = staleDependentParameterIds;
+        if (staleDependentParameterIds.length) {
+            const parameterLabelsToReview = staleDependentParameterIds.map(
+                (paramId) => parameterLabels.current.get(paramId) ?? paramId,
+            );
+            showWarningMessage({
+                message: t(
+                    "form.taskForm.dependentValuesNeedReview",
+                    {
+                        count: parameterLabelsToReview.length,
+                        parameters: parameterLabelsToReview.join(", ")
+                    },
+                ),
+                onClearHighlightedValues: () => void clearHighlightedDependentParameters(),
+            });
+        } else {
+            showWarningMessage(undefined);
+        }
+    }, [staleDependentParameterIds, showWarningMessage, t]);
 
     /** Initialize: register parameters, set default/existing values etc. */
     useEffect(() => {
@@ -382,6 +418,25 @@ export function TaskForm({
     }, [properties, register, projectId]);
 
     /** Change handler for a specific parameter. */
+    const clearHighlightedDependentParameters = React.useCallback(async () => {
+        const highlightedParameterIds = staleDependentParameterIdsRef.current;
+        highlightedParameterIds.forEach((paramId) => {
+            const oldValue = getValues(paramId);
+            if (dependentValues.current[paramId] !== undefined) {
+                dependentValues.current[paramId] = {
+                    value: "",
+                    isTemplate: parameterCallbacks.templateFlag(paramId),
+                };
+            }
+            setValue(paramId, "");
+            detectChange(paramId, "", oldValue);
+            propagateExternallyChangedParameterValue(paramId, "");
+        });
+        await Promise.all(highlightedParameterIds.map((paramId) => triggerValidation(paramId)));
+        setStaleDependentParameterIds([]);
+    }, [detectChange, getValues, propagateExternallyChangedParameterValue, setValue, triggerValidation]);
+
+    /** Change handler for a specific parameter. */
     const handleChange = useCallback(
         (key: string) => async (e) => {
             const { triggerValidation } = form;
@@ -403,40 +458,36 @@ export function TaskForm({
             if (!escapeKeyDisabled.current) {
                 escapeKeyDisabled.current = true;
             }
-            if (dependentParameters.current.has(key)) {
-                // collect all dependent parameters
-                const dependentParametersTransitiveSet = new Set<string>();
-                // Dependent parameters that were actually reset
-                const resetDependentParameters: string[] = [];
-                const collect = (currentParamId: string) => {
-                    const params = dependentParameters.current?.get(currentParamId) ?? [];
-                    params.forEach((p: string) => {
-                        if (!dependentParametersTransitiveSet.has(p)) {
-                            dependentParametersTransitiveSet.add(p);
-                            collect(p);
-                        }
-                    });
-                };
-                collect(key);
-                dependentParametersTransitiveSet.forEach((paramId) => {
-                    const currentValue = getValues(paramId);
-                    if (currentValue && paramId !== key) {
-                        resetDependentParameters.push(parameterLabels.current.get(paramId) ?? paramId);
-                        handleChange(paramId)("");
-                        propagateExternallyChangedParameterValue(paramId, "");
-                    }
-                });
-                if (resetDependentParameters.length) {
-                    showWarningMessage(
-                        t("form.taskForm.resetMessage", {
-                            parameters: resetDependentParameters.join(", "),
-                            dependOn: parameterLabels.current.get(key) ?? key,
-                        }),
-                    );
-                }
+            const populatedDependentParameters = dependentParameters.current.has(key)
+                ? collectPopulatedDependentParameters(
+                    key,
+                    dependentParameters.current,
+                    (paramId) => getValues(paramId),
+                )
+                : [];
+            if (populatedDependentParameters.length) {
+                scrollParameterIntoView(populatedDependentParameters[0]);
             }
+            setStaleDependentParameterIds((previousIds) => {
+                const nextIds = new Set(previousIds);
+                nextIds.delete(key);
+                populatedDependentParameters.forEach((paramId) => nextIds.add(paramId));
+                return Array.from(nextIds);
+            });
         },
-        [],
+        [
+            detectChange,
+            form,
+            getValues,
+            projectId,
+            propagateExternallyChangedParameterValue,
+            registerError,
+            setValue,
+            showWarningMessage,
+            scrollParameterIntoView,
+            t,
+            triggerValidation,
+        ],
     );
 
     const handleTagSelectionChange = React.useCallback(
@@ -458,7 +509,12 @@ export function TaskForm({
             handlers[key] = handleChange(key);
         });
         return handlers;
-    }, [formValueKeys]);
+    }, [formValueKeys, handleChange]);
+
+    const isDependencyReviewHighlighted = React.useCallback(
+        (fullParameterId: string) => staleDependentParameterIds.includes(fullParameterId),
+        [staleDependentParameterIds],
+    );
 
     const normalParams = visibleParams.filter(([k, param]) => !param.advanced);
     const advancedParams = visibleParams.filter(([k, param]) => param.advanced);
@@ -561,6 +617,7 @@ export function TaskForm({
                         initialValues={initialValues}
                         dependentValues={dependentValues}
                         parameterCallbacks={extendedCallbacks}
+                        isDependencyReviewHighlighted={isDependencyReviewHighlighted}
                     />
                 ))}
                 {
@@ -618,6 +675,7 @@ export function TaskForm({
                             initialValues={initialValues}
                             dependentValues={dependentValues}
                             parameterCallbacks={extendedCallbacks}
+                            isDependencyReviewHighlighted={isDependencyReviewHighlighted}
                         />
                     ))}
                 </AdvancedOptionsArea>

--- a/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/TaskForm.tsx
+++ b/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/TaskForm.tsx
@@ -71,6 +71,7 @@ export interface IProps {
 export interface TaskFormReviewWarning {
     message: React.JSX.Element | string;
     onClearHighlightedValues?: () => void;
+    onDismiss?: () => void;
 }
 
 export interface UpdateTaskProps {
@@ -268,26 +269,9 @@ export function TaskForm({
         parameterElement?.scrollIntoView({ behavior: "smooth", block: "center" });
     }, []);
 
-    useEffect(() => {
-        staleDependentParameterIdsRef.current = staleDependentParameterIds;
-        if (staleDependentParameterIds.length) {
-            const parameterLabelsToReview = staleDependentParameterIds.map(
-                (paramId) => parameterLabels.current.get(paramId) ?? paramId,
-            );
-            showWarningMessage({
-                message: t(
-                    "form.taskForm.dependentValuesNeedReview",
-                    {
-                        count: parameterLabelsToReview.length,
-                        parameters: parameterLabelsToReview.join(", ")
-                    },
-                ),
-                onClearHighlightedValues: () => void clearHighlightedDependentParameters(),
-            });
-        } else {
-            showWarningMessage(undefined);
-        }
-    }, [staleDependentParameterIds, showWarningMessage, t]);
+    const dismissHighlightedDependentParameters = React.useCallback(() => {
+        setStaleDependentParameterIds([]);
+    }, []);
 
     /** Initialize: register parameters, set default/existing values etc. */
     useEffect(() => {
@@ -433,8 +417,40 @@ export function TaskForm({
             propagateExternallyChangedParameterValue(paramId, "");
         });
         await Promise.all(highlightedParameterIds.map((paramId) => triggerValidation(paramId)));
-        setStaleDependentParameterIds([]);
-    }, [detectChange, getValues, propagateExternallyChangedParameterValue, setValue, triggerValidation]);
+        dismissHighlightedDependentParameters();
+    }, [
+        detectChange,
+        dismissHighlightedDependentParameters,
+        getValues,
+        propagateExternallyChangedParameterValue,
+        setValue,
+        triggerValidation,
+    ]);
+
+    useEffect(() => {
+        staleDependentParameterIdsRef.current = staleDependentParameterIds;
+        if (staleDependentParameterIds.length) {
+            const parameterLabelsToReview = staleDependentParameterIds.map(
+                (paramId) => parameterLabels.current.get(paramId) ?? paramId,
+            );
+            showWarningMessage({
+                message: t("form.taskForm.dependentValuesNeedReview", {
+                    count: parameterLabelsToReview.length,
+                    parameters: parameterLabelsToReview.join(", "),
+                }),
+                onDismiss: dismissHighlightedDependentParameters,
+                onClearHighlightedValues: () => void clearHighlightedDependentParameters(),
+            });
+        } else {
+            showWarningMessage(undefined);
+        }
+    }, [
+        clearHighlightedDependentParameters,
+        dismissHighlightedDependentParameters,
+        staleDependentParameterIds,
+        showWarningMessage,
+        t,
+    ]);
 
     /** Change handler for a specific parameter. */
     const handleChange = useCallback(

--- a/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/TaskForm.utils.test.ts
+++ b/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/TaskForm.utils.test.ts
@@ -1,0 +1,34 @@
+import { collectPopulatedDependentParameters, collectTransitiveDependentParameters } from "./TaskForm.utils";
+
+describe("TaskForm utils", () => {
+    it("collects transitive dependent parameters", () => {
+        const dependencyGraph = new Map<string, Set<string>>([
+            ["connection.password", new Set(["connection.database", "connection.schema"])],
+            ["connection.database", new Set(["connection.table"])],
+        ]);
+
+        expect(collectTransitiveDependentParameters("connection.password", dependencyGraph)).toEqual([
+            "connection.database",
+            "connection.table",
+            "connection.schema",
+        ]);
+    });
+
+    it("collects only populated dependent parameters and ignores the changed parameter in cycles", () => {
+        const dependencyGraph = new Map<string, Set<string>>([
+            ["connection.password", new Set(["connection.database", "connection.schema", "connection.role"])],
+            ["connection.database", new Set(["connection.password", "connection.table"])],
+        ]);
+        const values: Record<string, any> = {
+            "connection.password": "secret",
+            "connection.database": "analytics",
+            "connection.schema": "",
+            "connection.role": undefined,
+            "connection.table": "customers",
+        };
+
+        expect(
+            collectPopulatedDependentParameters("connection.password", dependencyGraph, (paramId) => values[paramId]),
+        ).toEqual(["connection.database", "connection.table"]);
+    });
+});

--- a/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/TaskForm.utils.ts
+++ b/workspace/src/app/views/shared/modals/CreateArtefactModal/ArtefactForms/TaskForm.utils.ts
@@ -1,0 +1,31 @@
+export const collectTransitiveDependentParameters = (
+    changedParameterId: string,
+    dependencyGraph: Map<string, Set<string>>,
+): string[] => {
+    const visited = new Set<string>([changedParameterId]);
+    const collected: string[] = [];
+
+    const collect = (currentParamId: string) => {
+        const dependentParams = dependencyGraph.get(currentParamId) ?? [];
+        dependentParams.forEach((paramId: string) => {
+            if (!visited.has(paramId)) {
+                visited.add(paramId);
+                collected.push(paramId);
+                collect(paramId);
+            }
+        });
+    };
+
+    collect(changedParameterId);
+    return collected;
+};
+
+export const collectPopulatedDependentParameters = (
+    changedParameterId: string,
+    dependencyGraph: Map<string, Set<string>>,
+    getValue: (paramId: string) => any,
+): string[] => {
+    return collectTransitiveDependentParameters(changedParameterId, dependencyGraph).filter((paramId) => {
+        return paramId !== changedParameterId && !!getValue(paramId);
+    });
+};

--- a/workspace/src/app/views/shared/modals/CreateArtefactModal/CreateArtefactModal.tsx
+++ b/workspace/src/app/views/shared/modals/CreateArtefactModal/CreateArtefactModal.tsx
@@ -978,7 +978,10 @@ export function CreateArtefactModal() {
                         ]
                         : undefined
                 }
-                onDismiss={() => setTaskFormGeneralWarning(undefined)}
+                onDismiss={() => {
+                    taskFormGeneralWarning.onDismiss?.();
+                    setTaskFormGeneralWarning(undefined);
+                }}
             />,
         );
     }

--- a/workspace/src/app/views/shared/modals/CreateArtefactModal/CreateArtefactModal.tsx
+++ b/workspace/src/app/views/shared/modals/CreateArtefactModal/CreateArtefactModal.tsx
@@ -40,7 +40,7 @@ import {
 } from "@ducks/common/typings";
 import Loading from "../../Loading";
 import { ProjectForm } from "./ArtefactForms/ProjectForm";
-import { TaskForm } from "./ArtefactForms/TaskForm";
+import { TaskForm, TaskFormReviewWarning } from "./ArtefactForms/TaskForm";
 import { DATA_TYPES } from "../../../../constants";
 import ArtefactTypesList from "./ArtefactTypesList";
 import { SearchBar } from "../../SearchBar/SearchBar";
@@ -156,7 +156,7 @@ export function CreateArtefactModal() {
     }, []);
     const [taskActionResult, setTaskActionResult] = React.useState<{ label: string; message: string }>();
     const [taskActionLoading, setTaskActionLoading] = React.useState<string | null>(null);
-    const [taskFormGeneralWarning, setTaskFormGeneralWarning] = React.useState<string | undefined>();
+    const [taskFormGeneralWarning, setTaskFormGeneralWarning] = React.useState<TaskFormReviewWarning | undefined>();
     const generalWarningTimeout = React.useRef<number | undefined>();
     const projectAcl = React.useRef<AccessControlConfig | undefined>();
 
@@ -164,11 +164,15 @@ export function CreateArtefactModal() {
         projectAcl.current = newProjectAcl;
     }, []);
 
-    const taskFormWarning = React.useCallback((message: string) => {
+    const taskFormWarning = React.useCallback((warning?: TaskFormReviewWarning) => {
         if (generalWarningTimeout.current) {
             clearTimeout(generalWarningTimeout.current);
         }
-        generalWarningTimeout.current = window.setTimeout(() => setTaskFormGeneralWarning(message), 250);
+        if (!warning) {
+            setTaskFormGeneralWarning(undefined);
+            return;
+        }
+        generalWarningTimeout.current = window.setTimeout(() => setTaskFormGeneralWarning(warning), 250);
     }, []);
 
     React.useEffect(() => {
@@ -956,7 +960,26 @@ export function CreateArtefactModal() {
 
     if (taskFormGeneralWarning) {
         notifications.push(
-            <Notification message={taskFormGeneralWarning} onDismiss={() => setTaskFormGeneralWarning(undefined)} />,
+            <Notification
+                data-test-id="task-form-dependent-values-warning"
+                intent="warning"
+                message={taskFormGeneralWarning.message}
+                actions={
+                    taskFormGeneralWarning.onClearHighlightedValues
+                        ? [
+                            <Button
+                                data-test-id="task-form-clear-highlighted-dependent-values"
+                                key="clear-highlighted-dependent-values"
+                                disruptive
+                                onClick={taskFormGeneralWarning.onClearHighlightedValues}
+                            >
+                                {t("form.taskForm.clearHighlightedValues")}
+                            </Button>,
+                        ]
+                        : undefined
+                }
+                onDismiss={() => setTaskFormGeneralWarning(undefined)}
+            />,
         );
     }
 

--- a/workspace/src/locales/manual/en.json
+++ b/workspace/src/locales/manual/en.json
@@ -481,7 +481,11 @@
             "title": "Title"
         },
         "taskForm": {
-            "resetMessage": "Following parameters have been reset because they depend on the changed parameter '{{dependOn}}': {{parameters}}"
+            "resetMessage": "Following parameters have been reset because they depend on the changed parameter '{{dependOn}}': {{parameters}}",
+            "dependentValuesNeedReview": "You have changed a parameter that {{count}} other parameter depends on. Following parameter needs to be checked: {{parameters}}",
+            "dependentValuesNeedReview_plural": "You have changed a parameter that {{count}} other parameters depend on. Following parameters need to be checked: {{parameters}}",
+            "affectedParameterNeedsReview": "This parameter depends on a changed parameter. Please check whether its value is still correct.",
+            "clearHighlightedValues": "Clear highlighted values"
         },
         "validations": {
             "float": "must be a valid floating point number",

--- a/workspace/test/integration/components/CreateArtefactModal/CreateArtefactModal.test.tsx
+++ b/workspace/test/integration/components/CreateArtefactModal/CreateArtefactModal.test.tsx
@@ -380,7 +380,7 @@ describe("Task creation widget", () => {
         });
     });
 
-    it("should keep dependent values, highlight them, and clear them only via the warning action", async () => {
+    const createDependentParameterWrapper = async () => {
         addDocumentCreateRangeMethod();
         const dependentParameterPluginDescription: IPluginDetails = {
             ...mockPluginDescription,
@@ -420,23 +420,71 @@ describe("Task creation widget", () => {
             expect(findElement(element, "#password")).toBeInTheDocument();
             expect(findElement(element, "#database")).toBeInTheDocument();
         });
+        return { element };
+    };
 
-        changeInputValue(findElement(element, "#password") as HTMLInputElement, "new-secret");
+    const databaseInput = (element: Element | RenderResult) => findElement(element, "#database") as HTMLInputElement;
+    const databaseInputGroupClassName = (element: Element | RenderResult) =>
+        databaseInput(element).closest(`.${bluePrintClassPrefix}-input-group`)?.className ?? "";
 
+    const expectDependentDatabaseWarning = async (
+        element: Element | RenderResult,
+        expectedValue: string = "analytics",
+    ) => {
         await waitFor(() => {
-            expect((findElement(element, "#database") as HTMLInputElement).value).toBe("analytics");
+            expect(databaseInput(element).value).toBe(expectedValue);
             expect(findElement(element, byTestId("task-form-dependent-values-warning"))).toBeInTheDocument();
+            expect(databaseInputGroupClassName(element)).toContain(`${bluePrintClassPrefix}-intent-warning`);
         });
+    };
 
-        expect(findElement(element, byTestId("task-form-parameter-database")).className).toContain(
-            "eccgui-intent--warning",
-        );
+    const expectDependentDatabaseWarningCleared = async (
+        element: Element | RenderResult,
+        expectedValue: string,
+    ) => {
+        await waitFor(() => {
+            expect(databaseInput(element).value).toBe(expectedValue);
+            expect(("container" in element ? element.container : element).querySelector(byTestId("task-form-dependent-values-warning"))).not.toBeInTheDocument();
+            expect(databaseInputGroupClassName(element)).not.toContain(`${bluePrintClassPrefix}-intent-warning`);
+        });
+    };
+
+    const dismissDependentDatabaseWarning = (element: Element | RenderResult) => {
+        const warning = findElement(element, byTestId("task-form-dependent-values-warning"));
+        clickRenderedElement(within(warning).getByLabelText("Close"));
+    };
+
+    it("should keep dependent values, highlight them, and clear them only via the warning action", async () => {
+        const { element } = await createDependentParameterWrapper();
+        changeInputValue(findElement(element, "#password") as HTMLInputElement, "new-secret");
+        await expectDependentDatabaseWarning(element);
 
         clickRenderedElement(findElement(element, byTestId("task-form-clear-highlighted-dependent-values")));
+        await expectDependentDatabaseWarningCleared(element, "");
+    });
 
-        await waitFor(() => {
-            expect((findElement(element, "#database") as HTMLInputElement).value).toBe("");
-        });
+    it("should remove dependent value highlighting but keep the value when dismissing the warning", async () => {
+        const { element } = await createDependentParameterWrapper();
+        changeInputValue(findElement(element, "#password") as HTMLInputElement, "new-secret");
+        await expectDependentDatabaseWarning(element);
+
+        dismissDependentDatabaseWarning(element);
+
+        await expectDependentDatabaseWarningCleared(element, "analytics");
+    });
+
+    it("should highlight dependent values again after dismissing the warning and changing the dependency again", async () => {
+        const { element } = await createDependentParameterWrapper();
+        const passwordInput = findElement(element, "#password") as HTMLInputElement;
+
+        changeInputValue(passwordInput, "new-secret");
+        await expectDependentDatabaseWarning(element);
+
+        dismissDependentDatabaseWarning(element);
+        await expectDependentDatabaseWarningCleared(element, "analytics");
+
+        changeInputValue(passwordInput, "newer-secret");
+        await expectDependentDatabaseWarning(element);
     });
 
     const value = (value: string, label?: string) => {

--- a/workspace/test/integration/components/CreateArtefactModal/CreateArtefactModal.test.tsx
+++ b/workspace/test/integration/components/CreateArtefactModal/CreateArtefactModal.test.tsx
@@ -380,6 +380,65 @@ describe("Task creation widget", () => {
         });
     });
 
+    it("should keep dependent values, highlight them, and clear them only via the warning action", async () => {
+        addDocumentCreateRangeMethod();
+        const dependentParameterPluginDescription: IPluginDetails = {
+            ...mockPluginDescription,
+            required: [],
+            properties: {
+                password: atomicParamDescription({
+                    title: "password",
+                    parameterType: INPUT_TYPES.PASSWORD,
+                }),
+                database: atomicParamDescription(
+                    {
+                        title: "database",
+                        parameterType: INPUT_TYPES.STRING,
+                    },
+                    {
+                        allowOnlyAutoCompletedValues: false,
+                        autoCompletionDependsOnParameters: ["password"],
+                    },
+                ),
+            },
+        };
+        const existingTaskWithDependentValue: RecursivePartial<IProjectTaskUpdatePayload> = {
+            projectId: PROJECT_ID,
+            taskId: TASK_ID,
+            taskPluginDetails: dependentParameterPluginDescription,
+            metaData: {
+                label: "Task label",
+            },
+            currentParameterValues: {
+                password: value("old-secret"),
+                database: value("analytics"),
+            },
+            currentTemplateValues: {},
+        };
+        const { element } = await createMockedListWrapper(existingTaskWithDependentValue);
+        await waitFor(() => {
+            expect(findElement(element, "#password")).toBeInTheDocument();
+            expect(findElement(element, "#database")).toBeInTheDocument();
+        });
+
+        changeInputValue(findElement(element, "#password") as HTMLInputElement, "new-secret");
+
+        await waitFor(() => {
+            expect((findElement(element, "#database") as HTMLInputElement).value).toBe("analytics");
+            expect(findElement(element, byTestId("task-form-dependent-values-warning"))).toBeInTheDocument();
+        });
+
+        expect(findElement(element, byTestId("task-form-parameter-database")).className).toContain(
+            "eccgui-intent--warning",
+        );
+
+        clickRenderedElement(findElement(element, byTestId("task-form-clear-highlighted-dependent-values")));
+
+        await waitFor(() => {
+            expect((findElement(element, "#database") as HTMLInputElement).value).toBe("");
+        });
+    });
+
     const value = (value: string, label?: string) => {
         const result: { value: string; label?: string } = { value };
         if (label) {


### PR DESCRIPTION
- Instead of clearing all dependent values, highlight them, so the user can check them.
- Also offer a clear button that clears all dependent values at once.