### PR TITLE
Add configurable separator to InputHashTransformer (CMEM-8043)

### DIFF
--- a/silk-rules/src/main/resources/org/silkframework/rule/plugins/transformer/value/InputHashTransformer.md
+++ b/silk-rules/src/main/resources/org/silkframework/rule/plugins/transformer/value/InputHashTransformer.md
@@ -1,29 +1,35 @@
-The **Combined input hash** operator produces exactly one hash value covering all input values combined, across all connected input ports. However many values arrive and however many ports are connected, the output is always a single string.
+The **Combined input hash** operator produces exactly one hash value covering all input values combined, across all connected input ports, with an optional separator inserted between them.
 
 ## How combining works
 
-All values from all input ports are fed sequentially into a single hash function — port 1 first, then port 2, and so on. Within each port, values are processed in the order they arrive. No separator is inserted between values or between ports. The hash covers the concatenated byte content of all values in that traversal order.
+All values from all input ports are fed sequentially into a single hash function, in port order; within each port, values are processed in the order they arrive. An optional separator, set with the glue parameter, can be inserted between every adjacent pair of values in that order — see the Glue parameter section below. The hash covers the concatenated byte content of all values in that order, together with any inserted separator.
 
-This means the result depends on both the content and the order of values. The same set of values in a different order produces a different hash. Connecting one port with values `["apple", "banana"]` produces the same hash as connecting two ports with `["apple"]` and `["banana"]` respectively, because the bytes are fed in the same sequence either way.
+Swapping two values, or changing a single character within one value, produces a different hash. Connecting one port with values `["apple", "banana"]` produces the same hash as connecting two ports with `["apple"]` and `["banana"]` respectively, because the bytes are fed in the same sequence either way.
 
 ## Output
 
-The output is a single lowercase hexadecimal string. The length depends on the algorithm: 64 characters for SHA-256, 32 for MD5, 40 for SHA-1, 96 for SHA-384, 128 for SHA-512. If the input is empty, the output is the hash of an empty message.
+The output is a single lowercase hexadecimal string whose length is fixed by the chosen algorithm: 64 characters for SHA-256, 32 for MD5, 40 for SHA-1, 96 for SHA-384, 128 for SHA-512. Connecting no values at all still produces a hash — the hash of the empty message, not an error.
 
-Values are encoded as UTF-8 before hashing.
+Values are encoded as UTF-8 before hashing, so the same text produces the same bytes regardless of platform or locale.
 
 ## Algorithm parameter
 
