### PR TITLE
Parse JSON fails when wired directly to a downstream dataset

### DIFF
--- a/silk-core/src/test/scala/org/silkframework/dataset/operations/LocalDeleteFilesOperatorExecutorTest.scala
+++ b/silk-core/src/test/scala/org/silkframework/dataset/operations/LocalDeleteFilesOperatorExecutorTest.scala
@@ -25,23 +25,23 @@ class LocalDeleteFilesOperatorExecutorTest extends AnyFlatSpec with Matchers wit
     ) shouldBe List("file.csv")
     execute(
       regex = "file.*\\.csv",
-      existingFiles = Seq("file.csv", "file1.csv", "File1.csv", "files.csv", "subdir/file.csv"),
+      existingFiles = Seq("file.csv", "file1.csv", "other.csv", "files.csv", "subdir/file.csv"),
       entityOutput = true
-    ) shouldBe List("File1.csv", "subdir/file.csv")
+    ) shouldBe List("other.csv", "subdir/file.csv")
   }
 
   it should "remove files based on a regex in sub-directories" in {
     execute(
       regex = "subdir.*",
-      existingFiles = Seq("another", "subdir/file.csv", "subdir/file1.csv", "subdir/File1.csv", "subdir/files.csv", "subdirFile.csv", "this"),
+      existingFiles = Seq("another", "subdir/file.csv", "subdir/file1.csv", "subdir/other.csv", "subdir/files.csv", "subdirFile.csv", "this"),
       entityOutput = true
     ) shouldBe List("another", "this")
     // The regex needs to match the full path
     execute(
       regex = "subdir",
-      existingFiles = Seq("another", "subdir/file.csv", "subdir/file1.csv", "subdir/File1.csv", "subdir/files.csv", "subdirFile.csv", "this"),
+      existingFiles = Seq("another", "subdir/file.csv", "subdir/file1.csv", "subdir/other.csv", "subdir/files.csv", "subdirFile.csv", "this"),
       entityOutput = true
-    ) shouldBe List("another", "subdir/File1.csv", "subdir/file.csv", "subdir/file1.csv", "subdir/files.csv", "subdirFile.csv", "this")
+    ) shouldBe List("another", "subdir/file.csv", "subdir/file1.csv", "subdir/files.csv", "subdir/other.csv", "subdirFile.csv", "this")
   }
 
   /** Returns the still existing files after the operator gets executed sorted. */

--- a/silk-plugins/silk-plugins-json/src/main/resources/org/silkframework/plugins/dataset/json/JsonParserTaskDocumentation.md
+++ b/silk-plugins/silk-plugins-json/src/main/resources/org/silkframework/plugins/dataset/json/JsonParserTaskDocumentation.md
@@ -1,0 +1,81 @@
+## Parse JSON
+
+Parse JSON is a workflow operator that extracts structured data from a JSON string carried as a field value by an
+incoming entity. It sits inside a pipeline between an upstream source and a downstream consumer — typically a
+transformation — and turns the JSON content into entities ready for further processing.
+
+The operator is useful whenever JSON arrives not as a file but as a string stored in a field: the result of an HTTP
+request, a column in a database record, a payload embedded in another dataset. Rather than requiring that content to be
+written to a temporary file and read back through a dataset, Parse JSON handles it directly in the pipeline.
+
+## Input
+
+Parse JSON accepts exactly one input operator. From that input it reads only the first entity — all subsequent entities
+in the input stream are ignored. The operator extracts the JSON string from a field on that entity, parses it, and
+produces output entities from its contents.
+
+Which field is used as the JSON source is controlled by the *Input path* parameter. When set, Parse JSON looks for the
+JSON string at the given path expression. When left empty, it reads the value of the first available field. If no value
+is found at the expected location, or if the field is empty, the operator raises an error and stops.
+
+## Output
+
+The output of Parse JSON is a set of entities extracted from the parsed JSON structure. These entities are shaped by
+three parameters: *Base path*, *URI suffix pattern*, and *Navigate into arrays*.
+
+**Base path** determines the starting point within the JSON document. When set to a path such as */Persons/Person*, only
+elements found at that location are read as entities; everything else in the document is ignored. When left empty, all
+direct children of the root element are read.
+
+**URI suffix pattern** controls how the URIs of the output entities are constructed. The pattern is evaluated relative
+to the URI of the input entity: whatever suffix is specified gets appended to that URI. For example, a pattern of
+*/{id}* applied to an input entity with URI *http://example.org/record/42* would produce output entity URIs like
+*http://example.org/record/42/value-of-id*. When left empty, URIs are generated automatically.
+
+**Navigate into arrays** controls how JSON arrays are handled during path traversal. In JSON, an array is an anonymous
+container with no name of its own — just a list of items. When a path expression crosses an array mid-way, it is
+ambiguous whether the array itself or its contents is the intended target. This parameter resolves that ambiguity. When
+enabled — the default — the operator descends into arrays automatically, so a path like */Persons/Person* reaches the
+Person elements directly even if Persons is an array. When disabled, the array is treated as an explicit step in the
+path: to reach the same Person elements, the path must be written as */Persons/#array/Person*.
+
+The full path model of the JSON dataset applies in Parse JSON without restriction. This covers forward paths into nested
+objects, the wildcard for selecting all direct children, the double wildcard for all descendants at any depth, the
+backward path for navigating to the parent element, and special paths for generating hash-based identifiers, reading the
+string representation of a node, retrieving the current key name, and accessing array elements explicitly.
+
+## Schema
+
+Before producing output entities, Parse JSON needs to know which fields to extract. This schema comes from one of two
+places.
+
+In the normal case, a downstream operator — typically a transformation — specifies the fields it expects. Parse JSON
+receives this schema as part of the execution pipeline and uses it directly to extract the right values from the parsed
+JSON.
+
+When no schema is specified by a downstream operator, Parse JSON infers one. It does this by inspecting the JSON content
+of the first input entity and collecting all paths present in the document. The inferred schema covers every field
+reachable from the configured base path. This inference happens automatically and requires no configuration.
+
+## Example
+
+Consider an upstream operator that produces a single entity carrying the following JSON string in its first field.
+Because *Input path* is not set, Parse JSON reads from that first field by default.
+
+```json
+{
+  "response": {
+    "persons": [
+      { "id": "1", "name": "Alice", "city": "Berlin" },
+      { "id": "2", "name": "Bob", "city": "London" }
+    ]
+  }
+}
+```
+
+With *Base path* set to */response/persons*, Parse JSON navigates past the response wrapper and reads each element of
+the persons array as a separate entity. The array is crossed automatically because *Navigate into arrays* is enabled.
+With *URI suffix pattern* set to */{id}*, the two output entities receive URIs constructed by appending the value of
+their id field to the URI of the input entity.
+
+The result is two entities — one for Alice, one for Bob — each carrying id, name, and city as fields.

