### PR TITLE
New `/api/workspace/status` endpoint that reports the failed task rep…

### DIFF
--- a/silk-workbench/silk-workbench-workspace/app/controllers/workspaceApi/WorkspaceStatusApi.scala
+++ b/silk-workbench/silk-workbench-workspace/app/controllers/workspaceApi/WorkspaceStatusApi.scala
@@ -1,0 +1,96 @@
+package controllers.workspaceApi
+
+import controllers.core.UserContextActions
+import controllers.core.util.ControllerUtilsTrait
+import controllers.errorReporting.ErrorReport.ErrorReportItem
+import controllers.workspaceApi.WorkspaceStatusApi.{ProjectFailedTasks, WorkspaceStatus}
+import controllers.workspaceApi.project.ProjectLoadingErrors
+import io.swagger.v3.oas.annotations.media.{ArraySchema, Content, Schema}
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import io.swagger.v3.oas.annotations.Operation
+import play.api.libs.json.{Format, Json}
+import play.api.mvc.{Action, AnyContent, InjectedController}
+
+/**
+  * Provides aggregate status information about the whole workspace.
+  */
+@Tag(name = "Workspace")
+class WorkspaceStatusApi extends InjectedController with UserContextActions with ControllerUtilsTrait {
+
+  @Operation(
+    summary = "Workspace status",
+    description = "Returns aggregate status information about the workspace. Currently this lists all tasks that " +
+      "could not be loaded, grouped by project, together with summary counts. Only projects that have at least one " +
+      "failed task are included in the 'projects' array.",
+    responses = Array(
+      new ApiResponse(
+        responseCode = "200",
+        description = "Success",
+        content = Array(new Content(
+          mediaType = "application/json",
+          schema = new Schema(implementation = classOf[WorkspaceStatus])
+        ))
+      )
+    ))
+  def status(): Action[AnyContent] = RequestUserContextAction { implicit request => implicit userContext =>
+    val projects = workspace.userProjects
+    val failingProjects =
+      for {
+        project <- projects
+        loadingErrors = project.loadingErrors
+        if loadingErrors.nonEmpty
+      } yield {
+        ProjectFailedTasks(
+          projectId = project.id.toString,
+          projectLabel = project.config.metaData.label,
+          failedTaskCount = loadingErrors.size,
+          failedTasks = loadingErrors.map(ProjectLoadingErrors.fromTaskLoadingError)
+        )
+      }
+    val status = WorkspaceStatus(
+      projectCount = projects.size,
+      failedProjectCount = failingProjects.size,
+      failedTaskCount = failingProjects.map(_.failedTaskCount).sum,
+      projects = failingProjects
+    )
+    Ok(Json.toJson(status))
+  }
+}
+
+object WorkspaceStatusApi {
+
+  @Schema(description = "The failed tasks of a single project.")
+  case class ProjectFailedTasks(@Schema(description = "The identifier of the project.")
+                                projectId: String,
+                                @Schema(description = "The label of the project, if defined.", nullable = true)
+                                projectLabel: Option[String],
+                                @Schema(description = "The number of tasks in this project that could not be loaded.")
+                                failedTaskCount: Int,
+                                @ArraySchema(schema = new Schema(
+                                  description = "The detailed loading error reports of the failed tasks.",
+                                  implementation = classOf[ErrorReportItem]
+                                ))
+                                failedTasks: Seq[ErrorReportItem])
+
+  object ProjectFailedTasks {
+    implicit val projectFailedTasksFormat: Format[ProjectFailedTasks] = Json.format[ProjectFailedTasks]
+  }
+
+  @Schema(description = "Aggregate workspace status, currently focused on tasks that failed to load.")
+  case class WorkspaceStatus(@Schema(description = "The total number of projects the user has access to.")
+                             projectCount: Int,
+                             @Schema(description = "The number of projects that have at least one failed task.")
+                             failedProjectCount: Int,
+                             @Schema(description = "The total number of failed tasks across all projects.")
+                             failedTaskCount: Int,
+                             @ArraySchema(schema = new Schema(
+                               description = "The failed tasks grouped by project. Only contains projects that have at least one failed task.",
+                               implementation = classOf[ProjectFailedTasks]
+                             ))
+                             projects: Seq[ProjectFailedTasks])
+
+  object WorkspaceStatus {
+    implicit val workspaceStatusFormat: Format[WorkspaceStatus] = Json.format[WorkspaceStatus]
+  }
+}

--- a/silk-workbench/silk-workbench-workspace/conf/workspaceApi.routes
+++ b/silk-workbench/silk-workbench-workspace/conf/workspaceApi.routes
@@ -5,6 +5,7 @@ POST          /searchItems                                                      
 POST          /pluginParameterAutoCompletion                                    controllers.workspaceApi.SearchApi.parameterAutoCompletion()
 GET           /recentlyViewedItems                                              controllers.workspaceApi.SearchApi.recentlyViewedItems()
 GET           /initFrontend                                                     controllers.workspaceApi.InitApi.init()
+GET           /status                                                           controllers.workspaceApi.WorkspaceStatusApi.status()
 
 GET           /taskActivitiesStatus                                             controllers.workspaceApi.ActivitiesApi.taskActivitiesStatus(projectId: Option[String] ?= None, statusFilter: Option[String] ?= None)
 POST          /searchActivities                                                 controllers.workspaceApi.ActivitiesApi.activitySearch()

--- a/silk-workbench/silk-workbench-workspace/test/controllers/workspaceApi/ProjectLoadingErrorIntegrationTest.scala
+++ b/silk-workbench/silk-workbench-workspace/test/controllers/workspaceApi/ProjectLoadingErrorIntegrationTest.scala
@@ -1,6 +1,7 @@
 package controllers.workspaceApi
 
 import controllers.errorReporting.ErrorReport.ErrorReportItem
+import controllers.workspaceApi.WorkspaceStatusApi.WorkspaceStatus
 import helper.IntegrationTestTrait
 
 import org.silkframework.config.MetaData
@@ -76,6 +77,24 @@ class ProjectLoadingErrorIntegrationTest extends AnyFlatSpec with SingleProjectW
     errorReport.flatMap(_.taskId) mustBe Seq(failingDataset, failingCustomTask)
     val datasetError = errorReport.head
     checkFailingDatasetReport(datasetError)
+  }
+
+  it should "report failed tasks of all projects grouped by project in the workspace status" in {
+    updateProjectMetaData()
+    val statusUrl = controllers.workspaceApi.routes.WorkspaceStatusApi.status().url
+    val statusJson = checkResponse(client.url(s"$baseUrl$statusUrl").withHttpHeaders(ACCEPT -> APPLICATION_JSON).get()).json
+    val status = Json.fromJson[WorkspaceStatus](statusJson).get
+    // Summary counts: exactly one project is failing with both of its tasks failing.
+    status.failedProjectCount mustBe 1
+    status.failedTaskCount mustBe 2
+    status.projectCount must be >= 1
+    status.projects must have size 1
+    val failingProject = status.projects.head
+    failingProject.projectId mustBe projectId
+    failingProject.projectLabel mustBe Some(projectLabel)
+    failingProject.failedTaskCount mustBe 2
+    failingProject.failedTasks.flatMap(_.taskId) mustBe Seq(failingDataset, failingCustomTask)
+    checkFailingDatasetReport(failingProject.failedTasks.head)
   }
 
   it should "consider changes in the workspace for the loading errors correctly" in {


### PR DESCRIPTION
…orts of all projects, grouped by project, together with workspace-wide summary counts (CMEM-7680).