### PR TITLE
Requesting mapping suggestions for a transformation whose input is not a dataset now shows a clear error message instead of a misleading "Task not found" error (CMEM-7777).

### DIFF
--- a/silk-rules/src/main/scala/org/silkframework/rule/TransformSpec.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/TransformSpec.scala
@@ -16,8 +16,8 @@ import org.silkframework.runtime.resource.Resource
 import org.silkframework.runtime.serialization.XmlSerialization._
 import org.silkframework.runtime.serialization.{ReadContext, WriteContext, XmlFormat, XmlSerialization}
 import org.silkframework.runtime.templating.{TemplateVariableName, TemplateVariables}
-import org.silkframework.runtime.validation.NotFoundException
-import org.silkframework.util.{Identifier, IdentifierGenerator}
+import org.silkframework.runtime.validation.{NotFoundException, ValidationException}
+import org.silkframework.util.{Identifier, IdentifierGenerator, Uri}
 import org.silkframework.workspace.{OriginalTaskData, TaskLoadingException, WorkspaceReadTrait}
 import org.silkframework.workspace.project.task.DatasetTaskReferenceAutoCompletionProvider
 
@@ -187,6 +187,16 @@ case class TransformSpec(@Param(label = "Input", value = "The source from which 
     **/
   lazy val ruleSchemataWithoutEmptyObjectRules: Seq[RuleSchemata] = {
     collectSchemata(mappingRule, UntypedPath.empty, UntypedPath.empty, withEmptyObjectRules = false)
+  }
+
+  /**
+    * The schemata of the rule that generates the given target type.
+    *
+    * @throws ValidationException If no rule generates the given type.
+    */
+  def ruleSchemataForTargetType(targetType: Uri): RuleSchemata = {
+    ruleSchemataWithoutEmptyObjectRules.find(_.transformRule.rules.typeRules.map(_.typeUri).contains(targetType))
+      .getOrElse(throw new ValidationException(s"No rule matching target type $targetType found."))
   }
 
   /**

--- a/silk-workbench/silk-workbench-workspace/app/controllers/workspaceApi/search/TransformFacetCollector.scala
+++ b/silk-workbench/silk-workbench-workspace/app/controllers/workspaceApi/search/TransformFacetCollector.scala
@@ -5,6 +5,7 @@ import org.silkframework.dataset.DatasetSpec.GenericDatasetSpec
 import org.silkframework.rule.TransformSpec
 import org.silkframework.runtime.activity.UserContext
 import org.silkframework.workspace.ProjectTask
+import org.silkframework.workspace.activity.transform.TransformTaskUtils._
 
 /**
   * Facet collector for the Transformation task.
@@ -21,8 +22,7 @@ case class TransformInputResourceFacetCollector() extends NoLabelKeywordFacetCol
 
   override def extractKeywordIds(projectTask: ProjectTask[TransformSpec])
                                 (implicit user: UserContext): Set[String] = {
-    val inputTaskId = projectTask.data.selection.inputTaskId
-    projectTask.project.taskOption[GenericDatasetSpec](inputTaskId).toSet flatMap { projectDatasetSpec: ProjectTask[GenericDatasetSpec] =>
+    projectTask.inputDatasetTaskOption.toSet flatMap { projectDatasetSpec: ProjectTask[GenericDatasetSpec] =>
       fileFacetCollector.extractKeywordIds(projectDatasetSpec)
     }
   }

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/activity/transform/TransformTaskUtils.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/activity/transform/TransformTaskUtils.scala
@@ -7,7 +7,7 @@ import org.silkframework.execution.{ExecutorRegistry, TaskException}
 import org.silkframework.rule.{TaskContext, TransformSpec, TransformedDataSource}
 import org.silkframework.runtime.activity.UserContext
 import org.silkframework.runtime.plugin.PluginContext
-import org.silkframework.runtime.validation.ValidationException
+import org.silkframework.runtime.validation.{NotFoundException, ValidationException}
 import org.silkframework.util.Uri
 import org.silkframework.workspace.{ProjectTask}
 
@@ -16,7 +16,22 @@ import org.silkframework.workspace.{ProjectTask}
   */
 object TransformTaskUtils {
 
-  implicit class TransformTask(task: ProjectTask[TransformSpec]) {
+  implicit class TransformTaskExtension(task: ProjectTask[TransformSpec]) {
+
+    /**
+      * Retrieves the input dataset task of this transform task.
+      * Note that the input of a transform task is not necessarily a dataset, but may also be another transform or a custom task.
+      *
+      * @throws NotFoundException If the input task exists, but is not a dataset.
+      * @throws org.silkframework.workspace.exceptions.TaskNotFoundException If no task with the configured input identifier exists.
+      */
+    def inputDatasetTask(implicit userContext: UserContext): ProjectTask[GenericDatasetSpec] = {
+      val inputId = task.data.selection.requiredInputId()
+      task.project.taskOption[GenericDatasetSpec](inputId).getOrElse {
+        val inputTask = task.project.anyTask(inputId) // Throws a 'task not found' error if the input task does not exist at all
+        throw new NotFoundException(s"The input task '${inputTask.id}' of transform task '${task.id}' is not a dataset. Only dataset inputs are supported for this feature.")
+      }
+    }
 
     /**
       * Retrieves the data source for this transform task.
@@ -31,7 +46,7 @@ object TransformTaskUtils {
             case Some(transformTask) =>
               transformTask.asDataSource(transformTask.data.selection.typeUri)
             case None =>
-              ExecutorRegistry.access(task.project.task[GenericDatasetSpec](sourceId)).source
+              ExecutorRegistry.access(inputDatasetTask).source
           }
       }
     }
@@ -42,7 +57,7 @@ object TransformTaskUtils {
     def asDataSource(typeUri: Uri)
                     (implicit userContext: UserContext): DataSource = {
       val transformSpec = task.data
-      val source = ExecutorRegistry.access(task.project.task[GenericDatasetSpec](transformSpec.selection.requiredInputId())).source
+      val source = ExecutorRegistry.access(task.inputDatasetTask).source
 
       // Find the rule that generates the selected type
       if(typeUri.uri.isEmpty) {

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/activity/transform/TransformTaskUtils.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/activity/transform/TransformTaskUtils.scala
@@ -7,7 +7,7 @@ import org.silkframework.execution.{ExecutorRegistry, TaskException}
 import org.silkframework.rule.{TaskContext, TransformSpec, TransformedDataSource}
 import org.silkframework.runtime.activity.UserContext
 import org.silkframework.runtime.plugin.PluginContext
-import org.silkframework.runtime.validation.{NotFoundException, ValidationException}
+import org.silkframework.runtime.validation.{BadUserInputException, ValidationException}
 import org.silkframework.util.Uri
 import org.silkframework.workspace.{ProjectTask}
 
@@ -22,14 +22,14 @@ object TransformTaskUtils {
       * Retrieves the input dataset task of this transform task.
       * Note that the input of a transform task is not necessarily a dataset, but may also be another transform or a custom task.
       *
-      * @throws NotFoundException If the input task exists, but is not a dataset.
+      * @throws BadUserInputException If the input task exists, but is not a dataset.
       * @throws org.silkframework.workspace.exceptions.TaskNotFoundException If no task with the configured input identifier exists.
       */
     def inputDatasetTask(implicit userContext: UserContext): ProjectTask[GenericDatasetSpec] = {
       val inputId = task.data.selection.requiredInputId()
       task.project.taskOption[GenericDatasetSpec](inputId).getOrElse {
         val inputTask = task.project.anyTask(inputId) // Throws a 'task not found' error if the input task does not exist at all
-        throw new NotFoundException(s"The input task '${inputTask.id}' of transform task '${task.id}' is not a dataset. Only dataset inputs are supported for this feature.")
+        throw BadUserInputException(s"The input task ${inputTask.labelAndId} of transform task ${task.labelAndId} is not a dataset. Only dataset inputs are supported for this feature.")
       }
     }
 

--- a/silk-workspace/src/main/scala/org/silkframework/workspace/activity/transform/TransformTaskUtils.scala
+++ b/silk-workspace/src/main/scala/org/silkframework/workspace/activity/transform/TransformTaskUtils.scala
@@ -7,7 +7,7 @@ import org.silkframework.execution.{ExecutorRegistry, TaskException}
 import org.silkframework.rule.{TaskContext, TransformSpec, TransformedDataSource}
 import org.silkframework.runtime.activity.UserContext
 import org.silkframework.runtime.plugin.PluginContext
-import org.silkframework.runtime.validation.{BadUserInputException, ValidationException}
+import org.silkframework.runtime.validation.BadUserInputException
 import org.silkframework.util.Uri
 import org.silkframework.workspace.{ProjectTask}
 
@@ -31,6 +31,15 @@ object TransformTaskUtils {
         val inputTask = task.project.anyTask(inputId) // Throws a 'task not found' error if the input task does not exist at all
         throw BadUserInputException(s"The input task ${inputTask.labelAndId} of transform task ${task.labelAndId} is not a dataset. Only dataset inputs are supported for this feature.")
       }
+    }
+
+    /**
+      * Retrieves the input dataset task of this transform task, if the input is a dataset.
+      * Non-throwing variant of `inputDatasetTask` for callers that can handle the absence of a dataset input:
+      * returns None if no input is configured, the input task does not exist or it is not a dataset.
+      */
+    def inputDatasetTaskOption(implicit userContext: UserContext): Option[ProjectTask[GenericDatasetSpec]] = {
+      task.project.taskOption[GenericDatasetSpec](task.data.selection.inputTaskId)
     }
 
     /**
@@ -63,12 +72,8 @@ object TransformTaskUtils {
       if(typeUri.uri.isEmpty) {
         new TransformedDataSource(source, transformSpec.inputSchema, transformSpec.mappingRule, task)
       } else {
-        transformSpec.ruleSchemataWithoutEmptyObjectRules.find(_.transformRule.rules.typeRules.map(_.typeUri).contains(typeUri)) match {
-          case Some(ruleSchemata) =>
-            new TransformedDataSource(source, ruleSchemata.inputSchema, ruleSchemata.transformRule, task)
-          case None =>
-            throw new ValidationException(s"No rule matching target type $typeUri found.")
-        }
+        val ruleSchemata = transformSpec.ruleSchemataForTargetType(typeUri)
+        new TransformedDataSource(source, ruleSchemata.inputSchema, ruleSchemata.transformRule, task)
       }
     }
 

--- a/silk-workspace/src/test/scala/org/silkframework/workspace/activity/workflow/BlankInputTaskExecutionTest.scala
+++ b/silk-workspace/src/test/scala/org/silkframework/workspace/activity/workflow/BlankInputTaskExecutionTest.scala
@@ -135,12 +135,13 @@ class BlankInputTaskExecutionTest extends AnyFlatSpec with Matchers with ConfigT
     project.addTask[TransformSpec]("transform", blankInputTransformSpec)
     project.addTask[LinkSpec]("linking", blankInputLinkSpec)
 
+    // The caches auto-start on addTask, so wait for that run instead of racing it with a second start
     val transformCache = project.task[TransformSpec]("transform").activity[TransformPathsCache]
-    transformCache.startBlocking()
+    transformCache.control.waitUntilFinished()
     transformCache.value().configuredSchema.typedPaths shouldBe empty
 
     val linkingCache = project.task[LinkSpec]("linking").activity[LinkingPathsCache]
-    linkingCache.startBlocking()
+    linkingCache.control.waitUntilFinished()
     // The cached schemas only contain the paths used in the linkage rule
     linkingCache.value().source.typedPaths.map(_.normalizedSerialization) shouldBe IndexedSeq("name")
   }


### PR DESCRIPTION
Requesting mapping suggestions for a transformation whose input is not a dataset now shows a clear error message instead of a misleading "Task not found" error (CMEM-7777).