-The algorithm parameter selects the hash function. The default is SHA-256. The following algorithms from the [SPARQL 1.1 specification](https://www.w3.org/TR/sparql11-query/#func-hash) are supported:
+The algorithm parameter selects the hash function. The following algorithms from the [SPARQL 1.1 specification](https://www.w3.org/TR/sparql11-query/#func-hash) are supported:
 
 | SPARQL name | Java name | Notes |
 |-------------|-----------|-------|
-| MD5 | MD5 | Weak — vulnerable to collision attacks. Avoid for security-sensitive use. |
-| SHA1 | SHA-1 | Weak — deprecated for most security purposes. |
-| SHA256 | SHA-256 | Recommended default. |
-| SHA384 | SHA-384 | Stronger than SHA-256. |
-| SHA512 | SHA-512 | Strongest in the SPARQL set. |
+| MD5 | MD5 | Has known collision vulnerabilities. |
+| SHA1 | SHA-1 | Deprecated for most security purposes. |
+| SHA256 | SHA-256 | Default. |
+| SHA384 | SHA-384 | |
+| SHA512 | SHA-512 | |
 
 Additional algorithms available on the JVM (such as SHA-512/256 and SHA-3 variants) are also accepted. The full list is JVM-dependent and visible in the algorithm parameter dropdown.
 
-Note that the Java names use hyphens (SHA-256, SHA-1) where SPARQL uses none (SHA256, SHA1). Both forms are accepted by this operator.
+The Java names use hyphens (SHA-256, SHA-1) where SPARQL uses none (SHA256, SHA1); both forms are accepted by this operator.
+
+## Glue parameter
+
+The glue parameter sets a separator string that is inserted between every adjacent pair of values in the traversal order described above, defaulting to an empty string. Its text can contain the escaped sequences `\n`, `\t`, and `\\`, which are converted to a newline, a tab, and a backslash respectively before hashing.
+
+Connecting one port with values `["apple", "banana"]` and a glue of `-` produces the same hash as connecting two ports with `["apple"]` and `["banana"]` respectively, using the same glue, because the glue is inserted at the same point in the byte sequence either way.

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/combine/ConcatMultipleValuesTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/combine/ConcatMultipleValuesTransformer.scala
@@ -4,6 +4,7 @@ import org.silkframework.rule.annotations.{TransformExample, TransformExamples}
 import java.util.regex.Pattern
 
 import org.silkframework.rule.input.InlineTransformer
+import org.silkframework.rule.plugins.transformer.value.InputHashTransformer
 import org.silkframework.runtime.plugin.annotations.{Plugin, PluginReference}
 
 /**
@@ -20,6 +21,12 @@ import org.silkframework.runtime.plugin.annotations.{Plugin, PluginReference}
     new PluginReference(
       id = ConcatTransformer.pluginId,
       description = "Concatenate multiple values collapses all values within each input into one string, preserving the boundary between inputs. Concatenate crosses that boundary — it takes one value from each input and produces all combinations, so the output grows with the number of inputs and values."
+    ),
+    new PluginReference(
+      id = InputHashTransformer.pluginId,
+      description = "Combined input hash always produces exactly one hash value, however many ports or values are " +
+        "connected. Concatenate multiple values instead combines everything on one port into a single string, so " +
+        "connecting more ports returns more separate strings instead of one."
     )
   )
 )

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/combine/ConcatTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/combine/ConcatTransformer.scala
@@ -16,6 +16,7 @@ package org.silkframework.rule.plugins.transformer.combine
 
 import org.silkframework.rule.annotations.{TransformExample, TransformExamples}
 import org.silkframework.rule.input.InlineTransformer
+import org.silkframework.rule.plugins.transformer.value.InputHashTransformer
 import org.silkframework.runtime.plugin.annotations.{Param, Plugin, PluginReference}
 
 @Plugin(
@@ -26,11 +27,20 @@ import org.silkframework.runtime.plugin.annotations.{Param, Plugin, PluginRefere
   relatedPlugins = Array(
     new PluginReference(
       id = ConcatPairwiseTransformer.pluginId,
-      description = "Concatenate takes the Cartesian product of all inputs and produces one string per combination. Concatenate pairwise aligns values by position and produces one string per position, truncating to the shortest input."
+      description = "Concatenate takes the Cartesian product of all inputs and produces one string per combination. " +
+        "Concatenate pairwise aligns values by position and produces one string per position, truncating to the shortest input."
     ),
     new PluginReference(
       id = ConcatMultipleValuesTransformer.pluginId,
-      description = "Passing multiple values to a single input of Concatenate does not combine them — it multiplies the output. Concatenate multiple values is the plugin that collapses multiple values within an input into one string, producing exactly one result per input."
+      description = "Passing multiple values to a single input of Concatenate does not combine them — it multiplies the output. " +
+        "Concatenate multiple values is the plugin that collapses multiple values within an input into one string, " +
+        "producing exactly one result per input."
+    ),
+    new PluginReference(
+      id = InputHashTransformer.pluginId,
+      description = "Concatenate returns one string only when each input provides exactly one value; an input with " +
+        "more than one value instead returns the Cartesian product as separate results. Combined input hash always " +
+        "returns exactly one hash value, no matter how many values or ports are connected."
     )
   )
 )
@@ -134,9 +144,7 @@ case class ConcatTransformer(
     }
   }
 
-  private def evaluate(strings: Seq[String]) = {
-    strings.mkString(parsedGlue)
-  }
+  private def evaluate(strings: Seq[String]): String = strings.mkString(parsedGlue)
 }
 
 object ConcatTransformer {
@@ -146,7 +154,7 @@ object ConcatTransformer {
   final val glueDescription  = "Separator to be inserted between two concatenated strings. The text can contain escaped characters \\n, \\t and" +
     " \\\\ that are replaced by a newline, tab or backslash respectively."
 
-  /** Converts escape sequences into their actual character. Supports: "\\", "\n" nad "\t" */
+  /** Converts escape sequences into their actual character. Supports: "\\", "\n" and "\t" */
   def parseGlue(glue: String): String = {
     if(glue.contains("\\")) {
       var lastCharEscapingBackSlash = false

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/combine/ZipTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/combine/ZipTransformer.scala
@@ -16,6 +16,7 @@ package org.silkframework.rule.plugins.transformer.combine
 
 import org.silkframework.rule.annotations.{TransformExample, TransformExamples}
 import org.silkframework.rule.input.InlineTransformer
+import org.silkframework.rule.plugins.transformer.value.InputHashTransformer
 import org.silkframework.runtime.plugin.annotations.{Param, Plugin, PluginReference}
 
 @Plugin(
@@ -27,6 +28,12 @@ import org.silkframework.runtime.plugin.annotations.{Param, Plugin, PluginRefere
     new PluginReference(
       id = ConcatPairwiseTransformer.pluginId,
       description = "Zip handles unequal input lengths by padding, not truncating, and is constrained to exactly two inputs. Concatenate pairwise removes that constraint — it accepts any number of inputs — but resolves the length mismatch by stopping at the shortest."
+    ),
+    new PluginReference(
+      id = InputHashTransformer.pluginId,
+      description = "Zip pairs exactly two inputs position by position and returns one output per pair, using the " +
+        "same optional separator between values. Combined input hash instead combines every connected value into " +
+        "a single hash, regardless of how many ports are used."
     )
   )
 )

--- a/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/InputHashTransformer.scala
+++ b/silk-rules/src/main/scala/org/silkframework/rule/plugins/transformer/value/InputHashTransformer.scala
@@ -1,18 +1,22 @@
 package org.silkframework.rule.plugins.transformer.value
 
 import org.silkframework.rule.annotations.{TransformExample, TransformExamples}
+import org.silkframework.rule.plugins.transformer.combine.ConcatMultipleValuesTransformer
+import org.silkframework.rule.plugins.transformer.combine.ConcatTransformer
+import org.silkframework.rule.plugins.transformer.combine.ZipTransformer
 import org.silkframework.rule.plugins.transformer.replace.MapTransformerWithDefaultInput
+import org.silkframework.rule.plugins.transformer.value.InputHashTransformer.SeqIntersperseOps
 import org.silkframework.runtime.plugin.annotations.{Param, Plugin, PluginReference}
 
 import java.security.MessageDigest
 
-
 /**
  * Combines all input values across all connected ports into a single hash.
  *
- * Values are fed sequentially into a single [[java.security.MessageDigest]] instance — port 1 first, then port 2,
- * and so on; within each port, values are processed in order. No separator is inserted between values or ports.
- * The output is always exactly one lowercase hexadecimal string, regardless of how many values or ports are provided.
+ * Values are fed sequentially into a single [[java.security.MessageDigest]] instance — port 1 first, then port 2, and
+ * so on; within each port, values are processed in order. An optional separator, configured via the glue parameter, is
+ * inserted between every pair of adjacent values; by default, no separator is used. The output is always exactly one
+ * lowercase hexadecimal string, regardless of how many values or ports are provided.
  *
  * @see [[PerValueHashTransformer]] for the per-value variant that produces one hash per input value.
  */
@@ -20,16 +24,40 @@ import java.security.MessageDigest
   id = InputHashTransformer.pluginId,
   categories = Array("Value"),
   label = "Combined input hash",
-  description = """Calculates a single hash value covering all input values combined, across all input ports. Values are fed into the hash function in port order without any separator between them.""",
+  description = "Calculates a single hash value covering all input values combined, across all input ports. Values " +
+    "are fed into the hash function in port order, with an optional separator (the glue parameter) inserted " +
+    "between them.",
   documentationFile = "InputHashTransformer.md",
   relatedPlugins = Array(
     new PluginReference(
       id = PerValueHashTransformer.pluginId,
-      description = "The Per-value hash plugin hashes each input value independently and returns one hash per value, preserving cardinality. The Combined input hash plugin instead feeds all values into a single hash function, producing one combined hash regardless of input size."
+      description = "The Per-value hash plugin hashes each input value independently and returns one hash per " +
+        "value, preserving cardinality. The Combined input hash plugin instead feeds all values into a single hash " +
+        "function, producing one combined hash regardless of input size."
     ),
     new PluginReference(
       id = MapTransformerWithDefaultInput.pluginId,
-      description = "One hash value is produced for the entire set of inputs by the Combined input hash plugin. The Map with default plugin instead keeps a value sequence and rewrites it position by position through the mapping, falling back to the second input where no mapping entry is found."
+      description = "One hash value is produced for the entire set of inputs by the Combined input hash plugin. The " +
+        "Map with default plugin instead keeps a value sequence and rewrites it position by position through the " +
+        "mapping, falling back to the second input where no mapping entry is found."
+    ),
+    new PluginReference(
+      id = ConcatTransformer.pluginId,
+      description = "Combined input hash always returns exactly one value, however many values or ports are " +
+        "connected. Concatenate instead produces every combination of connected values as a separate output, so " +
+        "more than one value on an input produces multiple outputs instead of one."
+    ),
+    new PluginReference(
+      id = ZipTransformer.pluginId,
+      description = "Combined input hash accepts any number of ports and always returns exactly one value. Zip " +
+        "instead requires exactly two inputs, pairs their values by position, and returns one output per position " +
+        "rather than one combined result."
+    ),
+    new PluginReference(
+      id = ConcatMultipleValuesTransformer.pluginId,
+      description = "Concatenate multiple values combines everything received on one port into a single string, " +
+        "but keeps each port's result separate; more ports still return separate results, one per port. Combined " +
+        "input hash instead crosses every port boundary, always returning one hash value overall."
     )
   )
 )
@@ -45,15 +73,126 @@ import java.security.MessageDigest
     output = Array("5b692305517af54eb5ae12b9ff89eaf89e31f6a6ee208365886a18b81a2fc2f8")
   ),
   new TransformExample(
-    description = "Reversing the value order produces a different hash, confirming order-sensitivity.",
+    description = "The order in which values are combined affects the resulting hash.",
     input1 = Array("banana", "apple"),
     output = Array("d4183362b538440bb9a5f82359791c647280e6b657a1812f16f7bcc2b8f141ca")
   ),
   new TransformExample(
-    description = "Values from multiple ports are combined in port order, producing the same hash as the equivalent single-port sequence.",
+    description = "Values from multiple ports are combined in port order: port 1's values first, then port 2's.",
     input1 = Array("apple"),
     input2 = Array("banana"),
     output = Array("5b692305517af54eb5ae12b9ff89eaf89e31f6a6ee208365886a18b81a2fc2f8")
+  ),
+  new TransformExample(
+    description = "The glue parameter inserts a separator between values.",
+    parameters = Array("glue", "-"),
+    input1 = Array("apple", "banana"),
+    output = Array("d6300f978b8699862450cbabc35349239c09e95c356723c32fc1407ec8104c78")
+  ),
+  new TransformExample(
+    description = "Values from multiple ports are combined using the glue separator in port order: port 1's values " +
+      "first, then port 2's.",
+    parameters = Array("glue", "-"),
+    input1 = Array("apple"),
+    input2 = Array("banana"),
+    output = Array("d6300f978b8699862450cbabc35349239c09e95c356723c32fc1407ec8104c78")
+  ),
+  new TransformExample(
+    description = "The glue parameter accepts escaped characters, here a newline.",
+    parameters = Array("glue", "\\n"),
+    input1 = Array("apple", "banana"),
+    output = Array("5c573825e0a168e9e382f9b7e78e6603271634dceac792b9c92fa77a27d404f8")
+  ),
+  new TransformExample(
+    description = "Values containing non-ASCII characters are encoded as UTF-8 before being hashed.",
+    parameters = Array("glue", "-"),
+    input1 = Array("café", "banana"),
+    output = Array("c17ffffc64b5ffd83dbc2a975134c65a7f7f457a898b6e1fc6d2db1217fa92ff")
+  ),
+  new TransformExample(
+    description = "The glue parameter accepts a separator longer than one character.",
+    parameters = Array("glue", "::"),
+    input1 = Array("apple", "banana"),
+    output = Array("7f721cdbf970bad79a82e7d827e0e5eef3d8263610aa6f062427060f5d2379db")
+  ),
+  new TransformExample(
+    description = "The order of values combined with a glue separator affects the resulting hash.",
+    parameters = Array("glue", "-"),
+    input1 = Array("banana", "apple"),
+    output = Array("4472ed905ebe09b0e7a37ffa5adc6b0b2f052a6d0045fc037e2e56cdb45fba0a")
+  ),
+  new TransformExample(
+    description = "The glue separator is never applied to a single value, since there is no adjacent value to " +
+      "separate it from.",
+    parameters = Array("glue", "-"),
+    input1 = Array("solo"),
+    output = Array("5364f2f2fc4f54e9d47ad29cfb08ef430c8153394bf2a0dff5cbe77a0ffef861")
+  ),
+  new TransformExample(
+    description = "With more than two values, the glue separator is inserted between every adjacent pair.",
+    parameters = Array("glue", "-"),
+    input1 = Array("a", "b"),
+    input2 = Array("c"),
+    output = Array("cbd2be7b96f770a0326948ebd158cf539fab0627e8adbddc97f7a65c6a8ae59a")
+  ),
+  new TransformExample(
+    description = "Three values in one port produce a hash with the glue separator inserted between every pair.",
+    parameters = Array("glue", "-"),
+    input1 = Array("a", "b", "c"),
+    output = Array("cbd2be7b96f770a0326948ebd158cf539fab0627e8adbddc97f7a65c6a8ae59a")
+  ),
+  new TransformExample(
+    description = "A value that is identical to the glue string is hashed as ordinary byte content, with no " +
+      "special escaping.",
+    parameters = Array("glue", "-"),
+    input1 = Array("a", "-", "b"),
+    output = Array("1acd27f89b4f44ddaf3b81fadb5491ea61f9ae3981545cf62d3502a387bcf350")
+  ),
+  new TransformExample(
+    description = "Values from three ports are combined using the glue separator in port order: port 1's value, " +
+      "then port 2's, then port 3's.",
+    parameters = Array("glue", "-"),
+    input1 = Array("a"),
+    input2 = Array("b"),
+    input3 = Array("c"),
+    output = Array("cbd2be7b96f770a0326948ebd158cf539fab0627e8adbddc97f7a65c6a8ae59a")
+  ),
+  new TransformExample(
+    description = "The order in which values are combined affects the resulting hash, even with more than two " +
+      "values and a glue separator.",
+    parameters = Array("glue", "-"),
+    input1 = Array("c", "b"),
+    input2 = Array("a"),
+    output = Array("8e599734c8f75bd7866757e5f9cd4ab3cc173d753fb858a85ae6efb817e3e200")
+  ),
+  new TransformExample(
+    description = "With more than two values, the SHA-1 algorithm still inserts the glue separator between every " +
+      "adjacent pair.",
+    parameters = Array("algorithm", "SHA-1", "glue", "-"),
+    input1 = Array("a", "b"),
+    input2 = Array("c"),
+    output = Array("e088d9e3f737c091378fe8494936b16d51eb42ee")
+  ),
+  new TransformExample(
+    description = "With the SHA-512 algorithm selected, the glue separator is inserted between every adjacent " +
+      "pair of three values.",
+    parameters = Array("algorithm", "SHA-512", "glue", "-"),
+    input1 = Array("a", "b"),
+    input2 = Array("c"),
+    output = Array("a271a54e93179f7dccb132a17c914e66e76a91ae3b7cb8b3abffa21a8ffb66b65a2883769bc4c6f95ab39fbd039cfe21046b485cef1588269d2605c7253f2b98")
+  ),
+  new TransformExample(
+    description = "With the MD5 algorithm selected, the glue parameter still inserts a separator between values.",
+    parameters = Array("algorithm", "MD5", "glue", "-"),
+    input1 = Array("apple", "banana"),
+    output = Array("9b22c402a5166c71ebdf2d1b99f37727")
+  ),
+  new TransformExample(
+    description = "With the MD5 algorithm selected, escaped glue characters are still converted before being used " +
+      "as the separator.",
+    parameters = Array("algorithm", "MD5", "glue", "\\n"),
+    input1 = Array("apple", "banana"),
+    output = Array("cf0bf238cadd6688db6f8d2511a52ebf")
   ),
   new TransformExample(
     description = "The algorithm parameter selects the hash function (MD5).",
@@ -91,23 +230,43 @@ import java.security.MessageDigest
     throwsException = classOf[IllegalArgumentException]
   ),
 ))