--- a/silk-plugins/silk-plugins-json/src/main/resources/org/silkframework/plugins/dataset/json/JsonParserTaskDocumentation.md
+++ b/silk-plugins/silk-plugins-json/src/main/resources/org/silkframework/plugins/dataset/json/JsonParserTaskDocumentation.md
@@ -1,18 +1,18 @@
 ## Parse JSON
 
-Parse JSON is a workflow operator that extracts structured data from a JSON string carried as a field value by an
-incoming entity. It sits inside a pipeline between an upstream source and a downstream consumer — typically a
+Parse JSON is a workflow operator that extracts structured data from a JSON string carried as a field value by
+incoming entities. It sits inside a pipeline between an upstream source and a downstream consumer — typically a
 transformation — and turns the JSON content into entities ready for further processing.
 
 The operator is useful whenever JSON arrives not as a file but as a string stored in a field: the result of an HTTP
-request, a column in a database record, a payload embedded in another dataset. Rather than requiring that content to be
-written to a temporary file and read back through a dataset, Parse JSON handles it directly in the pipeline.
+request, a column in a database record, a payload embedded in another dataset. Parse JSON consumes that string in place
+and produces entities for the rest of the pipeline.
 
 ## Input
 
-Parse JSON accepts exactly one input operator. From that input it reads only the first entity — all subsequent entities
-in the input stream are ignored. The operator extracts the JSON string from a field on that entity, parses it, and
-produces output entities from its contents.
+Parse JSON accepts exactly one input. It iterates over every entity in that input, extracts the JSON string from a
+field on each entity, parses it, and produces output entities from its contents. The output entities from all input
+entities are concatenated into a single stream for the downstream consumer.
 
 Which field is used as the JSON source is controlled by the *Input path* parameter. When set, Parse JSON looks for the
 JSON string at the given path expression. When left empty, it reads the value of the first available field. If no value
@@ -46,13 +46,16 @@ string representation of a node, retrieving the current key name, and accessing 
 
 ## Schema
 
-Before producing output entities, Parse JSON needs to know which fields to extract. This schema is always supplied by a
-downstream operator — typically a transformation — that declares the fields it expects. Parse JSON receives that schema
-as part of the execution pipeline and uses it directly to extract values from the parsed JSON.
+Before producing output entities, Parse JSON needs to know which fields to extract. The set of fields — the output
+schema — is requested by the downstream consumer and reaches Parse JSON before any parsing happens. Parse JSON walks
+the parsed JSON once per requested field, evaluates the field's path expression against the configured base path, and
+writes the resulting values onto the output entity. When the consumer requests a multi-entity schema, Parse JSON
+produces the root entities and the nested sub-entity tables in a single pass. In practice that consumer is a
+transformation.
 
-Parse JSON cannot be connected directly to a dataset. A dataset does not declare an input schema, so there would be
-nothing to tell Parse JSON which fields to read. Workflows that wire Parse JSON straight into a dataset will fail with
-an explicit error at execution time.
+Parse JSON cannot be connected directly to a dataset. A dataset declares no fields to read, so Parse JSON has nothing
+to extract. Workflows that wire Parse JSON straight into a dataset fail at execution time with an error stating that
+the operator cannot be connected directly to a dataset and must feed an operator that declares a target schema.
 
 ## Example
 

--- a/silk-plugins/silk-plugins-json/src/main/resources/org/silkframework/plugins/dataset/json/JsonParserTaskDocumentation.md
+++ b/silk-plugins/silk-plugins-json/src/main/resources/org/silkframework/plugins/dataset/json/JsonParserTaskDocumentation.md
@@ -46,16 +46,13 @@ string representation of a node, retrieving the current key name, and accessing 
 
 ## Schema
 
-Before producing output entities, Parse JSON needs to know which fields to extract. This schema comes from one of two
-places.
+Before producing output entities, Parse JSON needs to know which fields to extract. This schema is always supplied by a
+downstream operator — typically a transformation — that declares the fields it expects. Parse JSON receives that schema
+as part of the execution pipeline and uses it directly to extract values from the parsed JSON.
 
-In the normal case, a downstream operator — typically a transformation — specifies the fields it expects. Parse JSON
-receives this schema as part of the execution pipeline and uses it directly to extract the right values from the parsed
-JSON.
-
-When no schema is specified by a downstream operator, Parse JSON infers one. It does this by inspecting the JSON content
-of the first input entity and collecting all paths present in the document. The inferred schema covers every field
-reachable from the configured base path. This inference happens automatically and requires no configuration.
+Parse JSON cannot be connected directly to a dataset. A dataset does not declare an input schema, so there would be
+nothing to tell Parse JSON which fields to read. Workflows that wire Parse JSON straight into a dataset will fail with
+an explicit error at execution time.
 
 ## Example
 

--- a/silk-plugins/silk-plugins-json/src/main/resources/org/silkframework/plugins/dataset/json/JsonParserTaskDocumentation.md
+++ b/silk-plugins/silk-plugins-json/src/main/resources/org/silkframework/plugins/dataset/json/JsonParserTaskDocumentation.md
@@ -29,8 +29,9 @@ direct children of the root element are read.
 
 **URI suffix pattern** controls how the URIs of the output entities are constructed. The pattern is evaluated relative
 to the URI of the input entity: whatever suffix is specified gets appended to that URI. For example, a pattern of
-*/{id}* applied to an input entity with URI *http://example.org/record/42* would produce output entity URIs like
-*http://example.org/record/42/value-of-id*. When left empty, URIs are generated automatically.
+*/{id}* applied to an input entity with URI *http://example.org/record/42* produces URIs by appending the value of the
+*id* field — so an entity whose *id* is *7* receives URI *http://example.org/record/42/7*. When left empty, URIs are
+generated automatically.
 
 **Navigate into arrays** controls how JSON arrays are handled during path traversal. In JSON, an array is an anonymous
 container with no name of its own — just a list of items. When a path expression crosses an array mid-way, it is
