### PR TITLE
JSON dataset: numbers are now retrieved in plain notation instead of …

### DIFF
--- a/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/JsonNode.scala
+++ b/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/JsonNode.scala
@@ -4,11 +4,9 @@ import com.fasterxml.jackson.core.{JsonFactory, JsonGenerator, JsonParser, Versi
 import com.fasterxml.jackson.databind.Module.SetupContext
 import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.databind.node.{BigIntegerNode, DecimalNode}
 import com.fasterxml.jackson.databind.ser.Serializers
 
 import java.io.InputStream
-import java.math.{BigInteger, BigDecimal => JBigDec}
 import scala.collection.immutable.SeqMap
 
 /**
@@ -105,12 +103,7 @@ object JsonNodeSerializer {
     override def serialize(value: JsonNode, json: JsonGenerator, provider: SerializerProvider): Unit = {
       value match {
         case JsonNumber(v, _) =>
-          val str = v.bigDecimal.stripTrailingZeros.toString
-          if (str.indexOf('E') < 0 && str.indexOf('.') < 0) {
-            json.writeTree(new BigIntegerNode(new BigInteger(str)))
-          } else {
-            json.writeTree(new DecimalNode(new JBigDec(str)))
-          }
+          json.writeNumber(NumberFormatter.format(v.bigDecimal))
         case JsonString(v, _) => json.writeString(v)
         case JsonBoolean(v, _) => json.writeBoolean(v)
         case JsonArray(values, _) =>

--- a/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/JsonTraverser.scala
+++ b/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/JsonTraverser.scala
@@ -257,7 +257,7 @@ case class JsonTraverser(taskId: Identifier, parentOpt: Option[ParentTraverser],
   private def nodeToString(json: JsonNode): String = {
     json match {
       case JsonBoolean(v, _) => v.toString
-      case JsonNumber(v, _) => v.toString
+      case JsonNumber(v, _) => NumberFormatter.format(v.bigDecimal)
       case JsonString(v, _) => v
       case _ => json.toString
     }

--- a/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/NumberFormatter.scala
+++ b/silk-plugins/silk-plugins-json/src/main/scala/org/silkframework/plugins/dataset/json/NumberFormatter.scala
@@ -1,0 +1,46 @@
+package org.silkframework.plugins.dataset.json
+
+import java.math.{BigDecimal => JBigDec}
+
+/**
+ * Formats numbers for JSON serialization.
+ */
+object NumberFormatter {
+
+  /**
+   * Maximum number of characters a number may occupy in plain notation before scientific notation is used instead.
+   * Bounds the output size for numbers with extreme exponents (e.g., 1e100000000), which would otherwise be
+   * expanded into millions of digits.
+   */
+  private val maxPlainNotationLength = 50
+
+  /**
+   * Formats a number in plain notation (e.g., 172800000), unless that would exceed [[maxPlainNotationLength]]
+   * characters, in which case scientific notation is used (e.g., 1E+1000).
+   */
+  def format(value: JBigDec): String = {
+    val normalized = value.stripTrailingZeros
+    if (plainNotationLength(normalized) <= maxPlainNotationLength) {
+      normalized.toPlainString
+    } else {
+      normalized.toString
+    }
+  }
+
+  /**
+   * Computes the length of the plain notation of a number without generating it.
+   */
+  private def plainNotationLength(value: JBigDec): Long = {
+    val digits = value.precision.toLong
+    val scale = value.scale.toLong
+    val length =
+      if (scale <= 0) {
+        digits - scale // Integer digits plus trailing zeros
+      } else if (digits > scale) {
+        digits + 1 // Digits before and after the decimal point plus the point itself
+      } else {
+        scale + 2 // "0." followed by leading zeros and the digits
+      }
+    length + (if (value.signum < 0) 1 else 0)
+  }
+}

--- a/silk-plugins/silk-plugins-json/src/test/scala/org/silkframework/plugins/dataset/json/JsonReaderTest.scala
+++ b/silk-plugins/silk-plugins-json/src/test/scala/org/silkframework/plugins/dataset/json/JsonReaderTest.scala
@@ -77,6 +77,22 @@ class JsonReaderTest extends AnyFlatSpec with Matchers {
     evaluate(rootItems, "nonExistingProperty/#arrayText") should equal (Seq.empty)
   }
 
+  it should "format numbers in plain notation unless it would become excessively long" in {
+    val example = JsonTraverser.fromNode("alibi_task_id",
+      JsonNodeSerializer.parse("""{"small": 1e-7, "decimal": 1.50, "negative": -12.5, "huge": 1e1000, "tiny": 1e-1000}"""), navigateIntoArrays = true)
+    evaluate(Seq(example), "small/#arrayText") should equal (Seq("0.0000001"))
+    evaluate(Seq(example), "decimal/#arrayText") should equal (Seq("1.5"))
+    evaluate(Seq(example), "negative/#arrayText") should equal (Seq("-12.5"))
+    // Numbers whose plain notation would be excessively long are written in scientific notation
+    evaluate(Seq(example), "huge/#arrayText") should equal (Seq("1E+1000"))
+    evaluate(Seq(example), "tiny/#arrayText") should equal (Seq("1E-1000"))
+
+    // Values retrieved directly are formatted the same way
+    evaluate(Seq(example), "small") should equal (Seq("0.0000001"))
+    evaluate(Seq(example), "decimal") should equal (Seq("1.5"))
+    evaluate(Seq(example), "huge") should equal (Seq("1E+1000"))
+  }
+
   it should "allow retrieving ids and texts from array values (if navigateToArrays is false)" in {
     val example = json("exampleArrays.json", navigateIntoArrays = false)
 

--- a/silk-plugins/silk-plugins-json/src/test/scala/org/silkframework/plugins/dataset/json/NumberFormatterTest.scala
+++ b/silk-plugins/silk-plugins-json/src/test/scala/org/silkframework/plugins/dataset/json/NumberFormatterTest.scala
@@ -1,0 +1,41 @@
+package org.silkframework.plugins.dataset.json
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.math.{BigDecimal => JBigDec}
+
+class NumberFormatterTest extends AnyFlatSpec with Matchers {
+
+  behavior of "NumberFormatter"
+
+  it should "format integers in plain notation" in {
+    format("172800000") should equal ("172800000")
+    format("1.728e8") should equal ("172800000")
+    format("0") should equal ("0")
+    format("-42") should equal ("-42")
+  }
+
+  it should "format decimals in plain notation" in {
+    format("19.99") should equal ("19.99")
+    format("-12.5") should equal ("-12.5")
+    format("1e-7") should equal ("0.0000001")
+  }
+
+  it should "strip trailing zeros" in {
+    format("1.50") should equal ("1.5")
+    format("2.000") should equal ("2")
+  }
+
+  it should "use scientific notation if the plain notation would be excessively long" in {
+    format("1e1000") should equal ("1E+1000")
+    format("-1e1000") should equal ("-1E+1000")
+    format("1e-1000") should equal ("1E-1000")
+    // The limit also holds for exponents that are too large to expand in memory
+    format("1e100000000") should equal ("1E+100000000")
+  }
+
+  private def format(value: String): String = {
+    NumberFormatter.format(new JBigDec(value))
+  }
+}


### PR DESCRIPTION
…scientific notation (e.g., `172800000` instead of `1.728E+8`); scientific notation is only used if the plain notation would be excessively long (CMEM-7600).