-case class InputHashTransformer(@Param(value = "The hash algorithm to be used.",
-                                      autoCompletionProvider = classOf[HashAlgorithmAutoCompletionProvider], allowOnlyAutoCompletedValues = true)
-                                algorithm: String = "SHA256") extends HashTransformer {
+case class InputHashTransformer(
+  @Param(
+    value = "The hash algorithm to be used.",
+    autoCompletionProvider = classOf[HashAlgorithmAutoCompletionProvider],
+    allowOnlyAutoCompletedValues = true
+  )
+  algorithm: String = "SHA256",
+  @Param(ConcatTransformer.glueDescription)
+  glue: String = "",
+) extends HashTransformer {
 
   require(algorithm.trim.nonEmpty, "Algorithm must not be empty. Please specify an algorithm, such as 'SHA256'.")
 
-  override def apply(values: Seq[Seq[String]]): Seq[String] = {
-    def updateAll(digest: MessageDigest): Unit =
-      values.flatten.foreach(updateWith(digest, _))
+  // glue with escaped char sequences (\\, \n, \t) converted to actual character.
+  lazy val parsedGlue: String = ConcatTransformer.parseGlue(glue)
 
-    Seq(withDigest { digest =>
-      updateAll(digest)
+  /** Updates the digest with the UTF-8 encoding of all values. */
+  private def updateAll(digest: MessageDigest)(values: Seq[Seq[String]], separator: String): Unit =
+    values.flatten.intersperse(separator).foreach(updateWith(digest, _))
+
+  /** Hashes several values into a single output */
+  private def hashValues(values: Seq[Seq[String]], separator: String): String =
+    withDigest { digest =>
+      updateAll(digest)(values, separator)
       toHex(digest.digest())
-    })
-  }
+    }
+
+  override def apply(values: Seq[Seq[String]]): Seq[String] = Seq(hashValues(values, parsedGlue))
 }
 
 object InputHashTransformer {
   final val pluginId = "inputHash"
+
+  implicit class SeqIntersperseOps[A](val underlying: Seq[A]) extends AnyVal {
+    def intersperse[B >: A](separator: B): Seq[B] = underlying.toList match {
+      case Nil => Nil
+      case head :: tail => head :: tail.foldRight(List.empty[B])((element, acc) => separator :: element :: acc)
+    }
+  }
 }

--- a/silk-rules/src/test/scala/org/silkframework/rule/plugins/transformer/value/InputHashTransformerTest.scala
+++ b/silk-rules/src/test/scala/org/silkframework/rule/plugins/transformer/value/InputHashTransformerTest.scala
@@ -1,5 +1,72 @@
 package org.silkframework.rule.plugins.transformer.value
 
+import org.silkframework.rule.plugins.transformer.combine.ConcatTransformer
 import org.silkframework.rule.test.TransformerTest
 
-class InputHashTransformerTest extends TransformerTest[InputHashTransformer]
+import scala.util.Random
+
+class InputHashTransformerTest extends TransformerTest[InputHashTransformer] {
+
+  private val algorithms = Seq("SHA256", "MD5", "SHA-1", "SHA-384", "SHA-512")
+  private val glues = Seq("", "-", "\\n")
+
+  private def randomString(random: Random, length: Int): String = {
+    val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!?.,;: "
+    (1 to length).map(_ => chars(random.nextInt(chars.length))).mkString
+  }
+
+  private def randomPairs(seed: Long, count: Int): Seq[(String, String)] = {
+    val random = new Random(seed)
+    (1 to count).map { _ =>
+      randomString(random, random.nextInt(41)) -> randomString(random, random.nextInt(41))
+    }
+  }
+
+  it should "produce the same hash as concatenating first with ConcatTransformer and then hashing the single result" in {
+    for {
+      (a, b) <- randomPairs(seed = 42L, count = 20)
+      algorithm <- algorithms
+      glue <- glues
+    } {
+      val concatenated = ConcatTransformer(glue = glue).apply(Seq(Seq(a), Seq(b))).head
+      val hashOfConcatenated = InputHashTransformer(algorithm = algorithm).apply(Seq(Seq(concatenated)))
+
+      val combinedHash = InputHashTransformer(algorithm = algorithm, glue = glue).apply(Seq(Seq(a), Seq(b)))
+
+      combinedHash shouldEqual hashOfConcatenated
+    }
+  }
+
+  it should "produce the same MD5 hash as concatenating first with ConcatTransformer" in {
+    for {
+      a <- Seq("", "a", "hello world")
+      b <- Seq("b", "banana", "test!")
+      glue <- glues
+    } {
+      val concatenated = ConcatTransformer(glue = glue).apply(Seq(Seq(a), Seq(b))).head
+      val hashOfConcatenated = InputHashTransformer(algorithm = "MD5").apply(Seq(Seq(concatenated)))
+
+      val combinedHash = InputHashTransformer(algorithm = "MD5", glue = glue).apply(Seq(Seq(a), Seq(b)))
+
+      combinedHash shouldEqual hashOfConcatenated
+    }
+  }
+
+  it should "not distinguish a value's own separator character from inserted glue" in {
+    val asOneValue = InputHashTransformer().apply(Seq(Seq("grand-mère")))
+    val asSplitValuesWithGlue = InputHashTransformer(glue = "-").apply(Seq(Seq("grand", "mère")))
+
+    asSplitValuesWithGlue shouldEqual asOneValue
+  }
+
+  it should "produce the same hash for three glued values regardless of how they are split across ports" in {
+    val transformer = InputHashTransformer(glue = "-")
+
+    val singlePort = transformer.apply(Seq(Seq("a", "b", "c")))
+    val twoPorts = transformer.apply(Seq(Seq("a", "b"), Seq("c")))
+    val threePorts = transformer.apply(Seq(Seq("a"), Seq("b"), Seq("c")))
+
+    twoPorts shouldEqual singlePort
+    threePorts shouldEqual singlePort
+  }
+}


### PR DESCRIPTION
# Add configurable separator to InputHashTransformer (CMEM-8043)

## Description

InputHashTransformer now accepts an optional separator between values, reusing the same `glue` parameter and escaping rules `ConcatTransformer` already defines.

## Behavior

The transformer still reduces any number of connected ports and values to exactly one hash value, and with no separator configured, behaves exactly as before. Once a separator is set, it treats a port boundary the same as any other adjacent pair rather than as something special — so moving a value from one port to another never changes the hash, as long as the overall value order stays the same.

## Implementation

The separator is applied once, while flattening the per-port value sequences into the single ordered sequence that gets concatenated and hashed — the hashing step itself stays untouched and has no notion of separators or ports at all. That separator is parsed using `ConcatTransformer`'s own escaping rules rather than a second implementation of the same semantics, so the two plugins can't quietly drift apart on what an escape sequence means.

## Tests

Coverage comes from two complementary sources. Transform examples cover the sharper edges directly: a value identical to the separator string itself, which hashes as ordinary content rather than being specially escaped, and a single value on its own, where the separator never applies because there's no adjacent pair to insert it between. A property-based unit test composes `ConcatTransformer` and `InputHashTransformer` independently, rather than reimplementing the hashing logic as its own reference, and verifies across several algorithms and separator values that a value split across two ports and the same value combined on one port always hash identically.

## Additional changes

### Documentation

`InputHashTransformer.md` stated flatly that no separator was ever inserted between values — true when it was written, false the moment `glue` landed. It's been rewritten to document the parameter, and a table that judged algorithms instead of describing them ("weak," "recommended," bare comparisons) was cut down to the verifiable facts underneath those labels.

### Related plugins

InputHashTransformer cross-referenced two other transformers; it's now cross-referenced with five, each new pair naming the specific behavioral difference a user might otherwise miss rather than a generic note.