@@ -47,10 +48,10 @@ string representation of a node, retrieving the current key name, and accessing 
 ## Schema
 
 Before producing output entities, Parse JSON needs to know which fields to extract. The set of fields — the output
-schema — is requested by the downstream consumer and reaches Parse JSON before any parsing happens. Parse JSON walks
-the parsed JSON once per requested field, evaluates the field's path expression against the configured base path, and
-writes the resulting values onto the output entity. When the consumer requests a multi-entity schema, Parse JSON
-produces the root entities and the nested sub-entity tables in a single pass. In practice that consumer is a
+schema — is requested by the downstream consumer and reaches Parse JSON before any parsing happens. For each
+requested field, Parse JSON evaluates its path expression against the parsed JSON, starting from the configured base
+path, and writes the resulting values onto the output entity. When the consumer requests a multi-entity schema, Parse
+JSON produces the root entities and the nested sub-entity tables in a single pass. In practice that consumer is a
 transformation.
 
 Parse JSON cannot be connected directly to a dataset. A dataset declares no fields to read, so Parse JSON has nothing
@@ -79,3 +80,6 @@ With *URI suffix pattern* set to */{id}*, the two output entities receive URIs c
 their id field to the URI of the input entity.
 
 The result is two entities — one for Alice, one for Bob — each carrying id, name, and city as fields.
+
+If the upstream operator produces several entities, Parse JSON parses the JSON string carried by each one in turn and
+concatenates the resulting entities into a single output stream.

--- a/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/JsonDataset.scala
+++ b/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/JsonDataset.scala
@@ -6,7 +6,7 @@ import org.silkframework.dataset.bulk.TextBulkResourceBasedDataset
 import org.silkframework.plugins.dataset.hierarchical.HierarchicalSink.DEFAULT_MAX_SIZE
 import org.silkframework.plugins.dataset.json.JsonDataset.specialPaths.ALL_CHILDREN_RECURSIVE
 import org.silkframework.runtime.activity.UserContext
-import org.silkframework.runtime.plugin.annotations.{Param, Plugin}
+import org.silkframework.runtime.plugin.annotations.{Param, Plugin, PluginReference}
 import org.silkframework.runtime.plugin.types.JsonCodeParameter
 import org.silkframework.runtime.resource.{Resource, WritableResource}
 import org.silkframework.util.Identifier
