### PR TITLE
CMEM-7596: Add per-value hash operator

### DIFF
--- a/silk-rules/src/main/resources/org/silkframework/rule/plugins/transformer/value/InputHashTransformer.md
+++ b/silk-rules/src/main/resources/org/silkframework/rule/plugins/transformer/value/InputHashTransformer.md
@@ -1,2 +1,29 @@
-Calculates the hash sum of the input values. Generates a single hash sum for all input values combined.
-This operator supports using different hash algorithms from the [Secure Hash Algorithms family](https://en.wikipedia.org/wiki/Secure_Hash_Algorithms) (SHA, e.g. SHA256) and two algorithms from the [Message-Digest Algorithm family](https://en.wikipedia.org/wiki/MD5) (MD2 / MD5). Please be aware that some of these algorithms are not secure due the possibility of collision attacks and other attacks.
+The **Combined input hash** operator produces exactly one hash value covering all input values combined, across all connected input ports. However many values arrive and however many ports are connected, the output is always a single string.
+
+## How combining works
+
+All values from all input ports are fed sequentially into a single hash function — port 1 first, then port 2, and so on. Within each port, values are processed in the order they arrive. No separator is inserted between values or between ports. The hash covers the concatenated byte content of all values in that traversal order.
+
+This means the result depends on both the content and the order of values. The same set of values in a different order produces a different hash. Connecting one port with values `["apple", "banana"]` produces the same hash as connecting two ports with `["apple"]` and `["banana"]` respectively, because the bytes are fed in the same sequence either way.
+
+## Output
+
+The output is a single lowercase hexadecimal string. The length depends on the algorithm: 64 characters for SHA-256, 32 for MD5, 40 for SHA-1, 96 for SHA-384, 128 for SHA-512. If the input is empty, the output is the hash of an empty message.
+
+Values are encoded as UTF-8 before hashing.
+
+## Algorithm parameter
+
+The algorithm parameter selects the hash function. The default is SHA-256. The following algorithms from the [SPARQL 1.1 specification](https://www.w3.org/TR/sparql11-query/#func-hash) are supported:
+
+| SPARQL name | Java name | Notes |
+|-------------|-----------|-------|
+| MD5 | MD5 | Weak — vulnerable to collision attacks. Avoid for security-sensitive use. |
+| SHA1 | SHA-1 | Weak — deprecated for most security purposes. |
+| SHA256 | SHA-256 | Recommended default. |
+| SHA384 | SHA-384 | Stronger than SHA-256. |
+| SHA512 | SHA-512 | Strongest in the SPARQL set. |
+
+Additional algorithms available on the JVM (such as SHA-512/256 and SHA-3 variants) are also accepted. The full list is JVM-dependent and visible in the algorithm parameter dropdown.
+
+Note that the Java names use hyphens (SHA-256, SHA-1) where SPARQL uses none (SHA256, SHA1). Both forms are accepted by this operator.

--- a/silk-rules/src/main/resources/org/silkframework/rule/plugins/transformer/value/PerValueHashTransformer.md
+++ b/silk-rules/src/main/resources/org/silkframework/rule/plugins/transformer/value/PerValueHashTransformer.md
@@ -1,0 +1,37 @@
+The **Per-value hash** operator hashes each input value independently and returns one hash per value. The output count always equals the input count — cardinality is preserved.
+
+## SPARQL alignment
+
+This operator produces the same output as the SPARQL 1.1 hash functions applied per value. For a single input value, `SHA256(?x)` in SPARQL returns the same result as this operator with the default SHA256 algorithm.
+
+## Single-input constraint
+
+The operator accepts exactly one input port. Connecting more than one port throws an `IllegalArgumentException`. This constraint exists because per-value hashing is defined relative to a single value sequence — combining values across ports would require choosing a port-merging strategy, which is the behaviour of the **Combined input hash** operator instead.
+
+## Output
+
+Each input value produces one lowercase hexadecimal hash string. The output order matches the input order. If the input is empty, the output is empty — no hash is produced.
+
+Values are encoded as UTF-8 before hashing.
+
+## Algorithm parameter
+
+The algorithm parameter selects the hash function. The default is SHA-256. The five algorithms from the [SPARQL 1.1 specification](https://www.w3.org/TR/sparql11-query/#func-hash) are supported:
+
+| SPARQL name | Java name | Notes |
+|-------------|-----------|-------|
+| MD5 | MD5 | Weak — vulnerable to collision attacks. Avoid for security-sensitive use. |
+| SHA1 | SHA-1 | Weak — deprecated for most security purposes. |
+| SHA256 | SHA-256 | Recommended default. |
+| SHA384 | SHA-384 | Stronger than SHA-256. |
+| SHA512 | SHA-512 | Strongest in the SPARQL set. |
+
+Additional algorithms available on the JVM are also accepted. The full list is JVM-dependent and visible in the algorithm parameter dropdown.
+
+Note that the Java names use hyphens (SHA-256, SHA-1) where SPARQL uses none (SHA256, SHA1). Both forms are accepted by this operator.
+
+## Contrast with Combined input hash
+
+The **Combined input hash** operator feeds all values from all ports into a single hash function and returns one hash regardless of input size. Use it when you need a single fingerprint for a set of values taken together.
+
+Use **Per-value hash** when each value needs its own hash — for example, to hash a column of URIs independently, or to replicate `SHA256(?x)` in SPARQL.

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/RulePlugins.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/RulePlugins.scala
@@ -115,6 +115,7 @@ class RulePlugins extends PluginModule {
         // Dataset
         classOf[FileHashTransformer] ::
         classOf[InputHashTransformer] ::
+        classOf[PerValueHashTransformer] ::
         // Numeric
         classOf[NumReduceTransformer] ::
         classOf[NumOperationTransformer] ::

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/HashAlgorithmAutoCompletionProvider.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/HashAlgorithmAutoCompletionProvider.scala
@@ -1,0 +1,32 @@
+package org.silkframework.rule.plugins.transformer.value
+
+import org.silkframework.runtime.plugin.{AutoCompletionResult, ParamValue, PluginContext, PluginParameterAutoCompletionProvider}
+import org.silkframework.workspace.WorkspaceReadTrait
+
+import java.security.Security
+import scala.jdk.CollectionConverters.IterableHasAsScala
+
+/**
+ * Provides autocomplete suggestions for hash algorithm names.
+ *
+ * The algorithm list is sourced from the JVM's registered security providers via [[java.security.Security#getAlgorithms]],
+ * scoped to the `MessageDigest` service type. The result is JVM-dependent — different provider configurations
+ * return different sets. The list is built once on first access and cached.
+ */
+case class HashAlgorithmAutoCompletionProvider() extends PluginParameterAutoCompletionProvider {
+
+  private lazy val algorithms = Security.getAlgorithms("MessageDigest").asScala.toSeq
+
+  override def autoComplete(searchQuery: String, dependOnParameterValues: Seq[ParamValue],
+                            workspace: WorkspaceReadTrait)
+                           (implicit context: PluginContext): Iterable[AutoCompletionResult] = {
+    val multiSearchWords = extractSearchTerms(searchQuery)
+    algorithms
+      .filter(r => matchesSearchTerm(multiSearchWords, r.toLowerCase))
+      .map(r => AutoCompletionResult(r, None))
+  }
+
+  override def valueToLabel(value: String, dependOnParameterValues: Seq[ParamValue],
+                            workspace: WorkspaceReadTrait)
+                           (implicit context: PluginContext): Option[String] = None
+}

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/HashAlgorithmAutoCompletionProvider.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/HashAlgorithmAutoCompletionProvider.scala
@@ -15,7 +15,7 @@ import scala.jdk.CollectionConverters.IterableHasAsScala
  */
 case class HashAlgorithmAutoCompletionProvider() extends PluginParameterAutoCompletionProvider {
 
-  private lazy val algorithms = Security.getAlgorithms("MessageDigest").asScala.toSeq
+  private lazy val algorithms: Seq[String] = Security.getAlgorithms("MessageDigest").asScala.toSeq.sorted
 
   override def autoComplete(searchQuery: String, dependOnParameterValues: Seq[ParamValue],
                             workspace: WorkspaceReadTrait)

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/HashTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/HashTransformer.scala
@@ -16,18 +16,18 @@ trait HashTransformer extends Transformer {
   /** The hash algorithm name, passed directly to [[java.security.MessageDigest#getInstance]].
    *  Must be recognized by the JVM's security provider registry; unrecognized names cause
    *  [[java.security.NoSuchAlgorithmException]] at runtime. */
-  protected def algorithm: String
+  def algorithm: String
 
   /** Encodes a byte array as a fixed-length lowercase hex string. Each byte maps to exactly two
    *  characters; without zero-padding, a byte with value 5 would render as "5" instead of "05",
    *  producing a variable-length string that breaks any downstream comparison or length check. */
-  protected def toHex(bytes: Array[Byte]): String =
+  def toHex(bytes: Array[Byte]): String =
     bytes.map("%02x".format(_)).mkString
 
   /** Hashes a single string value and returns its hex digest. A fresh [[java.security.MessageDigest]]
    *  instance is created on every call: [[java.security.MessageDigest]] is stateful and not thread-safe,
    *  so reusing one instance across concurrent calls would corrupt the output. */
-  protected def hashValue(v: String): String = {
+  def hashValue(v: String): String = {
     val digest = MessageDigest.getInstance(algorithm)
     digest.update(v.getBytes(StandardCharsets.UTF_8))
     toHex(digest.digest())

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/HashTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/HashTransformer.scala
@@ -9,9 +9,13 @@ import java.util.HexFormat
 /**
  * Digest operations for hash transformer plugins.
  *
- * Provides [[toHex]] and [[hashValue]] as concrete implementations over the abstract [[algorithm]]
- * parameter, which each concrete plugin supplies via its own plugin parameter. Subclasses implement
- * [[apply]] according to their combining or per-value semantics.
+ * Provides [[toHex]], [[hashValue]], and [[withDigest]] as concrete implementations over the abstract
+ * [[algorithm]] parameter, which each concrete plugin supplies via its own plugin parameter. Subclasses
+ * implement [[apply]] according to their combining or per-value semantics:
+ *  - [[hashValue]] is suited to per-value operators: it is a complete, self-contained operation on a
+ *    single string.
+ *  - [[withDigest]] is suited to combining operators: it loans a reset digest for the duration of a
+ *    single lambda, leaving the caller responsible for updates and finalization within that scope.
  */
 trait HashTransformer extends Transformer {
   /** The hash algorithm name, passed directly to [[java.security.MessageDigest#getInstance]].
@@ -24,7 +28,7 @@ trait HashTransformer extends Transformer {
   @transient private lazy val hexFormat: HexFormat = HexFormat.of()
 
   // @transient: not serialized. lazy: recreated on first use after deserialization.
-  @transient private lazy val localDigest: ThreadLocal[MessageDigest] =
+  @transient private lazy val threadLocalDigest: ThreadLocal[MessageDigest] =
     ThreadLocal.withInitial(() => MessageDigest.getInstance(algorithm))
 
   /** Encodes a byte array as a fixed-length lowercase hex string. Each byte maps to exactly two
@@ -33,14 +37,25 @@ trait HashTransformer extends Transformer {
   def toHex(bytes: Array[Byte]): String =
     hexFormat.formatHex(bytes)
 
+  /** Updates the digest with the UTF-8 encoding of [[v]]. */
+  def updateWith(digest: MessageDigest, v: String): Unit =
+    digest.update(v.getBytes(StandardCharsets.UTF_8))
+
   /** Hashes a single string value and returns its hex digest. A thread-local
    *  [[java.security.MessageDigest]] instance is reused across calls on the same thread:
    *  [[java.security.MessageDigest]] is stateful and not thread-safe, so each thread maintains
    *  its own instance rather than allocating a new one per call. */
-  def hashValue(v: String): String = {
-    val digest = localDigest.get()
+  def hashValue(v: String): String =
+    withDigest { digest =>
+      updateWith(digest, v)
+      toHex(digest.digest())
+    }
+
+  /** Resets the thread-local [[java.security.MessageDigest]] and loans it to the given function.
+   *  The instance is shared on the calling thread; do not retain a reference beyond the function's scope. */
+  def withDigest[A](f: MessageDigest => A): A = {
+    val digest = threadLocalDigest.get()
     digest.reset()
-    digest.update(v.getBytes(StandardCharsets.UTF_8))
-    toHex(digest.digest())
+    f(digest)
   }
 }

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/HashTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/HashTransformer.scala
@@ -4,6 +4,7 @@ import org.silkframework.rule.input.Transformer
 
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
+import java.util.HexFormat
 
 /**
  * Digest operations for hash transformer plugins.
@@ -18,11 +19,15 @@ trait HashTransformer extends Transformer {
    *  [[java.security.NoSuchAlgorithmException]] at runtime. */
   def algorithm: String
 
+  // @transient: HexFormat is not serializable. lazy: transient fields are null after deserialization;
+  // lazy ensures the instance is recreated on first use rather than remaining null.
+  @transient private lazy val hexFormat: HexFormat = HexFormat.of()
+
   /** Encodes a byte array as a fixed-length lowercase hex string. Each byte maps to exactly two
    *  characters; without zero-padding, a byte with value 5 would render as "5" instead of "05",
    *  producing a variable-length string that breaks any downstream comparison or length check. */
   def toHex(bytes: Array[Byte]): String =
-    bytes.map("%02x".format(_)).mkString
+    hexFormat.formatHex(bytes)
 
   /** Hashes a single string value and returns its hex digest. A fresh [[java.security.MessageDigest]]
    *  instance is created on every call: [[java.security.MessageDigest]] is stateful and not thread-safe,

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/HashTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/HashTransformer.scala
@@ -23,17 +23,23 @@ trait HashTransformer extends Transformer {
   // lazy ensures the instance is recreated on first use rather than remaining null.
   @transient private lazy val hexFormat: HexFormat = HexFormat.of()
 
+  // @transient: not serialized. lazy: recreated on first use after deserialization.
+  @transient private lazy val localDigest: ThreadLocal[MessageDigest] =
+    ThreadLocal.withInitial(() => MessageDigest.getInstance(algorithm))
+
   /** Encodes a byte array as a fixed-length lowercase hex string. Each byte maps to exactly two
    *  characters; without zero-padding, a byte with value 5 would render as "5" instead of "05",
    *  producing a variable-length string that breaks any downstream comparison or length check. */
   def toHex(bytes: Array[Byte]): String =
     hexFormat.formatHex(bytes)
 
-  /** Hashes a single string value and returns its hex digest. A fresh [[java.security.MessageDigest]]
-   *  instance is created on every call: [[java.security.MessageDigest]] is stateful and not thread-safe,
-   *  so reusing one instance across concurrent calls would corrupt the output. */
+  /** Hashes a single string value and returns its hex digest. A thread-local
+   *  [[java.security.MessageDigest]] instance is reused across calls on the same thread:
+   *  [[java.security.MessageDigest]] is stateful and not thread-safe, so each thread maintains
+   *  its own instance rather than allocating a new one per call. */
   def hashValue(v: String): String = {
-    val digest = MessageDigest.getInstance(algorithm)
+    val digest = localDigest.get()
+    digest.reset()
     digest.update(v.getBytes(StandardCharsets.UTF_8))
     toHex(digest.digest())
   }

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/HashTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/HashTransformer.scala
@@ -1,0 +1,35 @@
+package org.silkframework.rule.plugins.transformer.value
+
+import org.silkframework.rule.input.Transformer
+
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+/**
+ * Digest operations for hash transformer plugins.
+ *
+ * Provides [[toHex]] and [[hashValue]] as concrete implementations over the abstract [[algorithm]]
+ * parameter, which each concrete plugin supplies via its own plugin parameter. Subclasses implement
+ * [[apply]] according to their combining or per-value semantics.
+ */
+trait HashTransformer extends Transformer {
+  /** The hash algorithm name, passed directly to [[java.security.MessageDigest#getInstance]].
+   *  Must be recognized by the JVM's security provider registry; unrecognized names cause
+   *  [[java.security.NoSuchAlgorithmException]] at runtime. */
+  protected def algorithm: String
+
+  /** Encodes a byte array as a fixed-length lowercase hex string. Each byte maps to exactly two
+   *  characters; without zero-padding, a byte with value 5 would render as "5" instead of "05",
+   *  producing a variable-length string that breaks any downstream comparison or length check. */
+  protected def toHex(bytes: Array[Byte]): String =
+    bytes.map("%02x".format(_)).mkString
+
+  /** Hashes a single string value and returns its hex digest. A fresh [[java.security.MessageDigest]]
+   *  instance is created on every call: [[java.security.MessageDigest]] is stateful and not thread-safe,
+   *  so reusing one instance across concurrent calls would corrupt the output. */
+  protected def hashValue(v: String): String = {
+    val digest = MessageDigest.getInstance(algorithm)
+    digest.update(v.getBytes(StandardCharsets.UTF_8))
+    toHex(digest.digest())
+  }
+}

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/HashTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/HashTransformer.scala
@@ -1,6 +1,6 @@
 package org.silkframework.rule.plugins.transformer.value
 
-import org.silkframework.rule.input.Transformer
+import org.silkframework.rule.input.InlineTransformer
 
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
@@ -17,7 +17,7 @@ import java.util.HexFormat
  *  - [[withDigest]] is suited to combining operators: it loans a reset digest for the duration of a
  *    single lambda, leaving the caller responsible for updates and finalization within that scope.
  */
-trait HashTransformer extends Transformer {
+trait HashTransformer extends InlineTransformer {
   /** The hash algorithm name, passed directly to [[java.security.MessageDigest#getInstance]].
    *  Must be recognized by the JVM's security provider registry; unrecognized names cause
    *  [[java.security.NoSuchAlgorithmException]] at runtime. */

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/InputHashTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/InputHashTransformer.scala
@@ -4,8 +4,8 @@ import org.silkframework.rule.annotations.{TransformExample, TransformExamples}
 import org.silkframework.rule.plugins.transformer.replace.MapTransformerWithDefaultInput
 import org.silkframework.runtime.plugin.annotations.{Param, Plugin, PluginReference}
 
-import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
+
 
 /**
  * Combines all input values across all connected ports into a single hash.
@@ -98,9 +98,13 @@ case class InputHashTransformer(@Param(value = "The hash algorithm to be used.",
   require(algorithm.trim.nonEmpty, "Algorithm must not be empty. Please specify an algorithm, such as 'SHA256'.")
 
   override def apply(values: Seq[Seq[String]]): Seq[String] = {
-    val digest = MessageDigest.getInstance(algorithm)
-    values.flatten.foreach(v => digest.update(v.getBytes(StandardCharsets.UTF_8)))
-    Seq(toHex(digest.digest()))
+    def updateAll(digest: MessageDigest): Unit =
+      values.flatten.foreach(updateWith(digest, _))
+
+    Seq(withDigest { digest =>
+      updateAll(digest)
+      toHex(digest.digest())
+    })
   }
 }
 

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/InputHashTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/InputHashTransformer.scala
@@ -84,6 +84,12 @@ import java.security.MessageDigest
     input1 = Array(),
     output = Array("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
   ),
+  new TransformExample(
+    description = "Empty algorithm string causes IllegalArgumentException.",
+    parameters = Array("algorithm", ""),
+    input1 = Array("foo"),
+    throwsException = classOf[IllegalArgumentException]
+  ),
 ))
 case class InputHashTransformer(@Param(value = "The hash algorithm to be used.",
                                       autoCompletionProvider = classOf[HashAlgorithmAutoCompletionProvider], allowOnlyAutoCompletedValues = true)

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/InputHashTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/InputHashTransformer.scala
@@ -14,20 +14,66 @@ import scala.jdk.CollectionConverters.IterableHasAsScala
 @Plugin(
   id = InputHashTransformer.pluginId,
   categories = Array("Value"),
-  label = "Input hash",
-  description = """Calculates the hash sum of the input values. Generates a single hash sum for all input values combined.""",
+  label = "Combined input hash",
+  description = """Calculates a single hash value covering all input values combined, across all input ports. Values are fed into the hash function in port order without any separator between them.""",
   documentationFile = "InputHashTransformer.md",
   relatedPlugins = Array(
     new PluginReference(
       id = MapTransformerWithDefaultInput.pluginId,
-      description = "One hash value is produced for the entire set of inputs by the Input hash plugin. The Map with default plugin instead keeps a value sequence and rewrites it position by position through the mapping, falling back to the second input where no mapping entry is found."
+      description = "One hash value is produced for the entire set of inputs by the Combined input hash plugin. The Map with default plugin instead keeps a value sequence and rewrites it position by position through the mapping, falling back to the second input where no mapping entry is found."
     )
   )
 )
 @TransformExamples(Array(
   new TransformExample(
+    description = "One SHA-256 hash per input value.",
     input1 = Array("input value"),
     output = Array("f708c2afff0ed197e8551c4dd549ee5b848e0b407106cbdb8e451c8cd1479362")
+  ),
+  new TransformExample(
+    description = "Multiple values on one input are combined into a single hash.",
+    input1 = Array("apple", "banana"),
+    output = Array("5b692305517af54eb5ae12b9ff89eaf89e31f6a6ee208365886a18b81a2fc2f8")
+  ),
+  new TransformExample(
+    description = "Reversing the value order produces a different hash, confirming order-sensitivity.",
+    input1 = Array("banana", "apple"),
+    output = Array("d4183362b538440bb9a5f82359791c647280e6b657a1812f16f7bcc2b8f141ca")
+  ),
+  new TransformExample(
+    description = "Values from multiple ports are combined in port order, producing the same hash as the equivalent single-port sequence.",
+    input1 = Array("apple"),
+    input2 = Array("banana"),
+    output = Array("5b692305517af54eb5ae12b9ff89eaf89e31f6a6ee208365886a18b81a2fc2f8")
+  ),
+  new TransformExample(
+    description = "The algorithm parameter selects the hash function (MD5).",
+    parameters = Array("algorithm", "MD5"),
+    input1 = Array("input value"),
+    output = Array("cee963a28f70ee97751a85ef732e66dd")
+  ),
+  new TransformExample(
+    description = "The algorithm parameter selects the hash function (SHA-1).",
+    parameters = Array("algorithm", "SHA-1"),
+    input1 = Array("apple"),
+    output = Array("d0be2dc421be4fcd0172e5afceea3970e2f3d940")
+  ),
+  new TransformExample(
+    description = "The algorithm parameter selects the hash function (SHA-384).",
+    parameters = Array("algorithm", "SHA-384"),
+    input1 = Array("apple"),
+    output = Array("3d8786fcb588c93348756c6429717dc6c374a14f7029362281a3b21dc10250ddf0d0578052749822eb08bc0dc1e68b0f")
+  ),
+  new TransformExample(
+    description = "The algorithm parameter selects the hash function (SHA-512).",
+    parameters = Array("algorithm", "SHA-512"),
+    input1 = Array("apple"),
+    output = Array("844d8779103b94c18f4aa4cc0c3b4474058580a991fba85d3ca698a0bc9e52c5940feb7a65a3a290e17e6b23ee943ecc4f73e7490327245b4fe5d5efb590feb2")
+  ),
+  new TransformExample(
+    description = "Empty input produces the hash of an empty message.",
+    input1 = Array(),
+    output = Array("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
   ),
 ))
 case class InputHashTransformer(@Param(value = "The hash algorithm to be used.",

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/InputHashTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/InputHashTransformer.scala
@@ -4,13 +4,19 @@ import org.silkframework.rule.annotations.{TransformExample, TransformExamples}
 import org.silkframework.rule.input.Transformer
 import org.silkframework.rule.plugins.transformer.replace.MapTransformerWithDefaultInput
 import org.silkframework.runtime.plugin.annotations.{Param, Plugin, PluginReference}
-import org.silkframework.runtime.plugin.{AutoCompletionResult, ParamValue, PluginContext, PluginParameterAutoCompletionProvider}
-import org.silkframework.workspace.WorkspaceReadTrait
 
 import java.nio.charset.StandardCharsets
-import java.security.{MessageDigest, Security}
-import scala.jdk.CollectionConverters.IterableHasAsScala
+import java.security.MessageDigest
 
+/**
+ * Combines all input values across all connected ports into a single hash.
+ *
+ * Values are fed sequentially into a single [[java.security.MessageDigest]] instance — port 1 first, then port 2,
+ * and so on; within each port, values are processed in order. No separator is inserted between values or ports.
+ * The output is always exactly one lowercase hexadecimal string, regardless of how many values or ports are provided.
+ *
+ * @see [[PerValueHashTransformer]] for the per-value variant that produces one hash per input value.
+ */
 @Plugin(
   id = InputHashTransformer.pluginId,
   categories = Array("Value"),
@@ -94,30 +100,4 @@ case class InputHashTransformer(@Param(value = "The hash algorithm to be used.",
 
 object InputHashTransformer {
   final val pluginId = "inputHash"
-}
-
-/**
- * Auto-completion for project resources.
- */
-case class HashAlgorithmAutoCompletionProvider() extends PluginParameterAutoCompletionProvider {
-
-  private lazy val algorithms = {
-    Security.getAlgorithms("MessageDigest").asScala.toSeq
-  }
-
-  override def autoComplete(searchQuery: String, dependOnParameterValues: Seq[ParamValue],
-                            workspace: WorkspaceReadTrait)
-                           (implicit context: PluginContext): Iterable[AutoCompletionResult] = {
-
-    val multiSearchWords = extractSearchTerms(searchQuery)
-    algorithms
-      .filter(r => matchesSearchTerm(multiSearchWords, r.toLowerCase))
-      .map(r => AutoCompletionResult(r, None))
-  }
-
-  override def valueToLabel(value: String, dependOnParameterValues: Seq[ParamValue],
-                            workspace: WorkspaceReadTrait)
-                           (implicit context: PluginContext): Option[String] = {
-    None
-  }
 }

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/InputHashTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/InputHashTransformer.scala
@@ -35,7 +35,7 @@ import java.security.MessageDigest
 )
 @TransformExamples(Array(
   new TransformExample(
-    description = "One SHA-256 hash per input value.",
+    description = "A single input value produces one combined SHA-256 hash.",
     input1 = Array("input value"),
     output = Array("f708c2afff0ed197e8551c4dd549ee5b848e0b407106cbdb8e451c8cd1479362")
   ),

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/InputHashTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/InputHashTransformer.scala
@@ -1,7 +1,6 @@
 package org.silkframework.rule.plugins.transformer.value
 
 import org.silkframework.rule.annotations.{TransformExample, TransformExamples}
-import org.silkframework.rule.input.Transformer
 import org.silkframework.rule.plugins.transformer.replace.MapTransformerWithDefaultInput
 import org.silkframework.runtime.plugin.annotations.{Param, Plugin, PluginReference}
 
@@ -24,6 +23,10 @@ import java.security.MessageDigest
   description = """Calculates a single hash value covering all input values combined, across all input ports. Values are fed into the hash function in port order without any separator between them.""",
   documentationFile = "InputHashTransformer.md",
   relatedPlugins = Array(
+    new PluginReference(
+      id = PerValueHashTransformer.pluginId,
+      description = "The Per-value hash plugin hashes each input value independently and returns one hash per value, preserving cardinality. The Combined input hash plugin instead feeds all values into a single hash function, producing one combined hash regardless of input size."
+    ),
     new PluginReference(
       id = MapTransformerWithDefaultInput.pluginId,
       description = "One hash value is produced for the entire set of inputs by the Combined input hash plugin. The Map with default plugin instead keeps a value sequence and rewrites it position by position through the mapping, falling back to the second input where no mapping entry is found."
@@ -84,17 +87,14 @@ import java.security.MessageDigest
 ))
 case class InputHashTransformer(@Param(value = "The hash algorithm to be used.",
                                       autoCompletionProvider = classOf[HashAlgorithmAutoCompletionProvider], allowOnlyAutoCompletedValues = true)
-                                algorithm: String = "SHA256") extends Transformer {
+                                algorithm: String = "SHA256") extends HashTransformer {
 
   require(algorithm.trim.nonEmpty, "Algorithm must not be empty. Please specify an algorithm, such as 'SHA256'.")
 
   override def apply(values: Seq[Seq[String]]): Seq[String] = {
-    val hashSum = MessageDigest.getInstance(algorithm)
-    for(value <- values; v <- value) {
-      hashSum.update(v.getBytes(StandardCharsets.UTF_8))
-    }
-    // Convert the byte array to a hexadecimal string
-    Seq(hashSum.digest().map("%02x".format(_)).mkString)
+    val digest = MessageDigest.getInstance(algorithm)
+    values.flatten.foreach(v => digest.update(v.getBytes(StandardCharsets.UTF_8)))
+    Seq(toHex(digest.digest()))
   }
 }
 

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/PerValueHashTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/PerValueHashTransformer.scala
@@ -85,6 +85,12 @@ import java.security.NoSuchAlgorithmException
     parameters = Array("algorithm", "NONEXISTENT"),
     input1 = Array("foo"),
     throwsException = classOf[NoSuchAlgorithmException]
+  ),
+  new TransformExample(
+    description = "Empty algorithm string causes IllegalArgumentException.",
+    parameters = Array("algorithm", ""),
+    input1 = Array("foo"),
+    throwsException = classOf[IllegalArgumentException]
   )
 ))
 case class PerValueHashTransformer(

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/PerValueHashTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/PerValueHashTransformer.scala
@@ -1,11 +1,9 @@
 package org.silkframework.rule.plugins.transformer.value
 
 import org.silkframework.rule.annotations.{TransformExample, TransformExamples}
-import org.silkframework.rule.input.Transformer
 import org.silkframework.runtime.plugin.annotations.{Param, Plugin, PluginReference}
 
-import java.nio.charset.StandardCharsets
-import java.security.{MessageDigest, NoSuchAlgorithmException}
+import java.security.NoSuchAlgorithmException
 
 /**
  * Hashes each input value independently and returns one hash per value, preserving cardinality.
@@ -95,18 +93,9 @@ case class PerValueHashTransformer(
     autoCompletionProvider = classOf[HashAlgorithmAutoCompletionProvider],
     allowOnlyAutoCompletedValues = true
   )
-  algorithm: String = "SHA256") extends Transformer {
+  algorithm: String = "SHA256") extends HashTransformer {
 
   require(algorithm.trim.nonEmpty, "Algorithm must not be empty. Please specify an algorithm, such as 'SHA256'.")
-
-  private def toHex(bytes: Array[Byte]): String =
-    bytes.map("%02x".format(_)).mkString
-
-  private def hashValue(v: String): String = {
-    val digest = MessageDigest.getInstance(algorithm)
-    digest.update(v.getBytes(StandardCharsets.UTF_8))
-    toHex(digest.digest())
-  }
 
   override def apply(values: Seq[Seq[String]]): Seq[String] = {
     require(values.size == 1,

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/PerValueHashTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/PerValueHashTransformer.scala
@@ -1,0 +1,120 @@
+package org.silkframework.rule.plugins.transformer.value
+
+import org.silkframework.rule.annotations.{TransformExample, TransformExamples}
+import org.silkframework.rule.input.Transformer
+import org.silkframework.runtime.plugin.annotations.{Param, Plugin, PluginReference}
+
+import java.nio.charset.StandardCharsets
+import java.security.{MessageDigest, NoSuchAlgorithmException}
+
+/**
+ * Hashes each input value independently and returns one hash per value, preserving cardinality.
+ *
+ * Accepts exactly one input port. Throws [[IllegalArgumentException]] if more than one port is connected.
+ * Each value is encoded as UTF-8 and hashed using a fresh [[java.security.MessageDigest]] instance.
+ * The output is a lowercase hexadecimal string for each input value, in the same order as the input.
+ *
+ * @see [[InputHashTransformer]] for the combining variant that produces a single hash for all input values combined.
+ */
+@Plugin(
+  id = PerValueHashTransformer.pluginId,
+  categories = Array("Value"),
+  label = "Per-value hash",
+  description = """Hashes each input value independently and returns one hash per value. Accepts exactly one input port.""",
+  // TODO: documentationFile = "PerValueHashTransformer.md",
+  relatedPlugins = Array(
+    new PluginReference(
+      id = InputHashTransformer.pluginId,
+      description = "The Combined input hash plugin produces one combined hash for all input values. The Per-value hash plugin instead hashes each value independently, preserving cardinality."
+    )
+  )
+)
+@TransformExamples(Array(
+  new TransformExample(
+    description = "Single value produces one SHA-256 hash.",
+    input1 = Array("input value"),
+    output = Array("f708c2afff0ed197e8551c4dd549ee5b848e0b407106cbdb8e451c8cd1479362")
+  ),
+  new TransformExample(
+    description = "Two values in, two independent hashes out — one per value, not a combined hash.",
+    input1 = Array("apple", "banana"),
+    output = Array("3a7bd3e2360a3d29eea436fcfb7e44c735d117c42d1c1835420b6b9942dd4f1b",
+                   "b493d48364afe44d11c0165cf470a4164d1e2609911ef998be868d46ade3de4e")
+  ),
+  new TransformExample(
+    description = "The algorithm parameter selects the hash function (MD5), single value.",
+    parameters = Array("algorithm", "MD5"),
+    input1 = Array("apple"),
+    output = Array("1f3870be274f6c49b3e31a0c6728957f")
+  ),
+  new TransformExample(
+    description = "The algorithm parameter selects the hash function (MD5), multiple values.",
+    parameters = Array("algorithm", "MD5"),
+    input1 = Array("apple", "banana"),
+    output = Array("1f3870be274f6c49b3e31a0c6728957f", "72b302bf297a228a75730123efef7c41")
+  ),
+  new TransformExample(
+    description = "The algorithm parameter selects the hash function (SHA-1).",
+    parameters = Array("algorithm", "SHA-1"),
+    input1 = Array("apple"),
+    output = Array("d0be2dc421be4fcd0172e5afceea3970e2f3d940")
+  ),
+  new TransformExample(
+    description = "The algorithm parameter selects the hash function (SHA-384).",
+    parameters = Array("algorithm", "SHA-384"),
+    input1 = Array("apple"),
+    output = Array("3d8786fcb588c93348756c6429717dc6c374a14f7029362281a3b21dc10250ddf0d0578052749822eb08bc0dc1e68b0f")
+  ),
+  new TransformExample(
+    description = "The algorithm parameter selects the hash function (SHA-512).",
+    parameters = Array("algorithm", "SHA-512"),
+    input1 = Array("apple"),
+    output = Array("844d8779103b94c18f4aa4cc0c3b4474058580a991fba85d3ca698a0bc9e52c5940feb7a65a3a290e17e6b23ee943ecc4f73e7490327245b4fe5d5efb590feb2")
+  ),
+  new TransformExample(
+    description = "Empty input produces empty output.",
+    input1 = Array(),
+    output = Array()
+  ),
+  new TransformExample(
+    description = "Two input ports causes IllegalArgumentException.",
+    input1 = Array("foo"),
+    input2 = Array("bar"),
+    throwsException = classOf[IllegalArgumentException]
+  ),
+  new TransformExample(
+    description = "Invalid algorithm name causes NoSuchAlgorithmException.",
+    parameters = Array("algorithm", "NONEXISTENT"),
+    input1 = Array("foo"),
+    throwsException = classOf[NoSuchAlgorithmException]
+  )
+))
+case class PerValueHashTransformer(
+  @Param(
+    value = "The hash algorithm to be used.",
+    autoCompletionProvider = classOf[HashAlgorithmAutoCompletionProvider],
+    allowOnlyAutoCompletedValues = true
+  )
+  algorithm: String = "SHA256") extends Transformer {
+
+  require(algorithm.trim.nonEmpty, "Algorithm must not be empty. Please specify an algorithm, such as 'SHA256'.")
+
+  private def toHex(bytes: Array[Byte]): String =
+    bytes.map("%02x".format(_)).mkString
+
+  private def hashValue(v: String): String = {
+    val digest = MessageDigest.getInstance(algorithm)
+    digest.update(v.getBytes(StandardCharsets.UTF_8))
+    toHex(digest.digest())
+  }
+
+  override def apply(values: Seq[Seq[String]]): Seq[String] = {
+    require(values.size == 1,
+      s"Per-value hash accepts exactly one input source, but ${values.size} were provided.")
+    values.head.map(hashValue)
+  }
+}
+
+object PerValueHashTransformer {
+  final val pluginId = "perValueHash"
+}

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/PerValueHashTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/PerValueHashTransformer.scala
@@ -21,7 +21,7 @@ import java.security.{MessageDigest, NoSuchAlgorithmException}
   categories = Array("Value"),
   label = "Per-value hash",
   description = """Hashes each input value independently and returns one hash per value. Accepts exactly one input port.""",
-  // TODO: documentationFile = "PerValueHashTransformer.md",
+  documentationFile = "PerValueHashTransformer.md",
   relatedPlugins = Array(
     new PluginReference(
       id = InputHashTransformer.pluginId,

--- a/silk-rules/src/test/scala/org/silkframework/rule/plugins/transformer/value/PerValueHashTransformerTest.scala
+++ b/silk-rules/src/test/scala/org/silkframework/rule/plugins/transformer/value/PerValueHashTransformerTest.scala
@@ -1,0 +1,5 @@
+package org.silkframework.rule.plugins.transformer.value
+
+import org.silkframework.rule.test.TransformerTest
+
+class PerValueHashTransformerTest extends TransformerTest[PerValueHashTransformer]


### PR DESCRIPTION
## What and why

SPARQL 1.1 hash functions (`SHA256(?x)`, `MD5(?x)`, etc.) operate value by value — ten rows in, ten hashes out. Silk's existing "Input hash" operator combines all values from all ports into a single hash, which makes it impossible to replicate SPARQL hashing logic in a Transform rule without changing its semantics.

This PR closes that gap. The existing "Input hash" operator is renamed to make its combining semantics explicit, and a new "Per-value hash" operator is added that hashes each value independently — one hash per value, cardinality preserved. Both operators share a common `HashTransformer` trait that provides the hex encoding and digest logic.

## Changes

The existing "Input hash" operator has been renamed to "Combined input hash". Its label and description now make the combining behavior unambiguous at a glance. The plugin ID (`inputHash`) is unchanged so that existing serialized configurations continue to work without migration. Its documentation has been rewritten from scratch and its test suite expanded from one case to eleven, covering multiple values, order sensitivity, multi-port combination, and all five SPARQL 1.1 algorithms.

The new "Per-value hash" operator (`perValueHash`) hashes each input value independently, producing one hash per value in the same order as the input. It accepts exactly one input port and throws `IllegalArgumentException` if more are connected. It uses the same open-ended JVM MessageDigest algorithm list as the existing operator, covering the full SPARQL 1.1 set and more. Its documentation and test suite (12 cases) are new.

A `HashTransformer` trait has been extracted to hold the shared hex encoding and digest logic; both plugins implement only their `apply` method and inherit everything else. The `HashAlgorithmAutoCompletionProvider`, previously a nested class inside `InputHashTransformer.scala`, has been moved to its own file and is shared by both operators. A `relatedPlugins` annotation on each operator links to the other, making the distinction discoverable in the UI.

## Tests

`InputHashTransformerTest` (existing, expanded) — 11 cases: single value, multiple values, order sensitivity, multi-port combination, all five SPARQL 1.1 algorithms (MD5, SHA-1, SHA-256, SHA-384, SHA-512), empty input.

`PerValueHashTransformerTest` (new) — 12 cases: single value, multiple values, all five algorithms, empty input, single-input constraint violation (`IllegalArgumentException`), empty algorithm string (`IllegalArgumentException`), invalid algorithm name (`NoSuchAlgorithmException`).

## Acceptance criteria

- "Input hash" renamed to "Combined input hash" — plugin ID unchanged for backward compatibility
- New "Per-value hash" operator hashes each value independently and enforces a single input source
- Both operators support MD5, SHA-1, SHA-256, SHA-384, SHA-512 and the full JVM MessageDigest provider set