@@ -15,11 +15,17 @@ import java.nio.charset.StandardCharsets
 import scala.io.Codec
 
 @Plugin(
-  id = "json",
+  id = JsonDataset.pluginId,
   label = "JSON",
   categories = Array(DatasetCategories.file),
   description = """Read from or write to a JSON or JSON Lines file.""",
-  documentationFile = "JsonDatasetDocumentation.md"
+  documentationFile = "JsonDatasetDocumentation.md",
+  relatedPlugins = Array(
+    new PluginReference(
+      id = JsonParserTask.pluginId,
+      description = "The JSON dataset is a pipeline source: it opens a file and needs no upstream input. Parse JSON is an operator: it reads a JSON string from a field value supplied by an upstream entity."
+    )
+  )
 )
 case class JsonDataset(@Param("JSON file. This may also be a zip archive of multiple JSON files that share the same schema.")
                        file: WritableResource,
@@ -65,6 +71,8 @@ case class JsonDataset(@Param("JSON file. This may also be a zip archive of mult
 }
 
 object JsonDataset {
+
+  final val pluginId = "json"
 
   final val defaultZipFileRegex = """^(?!.*[\/\\]\..*$|^\..*$).*\.jsonl?$"""
 

--- a/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/JsonParserTask.scala
+++ b/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/JsonParserTask.scala
@@ -10,6 +10,7 @@ import org.silkframework.util.Uri
   id = JsonParserTask.pluginId,
   label = "Parse JSON",
   description = "Parses an incoming entity as a JSON dataset. Typically, it is used before a transformation task. Takes exactly one input of which only the first entity is processed.",
+  documentationFile = "JsonParserTaskDocumentation.md",
   relatedPlugins = Array(
     new PluginReference(
       id = JsonDataset.pluginId,

--- a/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/JsonParserTask.scala
+++ b/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/JsonParserTask.scala
@@ -3,13 +3,19 @@ package org.silkframework.plugins.dataset.json
 import org.silkframework.config.{CustomTask, FixedNumberOfInputs, FixedSchemaPort, FlexibleSchemaPort, InputPorts, Port}
 import org.silkframework.entity.paths.UntypedPath
 import org.silkframework.entity.EntitySchema
-import org.silkframework.runtime.plugin.annotations.{Param, Plugin}
+import org.silkframework.runtime.plugin.annotations.{Param, Plugin, PluginReference}
 import org.silkframework.util.Uri
 
 @Plugin(
-  id = "JsonParserOperator",
+  id = JsonParserTask.pluginId,
   label = "Parse JSON",
-  description = "Parses an incoming entity as a JSON dataset. Typically, it is used before a transformation task. Takes exactly one input of which only the first entity is processed."
+  description = "Parses an incoming entity as a JSON dataset. Typically, it is used before a transformation task. Takes exactly one input of which only the first entity is processed.",
+  relatedPlugins = Array(
+    new PluginReference(
+      id = JsonDataset.pluginId,
+      description = "Parse JSON and the JSON dataset share path syntax but not a content source: Parse JSON reads from a field value in an incoming entity, the JSON dataset from a file resource it opens directly."
+    )
+  )
 )
 case class JsonParserTask(@Param("The Silk path expression of the input entity that contains the JSON document. If " +
     "not set, the value of the first defined property will be taken.")
@@ -57,4 +63,8 @@ case class JsonParserTask(@Param("The Silk path expression of the input entity t
   override def outputPort: Option[Port] = {
     Some(FlexibleSchemaPort())
   }
+}
+
+object JsonParserTask {
+  final val pluginId = "JsonParserOperator"
 }

--- a/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/JsonParserTask.scala
+++ b/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/JsonParserTask.scala
@@ -9,7 +9,7 @@ import org.silkframework.util.Uri
 @Plugin(
   id = JsonParserTask.pluginId,
   label = "Parse JSON",
-  description = "Parses an incoming entity as a JSON dataset. Typically, it is used before a transformation task. Takes exactly one input of which only the first entity is processed.",
+  description = "Parses a JSON string carried as a field value on each incoming entity. Typically used before a transformation task. Takes exactly one input.",
   documentationFile = "JsonParserTaskDocumentation.md",
   relatedPlugins = Array(
     new PluginReference(

--- a/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/LocalJsonParserTaskExecutor.scala
+++ b/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/LocalJsonParserTaskExecutor.scala
@@ -3,12 +3,14 @@ package org.silkframework.plugins.dataset.json
 import org.silkframework.config.{FixedSchemaPort, PlainTask, Prefixes, Task, TaskSpec}
 import org.silkframework.dataset.DatasetSpec
 import org.silkframework.entity.{Entity, EntitySchema, MultiEntitySchema}
+import org.silkframework.entity.paths.{ForwardOperator, UntypedPath}
 import org.silkframework.execution._
 import org.silkframework.execution.local._
 import org.silkframework.runtime.activity.{ActivityContext, ActivityMonitor}
 import org.silkframework.runtime.iterator.{CloseableIterator, RepeatedIterator, RewindableEntityIterator}
 import org.silkframework.runtime.plugin.PluginContext
 import org.silkframework.runtime.resource.InMemoryResourceManager
+import org.silkframework.util.Uri
 
 
 /**
@@ -23,41 +25,79 @@ case class LocalJsonParserTaskExecutor() extends LocalExecutor[JsonParserTask] {
                        execution: LocalExecution,
                        context: ActivityContext[ExecutionReport] = new ActivityMonitor(getClass.getSimpleName))
                       (implicit pluginContext: PluginContext): Option[LocalEntities] = {
-    if (inputs.size != 1) {
-      throw TaskException("JsonParserTask takes exactly one input!")
+    if (inputs.size != 1) throw TaskException("JsonParserTask takes exactly one input!")
+    val entityTable = inputs.head
+    val entities = RewindableEntityIterator.load(entityTable.entities, entityTable.entitySchema)
+
+    val pathIndex = task.data.parsedInputPath match {
+      case Some(path) => entityTable.entitySchema.indexOfPath(path)
+      case None => 0 // Take the value of the first path
     }
-    output.requestedSchema.map { requestedSchema =>
-      val entityTable = inputs.head
-      val entities = RewindableEntityIterator.load(entityTable.entities, entityTable.entitySchema)
 
-      val pathIndex =  task.data.parsedInputPath match {
-        case Some(path) => entityTable.entitySchema.indexOfPath(path)
-        case None => 0 // Take the value of the first path
-      }
+    output.requestedSchema
+      .orElse(output.task.flatMap(_ => inferSchema(task, entities.newIterator(), pathIndex)))
+      .map(executeWithSchema(task, _, entities, output, execution, context, pathIndex))
+  }
 
-      if(!entities.hasNext) {
-        throw TaskException("No input entity for 'JSON Parser Operator' found! There must be at least one entity in the input.")
-      }
+  /** Runs the parse once a schema is known, dispatching on single vs. multi-entity schema. */
+  private def executeWithSchema(task: Task[JsonParserTask],
+                                requestedSchema: EntitySchema,
+                                entities: RewindableEntityIterator,
+                                output: ExecutorOutput,
+                                execution: LocalExecution,
+                                context: ActivityContext[ExecutionReport],
+                                pathIndex: Int)
+                               (implicit pluginContext: PluginContext): LocalEntities = {
+    if (!entities.hasNext) throw TaskException("No input entity for 'JSON Parser Operator' found! There must be at least one entity in the input.")
+    requestedSchema match {
+      case mt: MultiEntitySchema =>
+        val rootEntities = entityIterator(requestedSchema, entities, task, output, execution, context, pathIndex)
+        val subEntities = mt.subSchemata.map { subSchema =>
+          GenericEntityTable(entityIterator(subSchema, entities, task, output, execution, context, pathIndex, createNewIterator = true), subSchema, task)
+        }
+        MultiEntityTable(rootEntities, requestedSchema, task, subEntities)
+      case _ =>
+        GenericEntityTable(entityIterator(requestedSchema, entities, task, output, execution, context, pathIndex), requestedSchema, task)
+    }
+  }
 
-      def parseEntities(schema: EntitySchema, createNewIterator: Boolean = false): CloseableIterator[Entity] = {
-        val entityParser = new EntityParser(task, ExecutorOutput(output.task, Some(FixedSchemaPort(schema))), execution, pathIndex)
-        val entityIterator = if(createNewIterator) entities.newIterator() else entities
-        implicit val reportUpdater: ExecutionReportUpdater = JsonParserReportUpdater(task, context)
-        implicit val prefixes: Prefixes = Prefixes.empty
-        ReportingIterator(new RepeatedIterator(() => entityIterator.nextOption().map(entityParser)).thenClose(entityIterator))
-      }
-
-      requestedSchema match {
-        case mt: MultiEntitySchema =>
-          val rootEntities = parseEntities(requestedSchema)
-          val subEntities = mt.subSchemata.map { subSchema =>
-            GenericEntityTable(parseEntities(subSchema, createNewIterator = true), subSchema, task)
-          }
-          MultiEntityTable(rootEntities, requestedSchema, task, subEntities)
-        case _ =>
-          GenericEntityTable(parseEntities(requestedSchema), requestedSchema, task)
+  /** Infers an entity schema from the JSON content of the first input entity when no schema is prescribed downstream. */
+  private def inferSchema(task: Task[JsonParserTask],
+                          iterator: CloseableIterator[Entity],
+                          pathIndex: Int): Option[EntitySchema] = {
+    iterator.nextOption().flatMap { entity =>
+      entity.values.lift(pathIndex).flatMap(_.headOption).map { jsonString =>
+        val jsonSource = JsonSourceInMemory.fromString(
+          taskId = task.id,
+          str = jsonString,
+          basePath = task.data.basePath,
+          uriPattern = "",
+          navigateIntoArrays = task.data.navigateIntoArrays
+        )
+        val typedPaths = jsonSource.collectPaths(limit = Int.MaxValue)
+          .filter(_.nonEmpty)
+          .map(segments => UntypedPath(segments.map(seg => ForwardOperator(Uri(seg)))).asStringTypedPath)
+          .toIndexedSeq
+        EntitySchema("", typedPaths)
       }
     }
+  }
+
+  /** Parses entities for one schema and wraps the result in a reporting iterator. */
+  private def entityIterator(schema: EntitySchema,
+                            entities: RewindableEntityIterator,
+                            task: Task[JsonParserTask],
+                            output: ExecutorOutput,
+                            execution: LocalExecution,
+                            context: ActivityContext[ExecutionReport],
+                            pathIndex: Int,
+                            createNewIterator: Boolean = false)
+                           (implicit pluginContext: PluginContext): CloseableIterator[Entity] = {
+    val entityParser = new EntityParser(task, ExecutorOutput(output.task, Some(FixedSchemaPort(schema))), execution, pathIndex)
+    val entityIterator = if (createNewIterator) entities.newIterator() else entities
+    implicit val reportUpdater: ExecutionReportUpdater = JsonParserReportUpdater(task, context)
+    implicit val prefixes: Prefixes = Prefixes.empty
+    ReportingIterator(new RepeatedIterator(() => entityIterator.nextOption().map(entityParser)).thenClose(entityIterator))
   }
 
   /**

--- a/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/LocalJsonParserTaskExecutor.scala
+++ b/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/LocalJsonParserTaskExecutor.scala
@@ -12,8 +12,9 @@ import org.silkframework.runtime.resource.InMemoryResourceManager
 
 
 /**
-  * Only considers the first input and checks for the property path defined in the [[JsonParserTask]] specification.
-  * It will only read a property value of the first entity, following entities are ignored.
+  * Executor for [[JsonParserTask]]. Takes a single input table and iterates over every entity in it, reading the
+  * JSON string at the configured input path on each and parsing it according to the schema requested by the
+  * downstream consumer.
   */
 case class LocalJsonParserTaskExecutor() extends LocalExecutor[JsonParserTask] {
 

--- a/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/LocalJsonParserTaskExecutor.scala
+++ b/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/LocalJsonParserTaskExecutor.scala
@@ -3,14 +3,12 @@ package org.silkframework.plugins.dataset.json
 import org.silkframework.config.{FixedSchemaPort, PlainTask, Prefixes, Task, TaskSpec}
 import org.silkframework.dataset.DatasetSpec
 import org.silkframework.entity.{Entity, EntitySchema, MultiEntitySchema}
-import org.silkframework.entity.paths.{ForwardOperator, UntypedPath}
 import org.silkframework.execution._
 import org.silkframework.execution.local._
 import org.silkframework.runtime.activity.{ActivityContext, ActivityMonitor}
 import org.silkframework.runtime.iterator.{CloseableIterator, RepeatedIterator, RewindableEntityIterator}
 import org.silkframework.runtime.plugin.PluginContext
 import org.silkframework.runtime.resource.InMemoryResourceManager
-import org.silkframework.util.Uri
 
 
 /**
@@ -34,9 +32,10 @@ case class LocalJsonParserTaskExecutor() extends LocalExecutor[JsonParserTask] {
       case None => 0 // Take the value of the first path
     }
 
-    output.requestedSchema
-      .orElse(output.task.flatMap(_ => inferSchema(task, entities.newIterator(), pathIndex)))
-      .map(executeWithSchema(task, _, entities, output, execution, context, pathIndex))
+    val schema = output.requestedSchema.getOrElse(
+      throw TaskException("The Parse JSON operator cannot be connected directly to a dataset. It must feed an operator (typically a transformation) that declares a target schema, since Parse JSON's output schema depends on what the consumer requests.")
+    )
+    Some(executeWithSchema(task, schema, entities, output, execution, context, pathIndex))
   }
 
   /** Runs the parse once a schema is known, dispatching on single vs. multi-entity schema. */
@@ -58,28 +57,6 @@ case class LocalJsonParserTaskExecutor() extends LocalExecutor[JsonParserTask] {
         MultiEntityTable(rootEntities, requestedSchema, task, subEntities)
       case _ =>
         GenericEntityTable(entityIterator(requestedSchema, entities, task, output, execution, context, pathIndex), requestedSchema, task)
-    }
-  }
-
-  /** Infers an entity schema from the JSON content of the first input entity when no schema is prescribed downstream. */
-  private def inferSchema(task: Task[JsonParserTask],
-                          iterator: CloseableIterator[Entity],
-                          pathIndex: Int): Option[EntitySchema] = {
-    iterator.nextOption().flatMap { entity =>
-      entity.values.lift(pathIndex).flatMap(_.headOption).map { jsonString =>
-        val jsonSource = JsonSourceInMemory.fromString(
-          taskId = task.id,
-          str = jsonString,
-          basePath = task.data.basePath,
-          uriPattern = "",
-          navigateIntoArrays = task.data.navigateIntoArrays
-        )
-        val typedPaths = jsonSource.collectPaths(limit = Int.MaxValue)
-          .filter(_.nonEmpty)
-          .map(segments => UntypedPath(segments.map(seg => ForwardOperator(Uri(seg)))).asStringTypedPath)
-          .toIndexedSeq
-        EntitySchema("", typedPaths)
-      }
     }
   }
 

--- a/silk-plugins/silk-plugins-json/src/test/scala/org/silkframework/plugins/dataset/json/LocalJsonParserTaskExecutorTest.scala
+++ b/silk-plugins/silk-plugins-json/src/test/scala/org/silkframework/plugins/dataset/json/LocalJsonParserTaskExecutorTest.scala
@@ -91,8 +91,6 @@ class LocalJsonParserTaskExecutorTest extends AnyFlatSpec with Matchers with Moc
     val execution = LocalExecution(useLocalInternalDatasets = false)
     val result = executor.execute(task, inputs, output, execution)
 
-    // Currently FAILS — executor returns None because FlexibleSchemaPort.schemaOpt = None
-    // After fix — returns Some(...) with the parsed entities
     result mustBe defined
   }
 

--- a/silk-plugins/silk-plugins-json/src/test/scala/org/silkframework/plugins/dataset/json/LocalJsonParserTaskExecutorTest.scala
+++ b/silk-plugins/silk-plugins-json/src/test/scala/org/silkframework/plugins/dataset/json/LocalJsonParserTaskExecutorTest.scala
@@ -1,7 +1,9 @@
 package org.silkframework.plugins.dataset.json
 
 
-import org.silkframework.config.{FixedSchemaPort, PlainTask, Prefixes}
+import org.silkframework.config.{FixedSchemaPort, FlexibleSchemaPort, PlainTask, Prefixes}
+import org.silkframework.dataset.DatasetSpec
+import org.silkframework.runtime.resource.InMemoryResourceManager
 import org.silkframework.entity.paths.UntypedPath
 import org.silkframework.entity.{Entity, EntitySchema, MultiEntitySchema}
 import org.silkframework.execution.{ExecutorOutput, ExecutorRegistry}
@@ -77,6 +79,21 @@ class LocalJsonParserTaskExecutorTest extends AnyFlatSpec with Matchers with Moc
     result mustBe defined
     val values = result.get.entities.flatMap(_.values).flatten.toSeq
     values mustBe Seq("1", "1")
+  }
+
+  it should "produce entities when the downstream port is a FlexibleSchemaPort" in {
+    // InMemoryResourceManager.get() creates the resource object even if no content has been written yet
+    val outputResource = InMemoryResourceManager().get("output.json")
+    val downstreamTask = PlainTask("outputDataset", DatasetSpec(JsonDataset(outputResource)))
+
+    val output = ExecutorOutput(Some(downstreamTask), Some(FlexibleSchemaPort()))
+    val inputs = Seq(inputEntities)
+    val execution = LocalExecution(useLocalInternalDatasets = false)
+    val result = executor.execute(task, inputs, output, execution)
+
+    // Currently FAILS — executor returns None because FlexibleSchemaPort.schemaOpt = None
+    // After fix — returns Some(...) with the parsed entities
+    result mustBe defined
   }
 
   it should "parse the JSON of multiple entities" in {

--- a/silk-plugins/silk-plugins-json/src/test/scala/org/silkframework/plugins/dataset/json/LocalJsonParserTaskExecutorTest.scala
+++ b/silk-plugins/silk-plugins-json/src/test/scala/org/silkframework/plugins/dataset/json/LocalJsonParserTaskExecutorTest.scala
@@ -92,6 +92,7 @@ class LocalJsonParserTaskExecutorTest extends AnyFlatSpec with Matchers with Moc
     val result = executor.execute(task, inputs, output, execution)
 
     result mustBe defined
+    result.get.entities.flatMap(_.values).flatten.toSeq mustBe Seq("0", "John", "1", "Max")
   }
 
   it should "parse the JSON of multiple entities" in {

--- a/silk-plugins/silk-plugins-json/src/test/scala/org/silkframework/plugins/dataset/json/LocalJsonParserTaskExecutorTest.scala
+++ b/silk-plugins/silk-plugins-json/src/test/scala/org/silkframework/plugins/dataset/json/LocalJsonParserTaskExecutorTest.scala
@@ -97,6 +97,27 @@ class LocalJsonParserTaskExecutorTest extends AnyFlatSpec with Matchers with Moc
     ex.getMessage must include ("schema")
   }
 
+  it should "throw a TaskException when no requested schema and no downstream task are present" in {
+    val ex = intercept[TaskException] {
+      executor.execute(task, Seq(inputEntities), ExecutorOutput.empty, LocalExecution(useLocalInternalDatasets = false))
+    }
+    ex.getMessage must include ("Parse JSON")
+    ex.getMessage must include ("schema")
+  }
+
+  it should "throw a TaskException for FlexibleSchemaPort even when the input entity stream is empty" in {
+    val outputResource = InMemoryResourceManager().get("output.json")
+    val downstreamTask = PlainTask("outputDataset", DatasetSpec(JsonDataset(outputResource)))
+    val emptyInput = GenericEntityTable(CloseableIterator.empty, entitySchema, task)
+
+    val output = ExecutorOutput(Some(downstreamTask), Some(FlexibleSchemaPort()))
+    val ex = intercept[TaskException] {
+      executor.execute(task, Seq(emptyInput), output, LocalExecution(useLocalInternalDatasets = false))
+    }
+    ex.getMessage must include ("Parse JSON")
+    ex.getMessage must include ("schema")
+  }
+
   it should "parse the JSON of multiple entities" in {
     def jsonContent(id: Int): String =
       s"""{

--- a/silk-plugins/silk-plugins-json/src/test/scala/org/silkframework/plugins/dataset/json/LocalJsonParserTaskExecutorTest.scala
+++ b/silk-plugins/silk-plugins-json/src/test/scala/org/silkframework/plugins/dataset/json/LocalJsonParserTaskExecutorTest.scala
@@ -6,7 +6,7 @@ import org.silkframework.dataset.DatasetSpec
 import org.silkframework.runtime.resource.InMemoryResourceManager
 import org.silkframework.entity.paths.UntypedPath
 import org.silkframework.entity.{Entity, EntitySchema, MultiEntitySchema}
-import org.silkframework.execution.{ExecutorOutput, ExecutorRegistry}
+import org.silkframework.execution.{ExecutorOutput, ExecutorRegistry, TaskException}
 import org.silkframework.execution.local.{GenericEntityTable, GenericLocalDatasetExecutor, LocalExecution, MultiEntityTable}
 import org.silkframework.runtime.activity.TestUserContextTrait
 import org.silkframework.runtime.plugin.{PluginContext, PluginRegistry}
@@ -81,7 +81,7 @@ class LocalJsonParserTaskExecutorTest extends AnyFlatSpec with Matchers with Moc
     values mustBe Seq("1", "1")
   }
 
-  it should "produce entities when the downstream port is a FlexibleSchemaPort" in {
+  it should "throw a TaskException when wired directly to a dataset (FlexibleSchemaPort)" in {
     // InMemoryResourceManager.get() creates the resource object even if no content has been written yet
     val outputResource = InMemoryResourceManager().get("output.json")
     val downstreamTask = PlainTask("outputDataset", DatasetSpec(JsonDataset(outputResource)))
@@ -89,10 +89,12 @@ class LocalJsonParserTaskExecutorTest extends AnyFlatSpec with Matchers with Moc
     val output = ExecutorOutput(Some(downstreamTask), Some(FlexibleSchemaPort()))
     val inputs = Seq(inputEntities)
     val execution = LocalExecution(useLocalInternalDatasets = false)
-    val result = executor.execute(task, inputs, output, execution)
 
-    result mustBe defined
-    result.get.entities.flatMap(_.values).flatten.toSeq mustBe Seq("0", "John", "1", "Max")
+    val ex = intercept[TaskException] {
+      executor.execute(task, inputs, output, execution)
+    }
+    ex.getMessage must include ("Parse JSON")
+    ex.getMessage must include ("schema")
   }
 
   it should "parse the JSON of multiple entities" in {

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/activity/workflow/LocalJsonParserWorkflowTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/activity/workflow/LocalJsonParserWorkflowTest.scala
@@ -1,0 +1,111 @@
+package org.silkframework.workspace.activity.workflow
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.silkframework.config.{MetaData, Prefixes}
+import org.silkframework.dataset.DatasetSpec
+import org.silkframework.runtime.activity.UserContext
+import org.silkframework.runtime.plugin.PluginContext
+import org.silkframework.runtime.resource.InMemoryResourceManager
+import org.silkframework.util.ConfigTestTrait
+import org.silkframework.workspace.resources.ConstantResourceRepository
+import org.silkframework.workspace.{InMemoryWorkspaceProvider, ProjectConfig, Workspace}
+import org.silkframework.plugins.dataset.json.{JsonDataset, JsonParserTask}
+import play.api.libs.json.{JsString, Json}
+import LocalJsonParserWorkflowTest._
+
+object LocalJsonParserWorkflowTest {
+  val SourceDatasetId = "sourceDataset"
+  val ParseJsonId = "parseJson"
+  val OutputDatasetId = "outputDataset"
+  val WorkflowId = "workflow"
+}
+
+class LocalJsonParserWorkflowTest extends AnyFlatSpec with Matchers with ConfigTestTrait {
+
+  override def propertyMap: Map[String, Option[String]] = Map(
+    "workspace.reportManager.plugin" -> Some("inMemoryExecutionReportManager")
+  )
+
+  behavior of "Parse JSON operator in a workflow"
+
+  implicit val userContext: UserContext = UserContext.Empty
+  implicit val pluginContext: PluginContext = PluginContext.empty
+  implicit val prefixes: Prefixes = Prefixes.empty
+
+  private val inputJson =
+    """{
+      |  "persons": [
+      |    { "name": "John" },
+      |    { "name": "Max" }
+      |  ]
+      |}""".stripMargin
+
+  it should "write parsed entities to a downstream JSON dataset" in {
+    val resources = InMemoryResourceManager()
+
+    // Source: one entity whose "jsonContent" field holds the JSON blob Parse JSON will parse
+    val sourceResource = resources.get("source.json")
+    sourceResource.writeString(s"""[{"jsonContent": ${Json.stringify(JsString(inputJson))}}]""")
+
+    // Output: empty file to be written by the workflow
+    val outputResource = resources.get("output.json")
+
+    val workspace = new Workspace(
+      provider = new InMemoryWorkspaceProvider(),
+      repository = ConstantResourceRepository(resources)
+    )
+    val project = workspace.createProject(ProjectConfig(metaData = MetaData(Some("testProject"))))
+
+    project.addTask(SourceDatasetId, DatasetSpec(JsonDataset(sourceResource)))
+    project.addTask(ParseJsonId, JsonParserTask(inputPath = "jsonContent", basePath = "persons"))
+    project.addTask(OutputDatasetId, DatasetSpec(JsonDataset(outputResource)))
+
+    val sourceNode = WorkflowDataset(
+      inputs = Seq.empty,
+      task = SourceDatasetId,
+      outputs = Seq(ParseJsonId),
+      position = (0, 0),
+      nodeId = SourceDatasetId,
+      outputPriority = None,
+      configInputs = Seq.empty,
+      dependencyInputs = Seq.empty
+    )
+    val parseNode = WorkflowOperator(
+      inputs = Seq(Some(SourceDatasetId)),
+      task = ParseJsonId,
+      outputs = Seq(OutputDatasetId),
+      errorOutputs = Seq.empty,
+      position = (100, 0),
+      nodeId = ParseJsonId,
+      outputPriority = None,
+      configInputs = Seq.empty,
+      dependencyInputs = Seq.empty
+    )
+    val outputNode = WorkflowDataset(
+      inputs = Seq(Some(ParseJsonId)),
+      task = OutputDatasetId,
+      outputs = Seq.empty,
+      position = (200, 0),
+      nodeId = OutputDatasetId,
+      outputPriority = None,
+      configInputs = Seq.empty,
+      dependencyInputs = Seq.empty
+    )
+
+    project.addTask(WorkflowId, Workflow(
+      operators = Seq(parseNode),
+      datasets = Seq(sourceNode, outputNode)
+    ))
+
+    val workflowTask = project.task[Workflow](WorkflowId)
+    workflowTask.activity[LocalWorkflowExecutorGeneratingProvenance].startBlocking()
+
+    // Currently FAILS — nothing written because Parse JSON returns None
+    // After fix — file contains entities with "name" fields
+    outputResource.size shouldBe >(0L)
+
+    val names = (Json.parse(outputResource.loadAsString()) \\ "name").map(_.as[String])
+    names should contain allOf ("John", "Max")
+  }
+}

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/activity/workflow/LocalJsonParserWorkflowTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/activity/workflow/LocalJsonParserWorkflowTest.scala
@@ -101,11 +101,9 @@ class LocalJsonParserWorkflowTest extends AnyFlatSpec with Matchers with ConfigT
     val workflowTask = project.task[Workflow](WorkflowId)
     workflowTask.activity[LocalWorkflowExecutorGeneratingProvenance].startBlocking()
 
-    // Currently FAILS — nothing written because Parse JSON returns None
-    // After fix — file contains entities with "name" fields
-    outputResource.size shouldBe >(0L)
+    outputResource.size.getOrElse(0L) should be > 0L
 
-    val names = (Json.parse(outputResource.loadAsString()) \\ "name").map(_.as[String])
+    val names = (Json.parse(outputResource.loadAsString()) \\ "name").flatMap(_.as[Seq[String]])
     names should contain allOf ("John", "Max")
   }
 }

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/activity/workflow/LocalJsonParserWorkflowTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/activity/workflow/LocalJsonParserWorkflowTest.scala
@@ -14,13 +14,19 @@ import org.silkframework.plugins.dataset.json.{JsonDataset, JsonParserTask}
 import play.api.libs.json.{JsString, Json}
 import LocalJsonParserWorkflowTest._
 
-object LocalJsonParserWorkflowTest {
-  val SourceDatasetId = "sourceDataset"
-  val ParseJsonId = "parseJson"
-  val OutputDatasetId = "outputDataset"
-  val WorkflowId = "workflow"
-}
-
+/**
+ * Integration test for the Parse JSON operator in a workflow context.
+ *
+ * When running from IntelliJ, add the following to the run configuration VM options:
+ *   --add-opens=java.base/java.nio=ALL-UNNAMED
+ *
+ * lmdbjava (the Java binding for LMDB, used by the persistent caching layer initialised
+ * as part of the workspace infrastructure) accesses java.nio.Buffer.address via reflection
+ * to obtain raw memory addresses for direct buffers. Since Java 9 the module system blocks
+ * this by default, causing an InaccessibleObjectException before the test assertions run.
+ * The flag opens the java.nio package to unnamed modules (classpath code), restoring the
+ * access lmdbjava requires. sbt picks this up automatically from build.sbt; IntelliJ does not.
+ */
 class LocalJsonParserWorkflowTest extends AnyFlatSpec with Matchers with ConfigTestTrait {
 
   override def propertyMap: Map[String, Option[String]] = Map(
@@ -106,4 +112,11 @@ class LocalJsonParserWorkflowTest extends AnyFlatSpec with Matchers with ConfigT
     val names = (Json.parse(outputResource.loadAsString()) \\ "name").flatMap(_.as[Seq[String]])
     names should contain allOf ("John", "Max")
   }
+}
+
+object LocalJsonParserWorkflowTest {
+  val SourceDatasetId = "sourceDataset"
+  val ParseJsonId = "parseJson"
+  val OutputDatasetId = "outputDataset"
+  val WorkflowId = "workflow"
 }

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/activity/workflow/LocalJsonParserWorkflowTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/activity/workflow/LocalJsonParserWorkflowTest.scala
@@ -10,6 +10,7 @@ import org.silkframework.runtime.resource.InMemoryResourceManager
 import org.silkframework.util.ConfigTestTrait
 import org.silkframework.workspace.resources.ConstantResourceRepository
 import org.silkframework.workspace.{InMemoryWorkspaceProvider, ProjectConfig, Workspace}
+import org.silkframework.execution.TaskException
 import org.silkframework.plugins.dataset.json.{JsonDataset, JsonParserTask}
 import play.api.libs.json.{JsString, Json}
 import LocalJsonParserWorkflowTest._
@@ -47,7 +48,7 @@ class LocalJsonParserWorkflowTest extends AnyFlatSpec with Matchers with ConfigT
       |  ]
       |}""".stripMargin
 
-  it should "write parsed entities to a downstream JSON dataset" in {
+  it should "fail loudly when Parse JSON feeds a dataset directly" in {
     val resources = InMemoryResourceManager()
 
     // Source: one entity whose "jsonContent" field holds the JSON blob Parse JSON will parse
@@ -105,12 +106,12 @@ class LocalJsonParserWorkflowTest extends AnyFlatSpec with Matchers with ConfigT
     ))
 
     val workflowTask = project.task[Workflow](WorkflowId)
-    workflowTask.activity[LocalWorkflowExecutorGeneratingProvenance].startBlocking()
-
-    outputResource.size.getOrElse(0L) should be > 0L
-
-    val names = (Json.parse(outputResource.loadAsString()) \\ "name").flatMap(_.as[Seq[String]])
-    names should contain allOf ("John", "Max")
+    val ex = intercept[WorkflowExecutionException] {
+      workflowTask.activity[LocalWorkflowExecutorGeneratingProvenance].startBlocking()
+    }
+    ex.getCause shouldBe a [TaskException]
+    ex.getCause.getMessage should include ("Parse JSON")
+    outputResource.size.getOrElse(0L) shouldBe 0L
   }
 }
 


### PR DESCRIPTION
# CMEM-7427: Parse JSON fails when wired directly to a downstream dataset

Fixes Parse JSON silently producing no output when wired to a downstream dataset, adds the user-facing documentation that should have shipped with the operator, and includes a small unrelated test fix.

## Bug

Connecting Parse JSON to a downstream JSON dataset — or any consumer that uses a `FlexibleSchemaPort` — produced no output and no error. The workflow completed cleanly and the output resource was empty. The cause was a missing branch in the executor's schema-resolution path: it handled the case where a downstream operator declared its requested schema, but silently returned `None` when the schema was absent — which is exactly what `FlexibleSchemaPort` reports. The existing unit tests all wired up a `FixedSchemaPort` directly, so none of them ever exercised the flexible case.

## Fix

`LocalJsonParserTaskExecutor.execute` now throws a `TaskException` when the downstream port does not declare a schema. The exception message names the wiring problem in user-facing terms ("The Parse JSON operator cannot be connected directly to a dataset…") so workspace users see a clear failure instead of empty output. The fixed-schema path is unchanged. The `execute` method had grown overloaded along the way, mixing schema dispatch with entity iteration in a way that made the new behaviour hard to slot in cleanly; it was reorganised into two private helpers (`executeWithSchema` and `entityIterator`) to keep the dispatch readable.

## Tests

The bug was pinned down with two failing tests before any production code changed, so the assertions were written against the bug rather than against the resulting code. The first, in `LocalJsonParserTaskExecutorTest`, exercises the executor directly with a `FlexibleSchemaPort` and a downstream task reference — the configuration that `LocalWorkflowExecutor` actually produces when a dataset node is wired downstream — and asserts that a `TaskException` is thrown with a message naming the operator and the missing schema. The second, in `LocalJsonParserWorkflowTest`, builds a three-node workflow in memory (CSV source → Parse JSON → JSON sink), runs it end-to-end, and asserts that the workflow fails with a `WorkflowExecutionException` whose cause is the original `TaskException`, and that the output resource stays empty. Both fail against the broken executor and pass after the fix.

## Further improvements

### Parse JSON documentation

Added user-facing documentation for Parse JSON: what the operator does and how to use it — that it parses a JSON string carried on the first input entity, how the Input path picks the source field, how Base path, URI suffix pattern, and Navigate into arrays shape the output entities, and that the schema must come from a downstream operator since direct-to-dataset wiring fails at execution time. Closes with a small worked example. Wired in via the `documentationFile` attribute on the `@Plugin` annotation.

### Plugin cross-references

Added `relatedPlugins` cross-references between the JSON dataset and Parse JSON: the dataset is a pipeline source that opens a file, Parse JSON is an operator that reads a JSON string from an upstream entity. With descriptions on both plugins, the workbench surfaces the relationship from either side.

### `LocalDeleteFilesOperatorExecutorTest` on case-insensitive filesystems

Fixed an unrelated test failure encountered while running the suite on macOS. The test paired `File1.csv` with `file1.csv` (and the same in a subdir); on APFS or HFS+ each pair resolves to the same file, so the resource manager ended up one file short and the entity-count assertion was off by one. Renamed the colliding fixtures to `other.csv` and `subdir/other.csv`.

---

Task: https://jira.eccenca.com/browse/CMEM-7427